### PR TITLE
Manki E: extend mine duration to 10s (600 ticks) + unit tests

### DIFF
--- a/docs/characters/manki.md
+++ b/docs/characters/manki.md
@@ -44,7 +44,7 @@ A pyromaniac/inventor macaque monkey. Always tinkering with explosives — bombs
 ## Design Notes
 
 - **RMB**: inspired by improvised flamethrower — aerosol + lighter. During charge, Manki frantically shakes the bomb. On release, cone-shaped flame jet.
-- **E**: rocket jump. On ground = plant dynamite, propelled upward. In air = drop dynamite below, propelled upward. Explosion has knockback — serves as defensive peel (detonate to break enemy engage) and combo setup. Hitbox needs to be bigger than visual-only.
+- **E**: rocket jump / area denial. On ground = plant dynamite mine (10s auto-detonate), can press E again to detonate early. Explosion launches self upward and knocks back enemies (CanHitOwner). Serves as defensive peel (detonate to break enemy engage), combo setup (bait opponent onto mine), and mobility (rocket jump). In air = drop dynamite below, propelled upward.
 - **R**: Bazooka. Manki rises up ~5m (skips rise if already airborne), hovers to aim a ground indicator, then fires a ballistic explosive shell toward the aimed point. Shell explodes on entity contact or ground impact. AoE explosion for zoning. Projectile has slight gravity arc.
 - **F**: Overclock. Manki injects himself with a mysterious substance (red can). Glowing red eyes, crackling energy. For 8 seconds, all his attacks deal +3 bonus damage and have +0.5m larger hitboxes. No single big hit, makes his whole kit scarier.
 

--- a/src/Shared/Characters/MankiData.cs
+++ b/src/Shared/Characters/MankiData.cs
@@ -214,7 +214,7 @@ public static partial class CharacterRegistry
                 Behavior = AbilityBehavior.AreaDenial,
                 CooldownTicks = 120,
                 MineRadius = 0.3f,
-                MineDurationTicks = 180,
+                MineDurationTicks = 600,
                 Stages = new AttackStage[]
                 {
                     new() { DurationTicks = 20, ChainWindowTicks = 0,

--- a/tests/Shared.Tests/MankiExplosiveMineTests.cs
+++ b/tests/Shared.Tests/MankiExplosiveMineTests.cs
@@ -1,0 +1,133 @@
+using Xunit;
+
+namespace SlopArena.Shared.Tests;
+
+/// <summary>
+/// Tests for Manki's E — ExplosiveMineSpec.
+/// Mine placement, manual detonation, auto-detonation, and per-owner isolation.
+/// </summary>
+public class MankiExplosiveMineTests
+{
+    private static readonly CharacterDefinition Def = TestHelpers.MankiDef!;
+
+    private static (CharacterState state, ExplosiveMineSpec spec, HitboxEvent evt, SpellResolver resolver) Setup()
+    {
+        var spec = (ExplosiveMineSpec)Def.E;
+        var evt = spec.Stages![0].HitboxEvents![0];
+        var state = TestHelpers.PlayerState();
+        state.PY = 1.3f; // standing height
+        var resolver = new SpellResolver();
+        return (state, spec, evt, resolver);
+    }
+
+    [Fact]
+    public void Place_SpawnsMineHitbox()
+    {
+        var (state, spec, evt, resolver) = Setup();
+        spec.SpawnHitbox(evt, state, Def, resolver, 1);
+
+        var hitboxes = resolver.GetActiveHitboxes();
+        Assert.Single(hitboxes);
+        var mine = hitboxes[0];
+        Assert.Equal(0f, mine.Gravity);
+        Assert.Equal(spec.MineDurationTicks, mine.DurationTicks);
+        Assert.Equal((ulong)1, mine.OwnerId);
+        Assert.True(mine.Explosion.HasValue);
+    }
+
+    [Fact]
+    public void Place_MineRadiusMatchesSpec()
+    {
+        var (state, spec, evt, resolver) = Setup();
+        spec.SpawnHitbox(evt, state, Def, resolver, 1);
+
+        var mine = resolver.GetActiveHitboxes()[0];
+        Assert.Equal(spec.MineRadius, mine.Radius);
+    }
+
+    [Fact]
+    public void Place_MinePositionAtFeet()
+    {
+        var (state, spec, evt, resolver) = Setup();
+        spec.SpawnHitbox(evt, state, Def, resolver, 1);
+
+        var mine = resolver.GetActiveHitboxes()[0];
+        Assert.Equal(state.PX, mine.X);
+        Assert.Equal(state.PY, mine.Y);
+        Assert.Equal(state.PZ, mine.Z);
+    }
+
+    [Fact]
+    public void Place_ReturnsTrue()
+    {
+        var (state, spec, evt, resolver) = Setup();
+        bool result = spec.SpawnHitbox(evt, state, Def, resolver, 1);
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void Detonate_RemovesExistingMine()
+    {
+        var (state, spec, evt, resolver) = Setup();
+
+        bool placeResult = spec.SpawnHitbox(evt, state, Def, resolver, 1);
+        Assert.True(placeResult);
+        Assert.Single(resolver.GetActiveHitboxes());
+
+        bool detonateResult = spec.SpawnHitbox(evt, state, Def, resolver, 1);
+        Assert.True(detonateResult);
+        Assert.Empty(resolver.GetActiveHitboxes());
+    }
+
+    [Fact]
+    public void Detonate_QueuesExplosion()
+    {
+        var (state, spec, evt, resolver) = Setup();
+
+        spec.SpawnHitbox(evt, state, Def, resolver, 1);
+        spec.SpawnHitbox(evt, state, Def, resolver, 1);
+
+        var explosions = resolver.DrainPendingExplosions();
+        Assert.Single(explosions);
+        Assert.True(explosions[0].explosion.CanHitOwner);
+    }
+
+    [Fact]
+    public void AutoDetonate_AfterDuration()
+    {
+        var (state, spec, evt, resolver) = Setup();
+
+        spec.SpawnHitbox(evt, state, Def, resolver, 1);
+        Assert.Single(resolver.GetActiveHitboxes());
+
+        int ticks = spec.MineDurationTicks;
+        var emptyEntities = new List<SpellResolver.EntityData>();
+        for (int i = 0; i < ticks; i++)
+            resolver.Tick(emptyEntities);
+
+        Assert.Empty(resolver.GetActiveHitboxes());
+        var explosions = resolver.DrainPendingExplosions();
+        Assert.Single(explosions);
+    }
+
+    [Fact]
+    public void TwoSeparateOwners_EachGetsOwnMine()
+    {
+        var (state, spec, evt, resolver) = Setup();
+
+        var state2 = TestHelpers.NpcState(x: 5f);
+        state2.PY = 1.3f;
+
+        spec.SpawnHitbox(evt, state, Def, resolver, 1);
+        spec.SpawnHitbox(evt, state2, Def, resolver, 2);
+
+        var hitboxes = resolver.GetActiveHitboxes();
+        Assert.Equal(2, hitboxes.Count);
+
+        spec.SpawnHitbox(evt, state, Def, resolver, 1);
+
+        hitboxes = resolver.GetActiveHitboxes();
+        Assert.Single(hitboxes);
+        Assert.Equal((ulong)2, hitboxes[0].OwnerId);
+    }
+}


### PR DESCRIPTION
- MineDurationTicks: 180 → 600 (3s → 10s at 60Hz)
- 8 new SpawnHitbox/SpellResolver unit tests covering:
  - Mine placement (hitbox props, radius, position, return value)
  - Manual detonation (removes mine, queues explosion with CanHitOwner)
  - Auto-detonation after duration expiry
  - Per-owner mine isolation (two owners, independent mines)
- Updated docs/characters/manki.md to reflect 10s area denial design

## Description

<!-- What does this PR do? -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Balance / tuning
- [ ] Code cleanup / refactor
- [ ] Documentation
- [ ] CI / infra

## Related Issues

<!-- Closes #issue_number, or "None" -->

## Testing

- [ ] `dotnet build` passes with 0 warnings
- [ ] Tested in sandbox mode
- [ ] No regressions in existing functionality

## Checklist

- [ ] All code is in English (no French)
- [ ] Shared/ has zero Godot dependencies
- [ ] Tick-based timers (ushort), not delta time
- [ ] Follows project coding style (Allman braces, tabs, _camelCase privates)

## Screenshots / Videos (if applicable)

<!-- Drag and drop media here -->
