### PR TITLE
feat: PvP Phase 1 — ISimulationBridge, NetworkSimulationBridge, PvPMatch scene

### DIFF
--- a/client/Unity/Assets/Scenes/Arena_PvP.unity
+++ b/client/Unity/Assets/Scenes/Arena_PvP.unity
@@ -1,0 +1,1276 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 10
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 13
+  m_BakeOnSceneLoad: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 1
+    m_PVRFilteringGaussRadiusAO: 1
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 20201, guid: 0000000000000000f000000000000000, type: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &390575599 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2363612637730096979, guid: 455bc6d55d776c34482adf02e622c2d9, type: 3}
+  m_PrefabInstance: {fileID: 3217259389550734977}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &390575604
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 390575599}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_AllowHDROutput: 1
+  m_UseScreenCoordOverride: 0
+  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_Version: 2
+  m_TaaSettings:
+    m_Quality: 3
+    m_FrameInfluence: 0.1
+    m_JitterScale: 1
+    m_MipBias: 0
+    m_VarianceClampScale: 0.9
+    m_ContrastAdaptiveSharpening: 0
+--- !u!1001 &466716234
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1794952206}
+    m_Modifications:
+    - target: {fileID: 1525142461768372567, guid: 3bb1444954873424c8ec94d9fb4ba07c, type: 3}
+      propertyPath: m_RootOrder
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1525142461768372567, guid: 3bb1444954873424c8ec94d9fb4ba07c, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -11.964679
+      objectReference: {fileID: 0}
+    - target: {fileID: 1525142461768372567, guid: 3bb1444954873424c8ec94d9fb4ba07c, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1525142461768372567, guid: 3bb1444954873424c8ec94d9fb4ba07c, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -7.020885
+      objectReference: {fileID: 0}
+    - target: {fileID: 1525142461768372567, guid: 3bb1444954873424c8ec94d9fb4ba07c, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.8649638
+      objectReference: {fileID: 0}
+    - target: {fileID: 1525142461768372567, guid: 3bb1444954873424c8ec94d9fb4ba07c, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1525142461768372567, guid: 3bb1444954873424c8ec94d9fb4ba07c, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.5018342
+      objectReference: {fileID: 0}
+    - target: {fileID: 1525142461768372567, guid: 3bb1444954873424c8ec94d9fb4ba07c, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1525142461768372567, guid: 3bb1444954873424c8ec94d9fb4ba07c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1525142461768372567, guid: 3bb1444954873424c8ec94d9fb4ba07c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 60.243
+      objectReference: {fileID: 0}
+    - target: {fileID: 1525142461768372567, guid: 3bb1444954873424c8ec94d9fb4ba07c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2189229156332588013, guid: 3bb1444954873424c8ec94d9fb4ba07c, type: 3}
+      propertyPath: m_Name
+      value: Respawn_02
+      objectReference: {fileID: 0}
+    - target: {fileID: 2189229156332588013, guid: 3bb1444954873424c8ec94d9fb4ba07c, type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5152821508095994033, guid: 3bb1444954873424c8ec94d9fb4ba07c, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6012441104629048870, guid: 3bb1444954873424c8ec94d9fb4ba07c, type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3bb1444954873424c8ec94d9fb4ba07c, type: 3}
+--- !u!4 &466716235 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1525142461768372567, guid: 3bb1444954873424c8ec94d9fb4ba07c, type: 3}
+  m_PrefabInstance: {fileID: 466716234}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &580449181
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 580449182}
+  m_Layer: 0
+  m_Name: respawn_1
+  m_TagString: SpawnPoint
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &580449182
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 580449181}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 12, y: 4, z: 7}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1794952206}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &651353928 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8849778546694332496, guid: 455bc6d55d776c34482adf02e622c2d9, type: 3}
+  m_PrefabInstance: {fileID: 3217259389550734977}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &651353934 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7089104827048010884, guid: 455bc6d55d776c34482adf02e622c2d9, type: 3}
+  m_PrefabInstance: {fileID: 3217259389550734977}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 651353928}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 920e321ce107d8c0fa05b1abf0346b9e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &651353939
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 651353928}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3b5d7c088409d9a40b7b09aa707777f8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  TargetOffset: {x: 0, y: 0, z: 0}
+  TrackerSettings:
+    BindingMode: 4
+    PositionDamping: {x: 0, y: 0, z: 0}
+    AngularDampingMode: 0
+    RotationDamping: {x: 0, y: 0, z: 0}
+    QuaternionDamping: 1
+  OrbitStyle: 0
+  Radius: 10
+  Orbits:
+    Top:
+      Radius: 2
+      Height: 5
+    Center:
+      Radius: 4
+      Height: 2.25
+    Bottom:
+      Radius: 2.5
+      Height: 0.1
+    SplineCurvature: 0.5
+  RecenteringTarget: 1
+  HorizontalAxis:
+    Value: 0
+    Center: 0
+    Range: {x: -180, y: 180}
+    Wrap: 1
+    Recentering:
+      Enabled: 0
+      Wait: 1
+      Time: 2
+    Restrictions: 0
+  VerticalAxis:
+    Value: 20
+    Center: 17.5
+    Range: {x: 10, y: 30}
+    Wrap: 0
+    Recentering:
+      Enabled: 0
+      Wait: 1
+      Time: 2
+    Restrictions: 0
+  RadialAxis:
+    Value: 1
+    Center: 1
+    Range: {x: 0.3, y: 1.5}
+    Wrap: 0
+    Recentering:
+      Enabled: 0
+      Wait: 1
+      Time: 2
+    Restrictions: 0
+--- !u!114 &651353940
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 651353928}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 89875cdc57c54474a8a74efd9b2a3b5d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ScanRecursively: 1
+  SuppressInputWhileBlending: 1
+  IgnoreTimeScale: 0
+  m_ControllerManager:
+    Controllers:
+    - Name: Look Orbit X
+      Owner: {fileID: 651353939}
+      Enabled: 1
+      Input:
+        InputAction: {fileID: -5630151704836100654, guid: 1d6e640e716dc4ff6989b73d02023f2b, type: 3}
+        Gain: 20
+        LegacyInput: 
+        LegacyGain: 1
+        CancelDeltaTime: 0
+      InputValue: 0
+      Driver:
+        AccelTime: 0
+        DecelTime: 0
+    - Name: Look Orbit Y
+      Owner: {fileID: 651353939}
+      Enabled: 0
+      Input:
+        InputAction: {fileID: -5630151704836100654, guid: 1d6e640e716dc4ff6989b73d02023f2b, type: 3}
+        Gain: 5
+        LegacyInput: 
+        LegacyGain: 1
+        CancelDeltaTime: 0
+      InputValue: 0
+      Driver:
+        AccelTime: 0
+        DecelTime: 0
+    - Name: Orbit Scale
+      Owner: {fileID: 651353939}
+      Enabled: 0
+      Input:
+        InputAction: {fileID: -423771258819551211, guid: 1d6e640e716dc4ff6989b73d02023f2b, type: 3}
+        Gain: -1
+        LegacyInput: 
+        LegacyGain: 1
+        CancelDeltaTime: 0
+      InputValue: 0
+      Driver:
+        AccelTime: 0
+        DecelTime: 0
+  PlayerIndex: -1
+  AutoEnableInputs: 1
+--- !u!114 &651353941
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 651353928}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1e8b78ac948f05a46a6d8339a503172b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  LookAtOffset: {x: 0, y: 0, z: 0}
+--- !u!1 &840612363
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 840612364}
+  m_Layer: 0
+  m_Name: respawn_2
+  m_TagString: SpawnPoint
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &840612364
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 840612363}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -12, y: 4, z: -7}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1794952206}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1212363335
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1212363338}
+  - component: {fileID: 1212363337}
+  - component: {fileID: 1212363336}
+  m_Layer: 0
+  m_Name: HUD
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1212363336
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1212363335}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 63de1be28ba4e9e4eb5e237d2665490d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _uiDocument: {fileID: 1212363337}
+--- !u!114 &1212363337
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1212363335}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 19102, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_PanelSettings: {fileID: 11400000, guid: 375219e0f9be73791af68905fab77544, type: 2}
+  m_ParentUI: {fileID: 0}
+  sourceAsset: {fileID: 9197481963319205126, guid: c1ac87288658425aaab7dc752a06bbbe, type: 3}
+  m_SortingOrder: 0
+  m_WorldSpaceSizeMode: 1
+  m_WorldSpaceWidth: 1920
+  m_WorldSpaceHeight: 1080
+--- !u!4 &1212363338
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1212363335}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.0002374649, y: -5.1266813, z: -0.10909283}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2988542345828366010}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1267380471 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8092821586305642039, guid: 6f653977c7842bb4d98d20ece9f13f85, type: 3}
+  m_PrefabInstance: {fileID: 2988542345828366009}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1267380474
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1267380471}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5a5c7f960d67611a7b5d3b2c502d1e9f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hitSparkPrefab: {fileID: 7319708159770229219, guid: a2847fd8610022df6b5eeeda80b12862, type: 3}
+  _sparkLifetime: 1
+--- !u!1001 &1399963924
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1480285202534727679, guid: 54dc9e080b7e68274b44ece5b64c0583, type: 3}
+      propertyPath: m_Name
+      value: Dummy
+      objectReference: {fileID: 0}
+    - target: {fileID: 3036402595136625710, guid: 54dc9e080b7e68274b44ece5b64c0583, type: 3}
+      propertyPath: m_Controller
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 4909017262345204786, guid: 54dc9e080b7e68274b44ece5b64c0583, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4909017262345204786, guid: 54dc9e080b7e68274b44ece5b64c0583, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4909017262345204786, guid: 54dc9e080b7e68274b44ece5b64c0583, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4909017262345204786, guid: 54dc9e080b7e68274b44ece5b64c0583, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4909017262345204786, guid: 54dc9e080b7e68274b44ece5b64c0583, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4909017262345204786, guid: 54dc9e080b7e68274b44ece5b64c0583, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4909017262345204786, guid: 54dc9e080b7e68274b44ece5b64c0583, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4909017262345204786, guid: 54dc9e080b7e68274b44ece5b64c0583, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4909017262345204786, guid: 54dc9e080b7e68274b44ece5b64c0583, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4909017262345204786, guid: 54dc9e080b7e68274b44ece5b64c0583, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6412583870191162628, guid: 54dc9e080b7e68274b44ece5b64c0583, type: 3}
+      propertyPath: _animator
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects:
+    - {fileID: 1227201508542476597, guid: 54dc9e080b7e68274b44ece5b64c0583, type: 3}
+    - {fileID: 8831973375768598239, guid: 54dc9e080b7e68274b44ece5b64c0583, type: 3}
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 54dc9e080b7e68274b44ece5b64c0583, type: 3}
+--- !u!114 &1399963925 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6412583870191162628, guid: 54dc9e080b7e68274b44ece5b64c0583, type: 3}
+  m_PrefabInstance: {fileID: 1399963924}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e87e200ca77218f2ca7a7cd9684d2290, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &1553613839
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1480285202534727679, guid: 2f016902f90d8f1f28459de7fdc5c621, type: 3}
+      propertyPath: m_Name
+      value: Player
+      objectReference: {fileID: 0}
+    - target: {fileID: 3036402595136625710, guid: 2f016902f90d8f1f28459de7fdc5c621, type: 3}
+      propertyPath: m_Controller
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 4909017262345204786, guid: 2f016902f90d8f1f28459de7fdc5c621, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4909017262345204786, guid: 2f016902f90d8f1f28459de7fdc5c621, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4909017262345204786, guid: 2f016902f90d8f1f28459de7fdc5c621, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4909017262345204786, guid: 2f016902f90d8f1f28459de7fdc5c621, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4909017262345204786, guid: 2f016902f90d8f1f28459de7fdc5c621, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4909017262345204786, guid: 2f016902f90d8f1f28459de7fdc5c621, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4909017262345204786, guid: 2f016902f90d8f1f28459de7fdc5c621, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4909017262345204786, guid: 2f016902f90d8f1f28459de7fdc5c621, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4909017262345204786, guid: 2f016902f90d8f1f28459de7fdc5c621, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4909017262345204786, guid: 2f016902f90d8f1f28459de7fdc5c621, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6270405280839711424, guid: 2f016902f90d8f1f28459de7fdc5c621, type: 3}
+      propertyPath: m_Controller
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 6270405280839711424, guid: 2f016902f90d8f1f28459de7fdc5c621, type: 3}
+      propertyPath: m_ApplyRootMotion
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6412583870191162628, guid: 2f016902f90d8f1f28459de7fdc5c621, type: 3}
+      propertyPath: _animator
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: 6270405280839711424, guid: 2f016902f90d8f1f28459de7fdc5c621, type: 3}
+    m_RemovedGameObjects:
+    - {fileID: 2376344202488840454, guid: 2f016902f90d8f1f28459de7fdc5c621, type: 3}
+    - {fileID: 769842967419730432, guid: 2f016902f90d8f1f28459de7fdc5c621, type: 3}
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 2f016902f90d8f1f28459de7fdc5c621, type: 3}
+--- !u!4 &1553613840 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4909017262345204786, guid: 2f016902f90d8f1f28459de7fdc5c621, type: 3}
+  m_PrefabInstance: {fileID: 1553613839}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1553613842 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6412583870191162628, guid: 2f016902f90d8f1f28459de7fdc5c621, type: 3}
+  m_PrefabInstance: {fileID: 1553613839}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e87e200ca77218f2ca7a7cd9684d2290, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1663229515 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5401717673974441158, guid: 2f016902f90d8f1f28459de7fdc5c621, type: 3}
+  m_PrefabInstance: {fileID: 1553613839}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9e0d06a7465872c1190de639fe9e6f41, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1794952205
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1794952206}
+  m_Layer: 0
+  m_Name: IslandArena
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1794952206
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1794952205}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2030226532}
+  - {fileID: 2091854371}
+  - {fileID: 466716235}
+  - {fileID: 580449182}
+  - {fileID: 840612364}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &2030226531
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1794952206}
+    m_Modifications:
+    - target: {fileID: 4990821864363784103, guid: 32e3d6ba51a5f0143b390eed5be1ec89, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4990821864363784103, guid: 32e3d6ba51a5f0143b390eed5be1ec89, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4990821864363784103, guid: 32e3d6ba51a5f0143b390eed5be1ec89, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4990821864363784103, guid: 32e3d6ba51a5f0143b390eed5be1ec89, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4990821864363784103, guid: 32e3d6ba51a5f0143b390eed5be1ec89, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4990821864363784103, guid: 32e3d6ba51a5f0143b390eed5be1ec89, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4990821864363784103, guid: 32e3d6ba51a5f0143b390eed5be1ec89, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4990821864363784103, guid: 32e3d6ba51a5f0143b390eed5be1ec89, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4990821864363784103, guid: 32e3d6ba51a5f0143b390eed5be1ec89, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4990821864363784103, guid: 32e3d6ba51a5f0143b390eed5be1ec89, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4990821864363784103, guid: 32e3d6ba51a5f0143b390eed5be1ec89, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4990821864363784103, guid: 32e3d6ba51a5f0143b390eed5be1ec89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4990821864363784103, guid: 32e3d6ba51a5f0143b390eed5be1ec89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4990821864363784103, guid: 32e3d6ba51a5f0143b390eed5be1ec89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5623068110867639581, guid: 32e3d6ba51a5f0143b390eed5be1ec89, type: 3}
+      propertyPath: m_Name
+      value: Arena_01
+      objectReference: {fileID: 0}
+    - target: {fileID: 5623068110867639581, guid: 32e3d6ba51a5f0143b390eed5be1ec89, type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 32e3d6ba51a5f0143b390eed5be1ec89, type: 3}
+--- !u!4 &2030226532 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4990821864363784103, guid: 32e3d6ba51a5f0143b390eed5be1ec89, type: 3}
+  m_PrefabInstance: {fileID: 2030226531}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2091854370
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1794952206}
+    m_Modifications:
+    - target: {fileID: 492293370196990862, guid: 94f02ad398797e847a6c0e2c89903189, type: 3}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 492293370196990862, guid: 94f02ad398797e847a6c0e2c89903189, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 11.963353
+      objectReference: {fileID: 0}
+    - target: {fileID: 492293370196990862, guid: 94f02ad398797e847a6c0e2c89903189, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 492293370196990862, guid: 94f02ad398797e847a6c0e2c89903189, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 6.9403296
+      objectReference: {fileID: 0}
+    - target: {fileID: 492293370196990862, guid: 94f02ad398797e847a6c0e2c89903189, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.5160172
+      objectReference: {fileID: 0}
+    - target: {fileID: 492293370196990862, guid: 94f02ad398797e847a6c0e2c89903189, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 492293370196990862, guid: 94f02ad398797e847a6c0e2c89903189, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.8565782
+      objectReference: {fileID: 0}
+    - target: {fileID: 492293370196990862, guid: 94f02ad398797e847a6c0e2c89903189, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 492293370196990862, guid: 94f02ad398797e847a6c0e2c89903189, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 492293370196990862, guid: 94f02ad398797e847a6c0e2c89903189, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -117.869
+      objectReference: {fileID: 0}
+    - target: {fileID: 492293370196990862, guid: 94f02ad398797e847a6c0e2c89903189, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 981550087478919476, guid: 94f02ad398797e847a6c0e2c89903189, type: 3}
+      propertyPath: m_Name
+      value: Respawn_01
+      objectReference: {fileID: 0}
+    - target: {fileID: 981550087478919476, guid: 94f02ad398797e847a6c0e2c89903189, type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 4651907937861741823, guid: 94f02ad398797e847a6c0e2c89903189, type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7358799569908816796, guid: 94f02ad398797e847a6c0e2c89903189, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 94f02ad398797e847a6c0e2c89903189, type: 3}
+--- !u!4 &2091854371 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 492293370196990862, guid: 94f02ad398797e847a6c0e2c89903189, type: 3}
+  m_PrefabInstance: {fileID: 2091854370}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2988542345828366009
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 629507886947414918, guid: 6f653977c7842bb4d98d20ece9f13f85, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.0002374649
+      objectReference: {fileID: 0}
+    - target: {fileID: 629507886947414918, guid: 6f653977c7842bb4d98d20ece9f13f85, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 5.1266813
+      objectReference: {fileID: 0}
+    - target: {fileID: 629507886947414918, guid: 6f653977c7842bb4d98d20ece9f13f85, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.10909283
+      objectReference: {fileID: 0}
+    - target: {fileID: 629507886947414918, guid: 6f653977c7842bb4d98d20ece9f13f85, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 629507886947414918, guid: 6f653977c7842bb4d98d20ece9f13f85, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 629507886947414918, guid: 6f653977c7842bb4d98d20ece9f13f85, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 629507886947414918, guid: 6f653977c7842bb4d98d20ece9f13f85, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 629507886947414918, guid: 6f653977c7842bb4d98d20ece9f13f85, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 629507886947414918, guid: 6f653977c7842bb4d98d20ece9f13f85, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 629507886947414918, guid: 6f653977c7842bb4d98d20ece9f13f85, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 817566539019222757, guid: 6f653977c7842bb4d98d20ece9f13f85, type: 3}
+      propertyPath: _arenaName
+      value: Island_arena
+      objectReference: {fileID: 0}
+    - target: {fileID: 817566539019222757, guid: 6f653977c7842bb4d98d20ece9f13f85, type: 3}
+      propertyPath: _npcAiMode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 817566539019222757, guid: 6f653977c7842bb4d98d20ece9f13f85, type: 3}
+      propertyPath: _hudManager
+      value: 
+      objectReference: {fileID: 1212363336}
+    - target: {fileID: 817566539019222757, guid: 6f653977c7842bb4d98d20ece9f13f85, type: 3}
+      propertyPath: _cameraMount
+      value: 
+      objectReference: {fileID: 651353934}
+    - target: {fileID: 817566539019222757, guid: 6f653977c7842bb4d98d20ece9f13f85, type: 3}
+      propertyPath: _npcRenderer
+      value: 
+      objectReference: {fileID: 1399963925}
+    - target: {fileID: 817566539019222757, guid: 6f653977c7842bb4d98d20ece9f13f85, type: 3}
+      propertyPath: _playerClass
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 817566539019222757, guid: 6f653977c7842bb4d98d20ece9f13f85, type: 3}
+      propertyPath: _aimIndicator
+      value: 
+      objectReference: {fileID: 2988542345828366012}
+    - target: {fileID: 817566539019222757, guid: 6f653977c7842bb4d98d20ece9f13f85, type: 3}
+      propertyPath: _showHitboxes
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 817566539019222757, guid: 6f653977c7842bb4d98d20ece9f13f85, type: 3}
+      propertyPath: _combatFeedback
+      value: 
+      objectReference: {fileID: 1267380474}
+    - target: {fileID: 817566539019222757, guid: 6f653977c7842bb4d98d20ece9f13f85, type: 3}
+      propertyPath: _playerRenderer
+      value: 
+      objectReference: {fileID: 1553613842}
+    - target: {fileID: 817566539019222757, guid: 6f653977c7842bb4d98d20ece9f13f85, type: 3}
+      propertyPath: _inputController
+      value: 
+      objectReference: {fileID: 1663229515}
+    - target: {fileID: 8092821586305642039, guid: 6f653977c7842bb4d98d20ece9f13f85, type: 3}
+      propertyPath: m_Name
+      value: TrainingMatch
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 629507886947414918, guid: 6f653977c7842bb4d98d20ece9f13f85, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1212363338}
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 8092821586305642039, guid: 6f653977c7842bb4d98d20ece9f13f85, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1267380474}
+    - targetCorrespondingSourceObject: {fileID: 8092821586305642039, guid: 6f653977c7842bb4d98d20ece9f13f85, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2988542345828366012}
+  m_SourcePrefab: {fileID: 100100000, guid: 6f653977c7842bb4d98d20ece9f13f85, type: 3}
+--- !u!4 &2988542345828366010 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 629507886947414918, guid: 6f653977c7842bb4d98d20ece9f13f85, type: 3}
+  m_PrefabInstance: {fileID: 2988542345828366009}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2988542345828366012
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1267380471}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 593b115fdf84a5606885ad1261b23c54, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _maxRange: 12
+  _minRange: 1
+--- !u!1001 &3217259389550734977
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1342048375675441088, guid: 455bc6d55d776c34482adf02e622c2d9, type: 3}
+      propertyPath: Target.TrackingTarget
+      value: 
+      objectReference: {fileID: 1553613840}
+    - target: {fileID: 2607289433223189454, guid: 455bc6d55d776c34482adf02e622c2d9, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2607289433223189454, guid: 455bc6d55d776c34482adf02e622c2d9, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 8.420201
+      objectReference: {fileID: 0}
+    - target: {fileID: 2607289433223189454, guid: 455bc6d55d776c34482adf02e622c2d9, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -9.396926
+      objectReference: {fileID: 0}
+    - target: {fileID: 2607289433223189454, guid: 455bc6d55d776c34482adf02e622c2d9, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9848078
+      objectReference: {fileID: 0}
+    - target: {fileID: 2607289433223189454, guid: 455bc6d55d776c34482adf02e622c2d9, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.1736482
+      objectReference: {fileID: 0}
+    - target: {fileID: 2607289433223189454, guid: 455bc6d55d776c34482adf02e622c2d9, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2607289433223189454, guid: 455bc6d55d776c34482adf02e622c2d9, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2607289433223189454, guid: 455bc6d55d776c34482adf02e622c2d9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 22.99
+      objectReference: {fileID: 0}
+    - target: {fileID: 2607289433223189454, guid: 455bc6d55d776c34482adf02e622c2d9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2607289433223189454, guid: 455bc6d55d776c34482adf02e622c2d9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5504645932548669358, guid: 455bc6d55d776c34482adf02e622c2d9, type: 3}
+      propertyPath: FollowOffset.x
+      value: -5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5504645932548669358, guid: 455bc6d55d776c34482adf02e622c2d9, type: 3}
+      propertyPath: FollowOffset.y
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5504645932548669358, guid: 455bc6d55d776c34482adf02e622c2d9, type: 3}
+      propertyPath: FollowOffset.z
+      value: -5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5504645932548669358, guid: 455bc6d55d776c34482adf02e622c2d9, type: 3}
+      propertyPath: TrackerSettings.BindingMode
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8849778546694332496, guid: 455bc6d55d776c34482adf02e622c2d9, type: 3}
+      propertyPath: m_Name
+      value: CameraMount
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 8849778546694332496, guid: 455bc6d55d776c34482adf02e622c2d9, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 651353939}
+    - targetCorrespondingSourceObject: {fileID: 8849778546694332496, guid: 455bc6d55d776c34482adf02e622c2d9, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 651353940}
+    - targetCorrespondingSourceObject: {fileID: 8849778546694332496, guid: 455bc6d55d776c34482adf02e622c2d9, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 651353941}
+    - targetCorrespondingSourceObject: {fileID: 2363612637730096979, guid: 455bc6d55d776c34482adf02e622c2d9, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 390575604}
+  m_SourcePrefab: {fileID: 100100000, guid: 455bc6d55d776c34482adf02e622c2d9, type: 3}
+--- !u!1001 &8956583311211441222
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 880809498417300422, guid: 8571f1a8d3d462332bcba632f3d6d50d, type: 3}
+      propertyPath: m_Name
+      value: GameManager
+      objectReference: {fileID: 0}
+    - target: {fileID: 7984191700762102927, guid: 8571f1a8d3d462332bcba632f3d6d50d, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.3841343
+      objectReference: {fileID: 0}
+    - target: {fileID: 7984191700762102927, guid: 8571f1a8d3d462332bcba632f3d6d50d, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.639741
+      objectReference: {fileID: 0}
+    - target: {fileID: 7984191700762102927, guid: 8571f1a8d3d462332bcba632f3d6d50d, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.205877
+      objectReference: {fileID: 0}
+    - target: {fileID: 7984191700762102927, guid: 8571f1a8d3d462332bcba632f3d6d50d, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7984191700762102927, guid: 8571f1a8d3d462332bcba632f3d6d50d, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7984191700762102927, guid: 8571f1a8d3d462332bcba632f3d6d50d, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7984191700762102927, guid: 8571f1a8d3d462332bcba632f3d6d50d, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7984191700762102927, guid: 8571f1a8d3d462332bcba632f3d6d50d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7984191700762102927, guid: 8571f1a8d3d462332bcba632f3d6d50d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7984191700762102927, guid: 8571f1a8d3d462332bcba632f3d6d50d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8571f1a8d3d462332bcba632f3d6d50d, type: 3}
+--- !u!1 &5000000001
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5000000002}
+  - component: {fileID: 5000000003}
+  - component: {fileID: 5000000004}
+  m_Layer: 0
+  m_Name: NetworkManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5000000002
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5000000001}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &5000000003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5000000001}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f51fa1f947d94e11ae6b75dab2a103e4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _playerRenderer: {fileID: 1553613842}
+  _opponentRenderer: {fileID: 1399963925}
+  _inputController: {fileID: 1663229515}
+  _cameraMount: {fileID: 651353934}
+  _networkClient: {fileID: 5000000004}
+  _arenaName: training
+  _playerClass: 0
+  _opponentClass: 0
+  _aimHandler: {fileID: 0}
+  _hudManager: {fileID: 1212363336}
+--- !u!114 &5000000004
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5000000001}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 40ae99a0bcc7f1b4284a0d2b0a219993, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _serverIp: 127.0.0.1
+  _serverPort: 9876
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 1399963924}
+  - {fileID: 3217259389550734977}
+  - {fileID: 1553613839}
+  - {fileID: 1794952206}
+  - {fileID: 2988542345828366009}
+  - {fileID: 8956583311211441222}
+  - {fileID: 5000000001}

--- a/client/Unity/Assets/Scenes/Arena_PvP.unity.meta
+++ b/client/Unity/Assets/Scenes/Arena_PvP.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9e50f62b09564aadb793e9ec9345e6c6
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/client/Unity/Assets/Scripts/Runtime/Simulation/ISimulationBridge.cs
+++ b/client/Unity/Assets/Scripts/Runtime/Simulation/ISimulationBridge.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using SlopArena.Shared;
+
+namespace SlopArena.Client.Simulation
+{
+    public interface ISimulationBridge
+    {
+        void RegisterEntity(ulong id, CharacterDefinition def, CharacterState initialState,
+            BakedAnimationData? baked = null);
+        void Tick(Dictionary<ulong, InputState> inputs);
+        CharacterState GetState(ulong id);
+        Dictionary<ulong, CharacterState> GetAllStates();
+        SpellResolver? Resolver { get; }
+    }
+}

--- a/client/Unity/Assets/Scripts/Runtime/Simulation/ISimulationBridge.cs.meta
+++ b/client/Unity/Assets/Scripts/Runtime/Simulation/ISimulationBridge.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 38a555e884dd44daa19d24129a971aad
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/client/Unity/Assets/Scripts/Runtime/Simulation/LocalSimulationBridge.cs
+++ b/client/Unity/Assets/Scripts/Runtime/Simulation/LocalSimulationBridge.cs
@@ -3,7 +3,7 @@ using SlopArena.Shared;
 
 namespace SlopArena.Client.Simulation
 {
-    public class LocalSimulationBridge
+    public class LocalSimulationBridge : ISimulationBridge
     {
         private readonly ServerSimulation _server;
         private readonly ArenaDefinition _arena;
@@ -22,6 +22,6 @@ namespace SlopArena.Client.Simulation
 
         public CharacterState GetState(ulong id) => _server.GetState(id);
         public Dictionary<ulong, CharacterState> GetAllStates() => _server.GetAllStates();
-        public SpellResolver Resolver => _server.Resolver;
+        public SpellResolver? Resolver => _server.Resolver;
     }
 }

--- a/client/Unity/Assets/Scripts/Runtime/Simulation/NetworkSimulationBridge.cs
+++ b/client/Unity/Assets/Scripts/Runtime/Simulation/NetworkSimulationBridge.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using SlopArena.Shared;
+using SlopArena.Client.Network;
+using UnityEngine;
+
+namespace SlopArena.Client.Simulation
+{
+    /// <summary>
+    /// ISimulationBridge backed by the UDP NetworkClient.
+    /// Sends local input each tick; returns latest server-authoritative states.
+    /// No local simulation — one-tick display latency is intentional (Phase 1).
+    /// </summary>
+    public class NetworkSimulationBridge : ISimulationBridge
+    {
+        private readonly NetworkClient _client;
+        private uint _tick;
+        private ulong _localEntityId;
+        private readonly Dictionary<ulong, CharacterState> _latestStates = new();
+
+        public NetworkSimulationBridge(NetworkClient client, ulong localEntityId)
+        {
+            _client = client;
+            _localEntityId = localEntityId;
+        }
+
+        /// <summary>No-op: server owns entity registration. Stored def handled by caller.</summary>
+        public void RegisterEntity(ulong id, CharacterDefinition def, CharacterState initialState,
+            BakedAnimationData? baked = null) { }
+
+        /// <summary>
+        /// Send local player input, advance tick, drain latest server states.
+        /// </summary>
+        public void Tick(Dictionary<ulong, InputState> inputs)
+        {
+            if (inputs.TryGetValue(_localEntityId, out var input))
+                _client.SendInput(input, _tick);
+
+            _tick++;
+
+            var received = _client.ReceiveStates();
+            foreach (var kv in received)
+                _latestStates[kv.Key] = kv.Value;
+        }
+
+        public CharacterState GetState(ulong id)
+            => _latestStates.TryGetValue(id, out var s) ? s : default;
+
+        public Dictionary<ulong, CharacterState> GetAllStates() => _latestStates;
+
+        /// <summary>No local resolver — server owns hitbox collision.</summary>
+        public SpellResolver? Resolver => null;
+    }
+}

--- a/client/Unity/Assets/Scripts/Runtime/Simulation/NetworkSimulationBridge.cs.meta
+++ b/client/Unity/Assets/Scripts/Runtime/Simulation/NetworkSimulationBridge.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4deba335bfc84fea8b2d41d184be5fc1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/client/Unity/Assets/Scripts/Runtime/World/PvPMatch.cs
+++ b/client/Unity/Assets/Scripts/Runtime/World/PvPMatch.cs
@@ -1,0 +1,232 @@
+using System.Collections.Generic;
+using System.IO;
+using System;
+using UnityEngine;
+using SlopArena.Shared;
+using SlopArena.Client.Entities;
+using SlopArena.Client.Input;
+using SlopArena.Client.Camera;
+using SlopArena.Client.UI;
+using SlopArena.Client.Network;
+using SlopArena.Client.Simulation;
+
+namespace SlopArena.Client.World
+{
+    /// <summary>
+    /// PvP match backed by a remote server. Uses NetworkSimulationBridge — no local sim.
+    /// Phase 1: raw server-state display, no prediction/rollback.
+    /// </summary>
+    public class PvPMatch : MatchBase
+    {
+        [Header("Entities")]
+        [SerializeField] private PlayerRenderer _playerRenderer;
+        [SerializeField] private PlayerRenderer _opponentRenderer;
+
+        [Header("Input")]
+        [SerializeField] private InputController _inputController;
+        [SerializeField] private CameraMount _cameraMount;
+
+        [Header("Network")]
+        [SerializeField] private NetworkClient _networkClient;
+
+        [Header("Arena")]
+        [SerializeField] private string _arenaName = "training";
+
+        [Header("Characters")]
+        [SerializeField] private CharacterClass _playerClass = CharacterClass.Manki;
+        [SerializeField] private CharacterClass _opponentClass = CharacterClass.Manki;
+
+        [Header("Aiming")]
+        [SerializeField] private AimHandler _aimHandler;
+        [SerializeField] private HUDManager _hudManager;
+
+        private const ulong PlayerEntityId = 1;
+        private const ulong OpponentEntityId = 2;
+
+        private bool _showCrosshair;
+        private uint _tick;
+        private CharacterDefinition _playerDef = null!;
+        private NetworkSimulationBridge _bridge = null!;
+        private UnityEngine.Camera _mainCamera;
+
+        protected override void OnMatchStart()
+        {
+            // Arena
+            string arenaPath = Path.GetFullPath(Path.Combine(
+                Application.dataPath, "..", "..", "..", "data", "arenas", _arenaName + ".arena"));
+            ArenaDefinition arena;
+            if (File.Exists(arenaPath))
+            {
+                var loaded = ArenaBinaryFormat.LoadFromFile(arenaPath);
+                arena = loaded ?? ArenaRegistry.Get(_arenaName);
+                Debug.Log($"[PvPMatch] Loaded arena: {arenaPath}");
+            }
+            else
+            {
+                arena = ArenaRegistry.Get(_arenaName);
+                Debug.Log($"[PvPMatch] Using hardcoded arena: {_arenaName}");
+            }
+
+            Simulation.OnDebugLog = msg => Debug.Log(msg);
+
+            // Bridge
+            _networkClient.EntityId = PlayerEntityId;
+            _bridge = new NetworkSimulationBridge(_networkClient, PlayerEntityId);
+
+            // Character definitions
+            var playerDef = CharacterRegistry.Get(_playerClass);
+            _playerDef = playerDef;
+            var playerBaked = LoadBakedData(playerDef);
+
+            var opponentDef = CharacterRegistry.Get(_opponentClass);
+            var opponentBaked = LoadBakedData(opponentDef);
+
+            // HUD
+            _hudManager?.Initialize(() => _bridge.GetState(PlayerEntityId));
+            _hudManager?.SetCharacterDefinition(playerDef);
+            for (int slot = 0; slot < 6; slot++)
+            {
+                var spec = playerDef.GetSlotAbility(slot, airborne: false);
+                if (spec != null)
+                    _hudManager?.SetSlotMaxCooldown(slot, spec.CooldownTicks);
+                var specAir = playerDef.GetSlotAbility(slot, airborne: true);
+                if (specAir != null && specAir.CooldownTicks > spec?.CooldownTicks)
+                    _hudManager?.SetSlotMaxCooldown(slot, specAir.CooldownTicks);
+            }
+
+            // Player renderer
+            _playerRenderer.ModelYOffset = playerDef.ModelYOffset;
+            _playerRenderer.CapsuleRadius = playerDef.CapsuleRadius;
+            _playerRenderer.CapsuleHeight = playerDef.CapsuleHeight;
+            _playerRenderer.HurtboxBoneDefs = playerDef.HurtboxBoneDefs;
+            _playerRenderer.SetBakedData(playerBaked);
+            _playerRenderer.SetCharacterDefinition(playerDef);
+            _playerRenderer.LoadModel(playerDef);
+
+            // Opponent renderer
+            if (_opponentRenderer != null)
+            {
+                _opponentRenderer.ModelYOffset = opponentDef.ModelYOffset;
+                _opponentRenderer.CapsuleRadius = opponentDef.CapsuleRadius;
+                _opponentRenderer.CapsuleHeight = opponentDef.CapsuleHeight;
+                _opponentRenderer.HurtboxBoneDefs = opponentDef.HurtboxBoneDefs;
+                _opponentRenderer.SetBakedData(opponentBaked);
+                _opponentRenderer.SetCharacterDefinition(opponentDef);
+                _opponentRenderer.LoadModel(opponentDef);
+            }
+
+            // Position renderers at spawn points
+            var spawnPoints = arena.SpawnPoints;
+            if (spawnPoints.Length > 0)
+                _playerRenderer.transform.position = new Vector3(spawnPoints[0].X, spawnPoints[0].Y, spawnPoints[0].Z);
+            if (_opponentRenderer != null && spawnPoints.Length > 1)
+                _opponentRenderer.transform.position = new Vector3(spawnPoints[1].X, spawnPoints[1].Y, spawnPoints[1].Z);
+
+            // Camera
+            if (_cameraMount != null)
+            {
+                _cameraMount.SetTarget(_playerRenderer.transform);
+                _cameraMount.ResetView(_playerRenderer.transform);
+            }
+
+            // Aim
+            _aimHandler?.Init(_cameraMount, _cameraMount?.RenderCamera);
+        }
+
+        private void Update()
+        {
+            _inputController.Poll();
+        }
+
+        protected override void OnMatchFixedUpdate()
+        {
+            if (_bridge == null || _playerRenderer == null) return;
+
+            byte slot = _inputController.ConsumePendingSlotPress();
+
+            var playerState = _bridge.GetState(PlayerEntityId);
+            var aimCtx = _aimHandler != null
+                ? _aimHandler.Evaluate(playerState, slot, _playerDef, _inputController)
+                : AimContext.None;
+            _showCrosshair = _aimHandler?.ShowCrosshair ?? false;
+
+            byte targetEntityId = PickScreenTarget(
+                _opponentRenderer != null ? new[] { _opponentRenderer } : Array.Empty<PlayerRenderer>(),
+                _mainCamera ??= _cameraMount?.RenderCamera ?? UnityEngine.Camera.main);
+
+            var (input, _, _) = _inputController.BuildInputState(
+                _cameraMount,
+                _playerRenderer.transform.eulerAngles.y,
+                isNPC: false,
+                pendingSlotPress: slot,
+                aimCtx: aimCtx,
+                canMove: null,
+                targetEntityId: targetEntityId);
+
+            _bridge.Tick(new Dictionary<ulong, InputState>
+            {
+                { PlayerEntityId, input }
+            });
+
+            _hudManager?.Refresh();
+
+            // Apply server states to renderers
+            _playerRenderer.ApplyServerState(_bridge.GetState(PlayerEntityId));
+            if (_opponentRenderer != null)
+                _opponentRenderer.ApplyServerState(_bridge.GetState(OpponentEntityId));
+
+            _tick++;
+            if (_tick % 120 == 1)
+            {
+                var ps = _bridge.GetState(PlayerEntityId);
+                Debug.Log($"[PvP] tick={_tick} connected={_networkClient.IsServerConnected} " +
+                          $"pos=({ps.PX:F1},{ps.PY:F2},{ps.PZ:F1}) serverTick={_networkClient.LastServerTick}");
+            }
+        }
+
+        private byte PickScreenTarget(PlayerRenderer[] renderers, UnityEngine.Camera cam)
+        {
+            if (cam == null || renderers == null || renderers.Length == 0 || _playerRenderer == null)
+                return 0;
+
+            byte bestId = 0;
+            float bestScreenDist = float.MaxValue;
+            Vector2 screenCenter = new(cam.pixelWidth * 0.5f, cam.pixelHeight * 0.5f);
+            Vector3 playerPos = _playerRenderer.transform.position;
+
+            foreach (var renderer in renderers)
+            {
+                if (renderer == null || renderer == _playerRenderer || renderer.EntityId == 0)
+                    continue;
+
+                Vector3 worldPos = renderer.transform.position;
+                Vector3 screenPos3 = cam.WorldToScreenPoint(worldPos);
+                if (screenPos3.z < 0) continue;
+
+                float screenDist = Vector2.Distance(new Vector2(screenPos3.x, screenPos3.y), screenCenter);
+                float worldDist = Vector3.Distance(playerPos, worldPos);
+
+                if (screenDist < bestScreenDist && worldDist <= 20f)
+                {
+                    bestScreenDist = screenDist;
+                    bestId = (byte)renderer.EntityId;
+                }
+            }
+            return bestId;
+        }
+
+        private void OnGUI()
+        {
+            if (!_showCrosshair) return;
+            float cx = Screen.width * 0.5f;
+            float cy = Screen.height * 0.5f;
+            var style = new GUIStyle(GUI.skin.label)
+            {
+                fontSize = 28,
+                alignment = TextAnchor.MiddleCenter,
+                normal = { textColor = Color.white }
+            };
+            GUI.Label(new Rect(cx - 20, cy - 20, 40, 40), "+", style);
+        }
+    }
+}

--- a/client/Unity/Assets/Scripts/Runtime/World/PvPMatch.cs.meta
+++ b/client/Unity/Assets/Scripts/Runtime/World/PvPMatch.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f51fa1f947d94e11ae6b75dab2a103e4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/client/Unity/Assets/Scripts/Runtime/World/TrainingMatch.cs
+++ b/client/Unity/Assets/Scripts/Runtime/World/TrainingMatch.cs
@@ -175,9 +175,8 @@ namespace SlopArena.Client.World
             byte slot = _inputController.ConsumePendingSlotPress();
 
             // ── Aim ──
-            var playerState = _localSim.GetState(PlayerEntityId);
             var aimCtx = _aimHandler != null
-                ? _aimHandler.Evaluate(playerState, slot, _playerDef, _inputController)
+                ? _aimHandler.Evaluate(_localSim.GetState(PlayerEntityId), slot, _playerDef, _inputController)
                 : AimContext.None;
             _showCrosshair = _aimHandler?.ShowCrosshair ?? false;
 

--- a/client/Unity/ProjectSettings/EditorBuildSettings.asset
+++ b/client/Unity/ProjectSettings/EditorBuildSettings.asset
@@ -4,7 +4,15 @@
 EditorBuildSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 2
-  m_Scenes: []
+  m_Scenes:
+  - enabled: 1
+    path: Assets/Scenes/Arena_Offline.unity
+    guid: 6144c43a70fbb81c4863dbcb54df49aa
+    buildIndex: 0
+  - enabled: 1
+    path: Assets/Scenes/Arena_PvP.unity
+    guid: 9e50f62b09564aadb793e9ec9345e6c6
+    buildIndex: 1
   m_configObjects:
     com.unity.dt.app-ui: {fileID: 11400000, guid: 1b1c20d82303e4b5781c3ef50ac1449f, type: 2}
   m_UseUCBPForAssetBundles: 0


### PR DESCRIPTION
## Summary

Implements T1.1–T1.3 from the PvP roadmap: minimum wiring to connect two Unity instances to the headless server and see each other move. No prediction/rollback — raw server-state display, one-tick latency.

## Changes

### New files
- `ISimulationBridge` — common interface for local and network simulation backends
- `NetworkSimulationBridge` — wraps `NetworkClient`; sends local input each tick, drains server-authoritative states; `Resolver` is null (server owns hitboxes)
- `PvPMatch` — `MatchBase` subclass backed by `NetworkSimulationBridge`; no NPC, no local sim, no CombatFeedback
- `Arena_PvP.unity` — copy of Arena_Offline with a `NetworkManager` root GameObject wiring `PvPMatch` + `NetworkClient` to all existing scene objects
- `.meta` files for all new scripts and scene (stable GUIDs)

### Modified files
- `LocalSimulationBridge` — implements `ISimulationBridge`; `Resolver` return type narrowed to `SpellResolver?`
- `TrainingMatch` — fixed duplicate `var playerState` declaration (lines 178 + 199 both declared it; first removed, aim call now inlines `GetState()`)
- `EditorBuildSettings.asset` — Arena_Offline (index 0) + Arena_PvP (index 1) registered

## Verification

**Build check:** open Unity project → confirm zero compile errors.

**Training regression:** `Arena_Offline` → Play → player moves, NPC attacks, HUD updates.

**PvP cold path:** `Arena_PvP` → Play → `[PvPMatch] Using hardcoded arena: training` log, no crash, `connected=False` in 120-tick log.

**PvP two clients:**
```
# Terminal 1
dotnet run --project src/Server/

# Unity instance A — Arena_PvP, Play
# Expect: [PvP] tick=121 connected=True pos=(...)

# Unity instance B — Arena_PvP, Play, set NetworkClient.EntityId=2 in inspector
# Expect: both instances log connected=True, opponent renderer moves
```

## Notes

- `TrainingMatch` prefab instance remains in `Arena_PvP.unity` — early-return guard on null `_localSim` prevents ticking. Can be disabled via prefab override if needed; deferred to cleanup.
- Entity ID handshake is Phase 2+ work. For Phase 1 testing: client A uses `EntityId=1` (default), client B sets `EntityId=2` in inspector.
- `CombatFeedback` / hit sparks omitted intentionally — requires a local `ServerSimulation`.