### PR TITLE
Add Kistu, the Kitsune Blade (3rd character)

### DIFF
--- a/docs/characters/kistu.md
+++ b/docs/characters/kistu.md
@@ -1,0 +1,132 @@
+---
+id: "kistu"
+name: "Kistu"
+title: "The Kitsune Blade"
+status: "Implemented (sim) — art/anim pending"
+archetype: "In-your-face spacing duelist. Wins neutral with disjointed blade reach, converts hits into vertical air juggles. Agile, aggressive mid-range control — not a full run-in rushdown."
+source_image: "TBD"
+inspiration: "Marth (Fire Emblem / Smash) — spacing, reach, punish game, counter, exploitable recovery. Amaterasu (DKO) — fast agile sword, launcher, air-juggle payoff."
+palette:
+  # Direction: mystic fox spirit. Refine during model/concept pass.
+  fur: "TBD (white / silver, or classic fox orange)"
+  accents: "TBD (foxfire — cyan/violet or crimson)"
+  blade: "TBD"
+kit:
+  - slot: "LMB"
+    name: "Light Slash Combo"
+    type: "melee"
+    description: "3-4 hit slash chain. Fast, low commit, modest knockback on finisher. Close-range bread-and-butter."
+  - slot: "Air LMB"
+    name: "Air Slash (3 hits)"
+    type: "melee"
+    description: "3-hit aerial slash. Low commit, predictable near-neutral/upward KB. Doubles as manual juggle-sustain and a fall-stall (minor recovery aid)."
+  - slot: "RMB"
+    name: "Charged Spin"
+    type: "charge"
+    description: "Tap = quick horizontal spacing poke. Hold = charged spinning vertical slice = the KILL move (big horizontal knockback toward blast zone at high %). Slow, telegraphed, high reward."
+  - slot: "Air RMB"
+    name: "Falling Slash"
+    type: "melee"
+    description: "Committed downward slash. Strong, predictable DOWNWARD knockback. Edgeguard / off-stage finisher — deliberately the opposite of the juggle."
+  - slot: "Q"
+    name: "Counter"
+    type: "counter"
+    description: "Marth-style parry window. If struck during the window, riposte LAUNCHES the attacker (knockback, no lingering stun -> can lead into a juggle). Read-based answer to being rushed inside the blade."
+  - slot: "E"
+    name: "Charged Dash Slash"
+    type: "mobility"
+    description: "Forward dash + slash. Tap = short reposition, hold = full gap-close. Distance scales with charge. Primary horizontal recovery. NO stun (differentiates from FightGuy Cyclone Kick)."
+  - slot: "R"
+    name: "Rising Slash"
+    type: "mobility"
+    description: "Multi-charge homing rising slash. THE SIGNATURE. Launches grounded enemies, re-launches airborne ones. Charge refunds on hit -> sustains the juggle as long as you keep connecting. Whiffing in empty air gives only capped height -> also serves as (honestly exploitable) vertical recovery-from-below."
+  - slot: "F"
+    name: "Blade Flurry"
+    type: "ult"
+    description: "Committed moving multi-slash flurry (forward/rising movement) that ends in a hard launch. Telegraphed startup, dodgeable, heavily punishable on whiff. Kept intentionally simple — a solid finisher, not a showstopper. Foxfire + tails visual."
+---
+
+# Kistu — The Kitsune Blade
+
+> Status: Implemented in Shared sim (all 8 slots + counter/charge-stock infra, 18 passing tests). Model/animation/VFX assets pending; plays now with a placeholder (FightGuy prefab, T-pose). See `docs/plans/2026-07-27-kistu-implementation.md`.
+> Inspired by: **Marth** (spacing, reach, punish, counter, exploitable recovery) × **Amaterasu** (DKO — fast agile sword, launcher, air-juggle payoff).
+
+## Concept
+
+A **kitsune (fox spirit) swordswoman** — agile, precise, trickster-elegant. Where **FightGuy** is a close-range fists-and-ki execution brawler and **Manki** is an explosive zoner, Kistu owns the **mid-range sword game**: a disjointed blade used aggressively to control space and stay glued to the opponent at the edge of its reach, then convert a clean hit into a vertical air juggle.
+
+Fox-spirit theme gives a distinct roster silhouette (monkey / human / fox) and natural VFX flair — **foxfire** trails on slashes, tails flourishing on spins and the counter riposte.
+
+*Species/gender chosen (female kitsune), name locked (**Kistu**); exact palette and tail count still to refine — see Open Decisions.*
+
+## Archetype
+
+**In-your-face spacing duelist.**
+- Neutral: out-space with **disjointed blade reach** and aggressive mid-range pressure. Uniform hit quality — **no positional sweetspot / tipper** (positional sweetspots are unreadable in 3D alongside warp + lunge).
+- Payoff: convert a hit into **launch -> air juggle -> finish** (the "fun" of the kit).
+- Mobility: agile, for **repositioning and spacing**, not stealth/escape. Not a full run-in rushdown — a pressure-at-range fighter.
+- **Designed weakness:** weak once an opponent gets *inside* the blade (classic Marth flaw) and an **honestly exploitable recovery** (see below).
+
+## Design Pillars
+
+### Predictable knockback, emergent combos
+Every ability has **consistent, learnable knockback** (angle + magnitude, scaling with %). Combos are **discovered by the player**, not scripted into the kit. Smash's philosophy, not DKO's fixed launch-chains. No ability is wired to "feed into" another — R reliably launches up, aerials have honest KB, and the juggle *emerges* because the values are readable.
+
+> This pillar is broader than one character — it describes the game's intended combat feel. Consider promoting it to `docs/systems/combat-systems.md`.
+
+### Recovery is a system, not one move
+Recovery is spread across slots and is deliberately **functional-but-exploitable** (the character's signature weakness):
+- **E** (charged dash) — horizontal distance, scales with charge.
+- **Air LMB** (3-hit) — stall / slight drift, buys airtime.
+- **R** (rising slash) — capped vertical height when whiffing in empty air (the flaw); only "extends" when it actually connects with an enemy.
+
+## Kit
+
+| Slot | Name | Role | Mechanic |
+|------|------|------|----------|
+| **LMB** | Light Slash Combo | Light attack | 3-4 hit slash chain, modest KB finisher |
+| **Air LMB** | Air Slash (3 hits) | Aerial / juggle-sustain | 3-hit air slash, predictable upward KB, fall-stall |
+| **RMB** | Charged Spin | Heavy / **kill move** | Tap = horizontal poke; Hold = charged spin = big horizontal launch (blast-zone kill) |
+| **Air RMB** | Falling Slash | Aerial heavy / spike | Strong downward KB, edgeguard/finisher |
+| **Q** | Counter | Counter / read | Parry window -> riposte **launches** attacker (knockback, no lingering stun) |
+| **E** | Charged Dash Slash | Mobility / gap-close | Tap = short reposition, Hold = full gap-close; horizontal recovery; no stun |
+| **R** | Rising Slash | **Signature** launcher + juggle + vertical recovery | Multi-charge homing uppercut; charge refunds on hit -> sustains juggle; capped self-height on whiff |
+| **F** | Blade Flurry | Burst / finisher | Committed moving multi-slash flurry, ends in a hard launch; telegraphed, punishable on whiff |
+
+## Gameplan
+
+Control mid-range with LMB pokes and the disjointed blade -> land a hit or gap-close with E -> **R** to launch -> chase with double-jump/dash + Air LMB, re-launching with R (charges refund on hit) -> cash out with **RMB (charged)** for the kill at high %, or **Air RMB** to spike off-stage. **Q (Counter)** punishes opponents who try to rush inside your range.
+
+## Weaknesses
+- **Inside the blade:** loses to characters who get past the reach and pressure up close.
+- **Recovery:** functional but exploitable — mostly horizontal (E) + capped vertical (R on whiff). Vulnerable to edgeguarding.
+- **Commitment:** RMB charged spin and F are telegraphed; whiffing is heavily punishable.
+- **Counter is a read:** whiffing Q leaves a vulnerable window.
+
+## Open Decisions (implementation-time only)
+
+Kit is fully specified. Remaining items are tuning/art, not design:
+
+1. **Palette** — species/gender/name locked (female kitsune, **Kistu**). Open: exact palette (foxfire color, fur color), tail count.
+2. **Numbers** — all damage / KB / charge counts / CDs / charge-refund timing TBD; tune in implementation against `character-kit-design-principles.md` baselines.
+3. **Q = Counter** — locked as v1 but flagged "a bit lazy"; revisit after playtest depending on how oppressive rushdown feels in practice.
+
+## Animation Needs (soft constraint)
+
+Standard katana motions only — no exotic out-of-the-box motions. All of these are common in stylized katana packs:
+- Ground light combo (multi-slash chain) — LMB
+- 3-hit air slash — Air LMB
+- Charged spin / spinning vertical slice — RMB (hold) + candidate for F
+- Downward falling slash — Air RMB
+- Counter guard + riposte — Q
+- Forward dash slash / lunge — E
+- Rising / uppercut slash — R (the one motion to specifically confirm the pack has)
+
+## Files (to create when built)
+- `src/Shared/Characters/KistuData.cs` — character definition (stats, abilities, animation names)
+- `src/Shared/Abilities/KistuRisingSlash.cs` — R (multi-charge, charge-refund-on-hit)
+- `src/Shared/Abilities/KistuCounter.cs` — Q
+- Charged Spin (RMB) + Charged Dash (E) — likely reuse `ChargeAttackAbility.cs`
+- `src/Shared/CharacterDefinition.cs` — enum + registry entry
+
+See `docs/characters/character-kit-design-principles.md` for design patterns and `docs/systems/combat-systems.md` for universal combat mechanics.

--- a/docs/plans/2026-07-27-kistu-implementation.md
+++ b/docs/plans/2026-07-27-kistu-implementation.md
@@ -1,0 +1,184 @@
+# Kistu — Implementation Plan (code only, no art/anim/model)
+
+> Character design: `docs/characters/kistu.md` (Kistu, The Kitsune Blade — agile katana spacing duelist, launch→juggle payoff).
+> This plan covers **code only**: Shared sim registration, all 8 abilities, the two pieces of genuinely new infra, tests, and the *placeholder* client config that makes Kistu playable without art. Art/anim/model/VFX are explicitly deferred.
+> All file:line refs verified against the current tree (2026-07-27), not the docs. **`docs/characters/adding-a-new-character.md` and `character-import-checklist.md` are STALE** (they describe an obsolete flat `AttackStage` and a numeric `AbilityTypeId` factory) — author against `AttackData.cs` / `AbilitySpec.cs` / `KnockbackProfile.cs` and the `(CharacterClass, slot, airborne)` factory.
+
+---
+
+## 1. Scope
+
+**In scope (code):**
+- New `CharacterClass.Kistu` + registry entry + `KistuData.cs` (8 `AbilitySpec`s).
+- 8 abilities wired through `AbilityFactory.CreateKistuAbility`.
+- Two new infra pieces: **R charge-stock** (`CharacterState` field + gate/consume/refund) and **Q counter** (`ServerAbility.TryCounter` virtual + target-side interception in `ResolveHits`).
+- xUnit tests (golden scenarios for standard abilities, hand-written units for novel infra).
+- **Placeholder** client config (reuse FightGuy prefab, empty baked data) so the kit is selectable and every ability fires with a T-pose stand-in.
+
+**Out of scope (deferred art/anim):** real model prefab, `Kistu_AnimConfig.asset`, baked skeleton `.bin`, VFX/foxfire trails, HUD/ability icons, weapon config, and final balance numbers (placeholders only, tuned later against `character-kit-design-principles.md` + existing Manki/FightGuy values).
+
+---
+
+## 2. Architecture grounding (verified)
+
+**Dispatch chain:** `input.ActiveSlot (1-6)` → `ServerSimulation.PreTickAbilities` (`ServerSimulation.cs:327`) → `AbilityFactory.CreateServer(def.Class, slot-1, airborne)` (`AbilityFactory.cs:15`) → **fresh** `ServerAbility` instance per activation → `ActivateAbility` (`:65`, injects `Resolver`/`SimulationStates`/`BakedData`/`CharacterDef`, calls `OnStart`) → `TickAbilities` (`:129`) calls `.Tick` each frame → `EndAbility` (sets `AttackSlot=0`) → deactivate + cooldown (`:181`).
+
+**Slot indices:** `0=LMB, 1=RMB, 2=Q, 3=E, 4=R, 5=F`; `airborne` routes `(0,true)→AirLMB`, `(1,true)→AirRMB` (`CharacterDefinition.GetSlotAbility`, `:147`).
+
+**Base classes to reuse:**
+- `StageChainAbility` (`StageChainAbility.cs`) — multi-stage melee combos w/ input-buffered chaining; stages come from `AbilitySpec.Stages[]`. `LmbCombo`/`AirLmbCombo` are character-agnostic subclasses → **reuse verbatim**.
+- `ChargeAttackAbility` (`ChargeAttackAbility.cs`) — hold-to-charge, **binary** tap-vs-hold (not analog). `_wasCharged = _chargeTicks >= ChargeHoldTicks`; picks `ChargedStages[0]` if charged else `Stages[1]`. Hooks: `OnChargeStart` (`:35`), `OnAttackStart` (`:38`). `GetChargeHoldTicks(def, fallback)` reads `spec.ChargeHoldTicks`.
+- `AirRmbAttack` (`AirRmbAttack.cs`) — shared single-stage aerial spike; reads `Stages[0]`.
+- `FightGuyDragonKick` (`FightGuyDragonKick.cs`) — **reference** for homing (scans `SimulationStates` for nearest target, steers `s.VX/VZ`), mid-ability state change from a hit (`OnHitEntity` → phase transition), and multi-hit escalating-damage combos with a final launcher.
+
+**Knockback** (`KnockbackProfile.cs`): `KnockbackProfile` enum + `ProfileTable` `(angle, base, growth)` — `Light(15,2,1.5)`, `Medium(15,8,5)`, `Launcher(25,8,4)`, `Kill(20,18,10)`, `Spike(-45,12,4)`, `Custom`. Authored per hit on `HitboxEvent.Knockback` (`KnockbackData{Profile | Custom + Angle/Base/Growth}.Resolve()`). Applied by `Simulation.ApplyKnockback` (`Simulation.cs:891`): `mag = base + growth*(pct*0.01)`; `KVY>0` sets `IsGrounded=false` (launchers pop off ground). Hitstun derived from `kbMag` capped by `StunTicks`; DI added at hitstun end (`Simulation.cs:454`).
+
+**Self-movement:** write `s.VX/VY/VZ` directly in `Tick()` (Grapple/Dragon/Cyclone pattern), or `SetVelocityInFacing(ref s, forwardSpeed, vertical)` (`ServerAbility.cs:199`), or `AttackStage.LungeForce` (one-shot burst at stage start). **`AttackStage.MoveX/MoveY/MoveZ` are declared but NEVER consumed** (verified via grep) — do not rely on them; set velocity directly.
+
+**Hitbox authoring** (`AttackData.cs` `HitboxEvent`): `TriggerTick`, `DurationTicks`, `Shape` (Sphere/Capsule), `Radius`, facing-rotated `OffX/Y/Z` (+ `EndOffX/Y/Z` for capsule far end), `Damage`, `Knockback`, `StunTicks`. **Reach-y disjoint sword = `Shape=Capsule` with `EndOff` extended along facing.** For sim-only (no baked data) use `OffX/Y/Z`, **not** `BoneName` (bone-attached hitboxes need baked skeleton data).
+
+**Movement gating:** velocity/movement auto-processed only when `State==Idle`; during `Attacking`, abilities own velocity. All constraints are server-authoritative (client passes `canMove: null`).
+
+---
+
+## 3. Per-slot verdict
+
+| Slot | Ability | Approach | New code? |
+|------|---------|----------|-----------|
+| LMB (0) | Light Slash Combo (4-hit) | **Reuse `LmbCombo`** — author `Stages[]` only | Data only |
+| AirLMB (0 air) | Air Slash (3-hit) | **Reuse `AirLmbCombo`** — author airborne `Stages[]` | Data only |
+| RMB (1) | Charged Spin | Subclass `ChargeAttackAbility` → `KistuRmbSpin` (`Stages[1]`=poke, `ChargedStages[0]`=horizontal Kill) | Thin subclass |
+| AirRMB (1 air) | Falling Slash | **Reuse `AirRmbAttack`** (Spike KB) — or tiny `KistuAirRmbSpike` if self-plunge | Data (+~10 lines opt) |
+| Q (2) | Counter | **NEW `KistuCounter` + `ServerAbility.TryCounter` virtual + `ResolveHits` interception** | **New infra** |
+| E (3) | Charged Dash Slash | Subclass `ChargeAttackAbility` → `KistuDashSlash` (dash via `SetVelocityInFacing`, no stun) | Thin subclass |
+| R (4) | Rising Slash | **NEW `KistuRisingSlash` + `CharacterState.RChargesLeft` charge-stock** | **New infra** |
+| F (5) | Blade Flurry | **NEW `KistuUltFlurry`** (moving multi-hit → launch, DragonKick pattern) | New subclass |
+
+**The only genuinely novel infra:** (1) `CharacterState.RChargesLeft` charge-stock + gate/consume/refund; (2) `ServerAbility.TryCounter` + target-side interception in `ResolveHits`. Everything else is subclasses + data.
+
+---
+
+## 4. Phases
+
+### Phase 0 — Character scaffold (prerequisite for everything)
+*Goal: Kistu exists, is selectable, spawns, and every slot dispatches to a placeholder ability. Builds green.*
+
+1. `src/Shared/CharacterDefinition.cs:7` — add `Kistu` to `enum CharacterClass : byte { None, Manki, FightGuy, Kistu }` (ordinal 3).
+2. `src/Shared/CharacterDefinition.cs:~181-189` — append `BuildKistu()` to the `BuildRegistry()` array at index 3 (ordinal-aligned; order is load-bearing).
+3. **New** `src/Shared/Characters/KistuData.cs` — `public static partial class CharacterRegistry { private static CharacterDefinition BuildKistu() {...} }` mirroring `FightGuyData.cs`. Fill:
+   - **Sim-required:** `Class`, `DisplayName`, `MovementStats` (copy FightGuy: walk 10 / sprint 14 / dash 32 / jump 14 / gravity 34 / 2 jumps / dash 8t / dash CD 48t — tune later, agile so maybe faster), `CapsuleRadius`/`CapsuleHeight`, `HurtboxRadius`, `HurtboxCapsules[]` (static fallback so entity is hittable), all 8 `AbilitySpec`s (initially minimal/stub stages).
+   - **Art-deferred placeholders:** `ModelResourcePath = "Characters/FightGuy"` (reuse prefab), `BakedDataPath = ""` (→ capsule hurtboxes), copy `VisualScale`/`HipHeight`/`ModelYOffset`/`ModelSoleOffset` from FightGuy, `AnimationNames` = placeholder strings, `HurtboxBoneDefs = null`.
+4. `src/Shared/Abilities/AbilityFactory.cs:17` — add `CharacterClass.Kistu => CreateKistuAbility(slot, airborne)` and a `CreateKistuAbility(byte slot, bool airborne)` method:
+   ```
+   (0,false)=>new LmbCombo(), (0,true)=>new AirLmbCombo(),
+   (1,false)=>new KistuRmbSpin(), (1,true)=>new AirRmbAttack(),
+   (2,_)=>new KistuCounter(), (3,_)=>new KistuDashSlash(),
+   (4,_)=>new KistuRisingSlash(), (5,_)=>new KistuUltFlurry()
+   ```
+   (Stub the new classes in Phase 0 as trivial `EndAbility`-after-N-ticks placeholders so it compiles; flesh out in later phases.)
+5. `tests/Shared.Tests/TestHelpers.cs` — add `KistuDef` accessor (`CharacterRegistry.Get(CharacterClass.Kistu)`) + `KistuGroundPY`; `tests/Shared.Tests/KitScenarioTests.cs` — add `KistuGpy`.
+
+**Verify:** `dotnet build src/Shared/ --nologo` green; a smoke test that spawns Kistu and ticks idle without throwing; `AbilityLifecycleTests`-style test that each of the 8 slots activates.
+
+---
+
+### Phase 1 — Data-only abilities: LMB, AirLMB, AirRMB
+*Reuse existing base classes; author stage data + hitbox geometry only.*
+
+- **LMB** (`def.LMB.Stages`, 4 stages, reuse `LmbCombo`): each stage `DurationTicks` + `ChainWindowTicks>0` (last stage 0) + one `HitboxEvent` (Capsule, reach-y `EndOff` along facing, modest `Damage`). Finisher stage: bigger KB (`Launcher` for the juggle entry, or `Medium` — respecting the *predictable-KB, no scripted-combo* pillar, keep it a plain readable value, not a wired combo hook). Optional small `LungeForce` per stage.
+- **AirLMB** (`def.AirLMB.Stages`, 3 stages, reuse `AirLmbCombo`): fast, low commit, near-neutral/slight-up KB (juggle-sustain + fall-stall). `ChainWindowTicks` for chaining.
+- **AirRMB** (`def.AirRMB.Stages[0]`, reuse `AirRmbAttack`): single committed slash, `HitboxEvent.Knockback = Spike` (angle −45..−70) for the downward spike. If Kistu should also plunge, add ~10-line `KistuAirRmbSpike : ServerAbility` (copy `AirRmbAttack`, add `SetVelocity(ref s,0,-diveSpeed,0)` in `OnStart`) and swap the factory `(1,true)` entry.
+
+**Verify:** golden scenarios (`KitScenario` + `AssertGoldenScenario`) for LMB chain (all 4 stages, damage/KB), AirLMB (3-stage chain), AirRMB (downward KB direction on the dummy). Snapshot mid-ability tick where hitbox is active.
+
+---
+
+### Phase 2 — Charge abilities: RMB (kill spin), E (dash slash)
+*Subclass `ChargeAttackAbility`; charge is binary tap-vs-hold.*
+
+- **`KistuRmbSpin : ChargeAttackAbility`** — `Stages[1]` = quick horizontal poke (`Medium` KB, fast), `ChargedStages[0]` = charged spin = **kill move** (`Kill` KB, horizontal-biased angle ~10-20°, slow startup, high growth). `ChargeHoldTicks` ~45-60. `Behavior = ChargeAttack`, `AimMode = None`.
+- **`KistuDashSlash : ChargeAttackAbility`** — override `OnAttackStart` → `SetVelocityInFacing(ref s, dashSpeed, 0)` with `dashSpeed` short if `!_wasCharged` else full (two-tier gap-close; "distance scales with charge" becomes tap=short / hold=full, acceptable given binary charge). Add a `Tick` override re-applying forward velocity for the dash duration (DragonKick loop pattern) so it travels, not just an initial burst. Hitbox with **no** (or tiny) `StunTicks` — **no stun** (differentiates from FightGuy Cyclone Kick, preserves zero-hard-CC). Serves as horizontal recovery. `Behavior = ChargeAttack`, `AimMode = None`.
+
+**Verify:** hand-written unit tests (`ChargeAttackAbility` charge needs a **manual** `sim.Tick` loop holding `IsAiming` — `TestHelpers.TickN` drops held input after tick 0):
+- RMB tap (release before threshold) → uses `Stages[1]`, lower damage; RMB hold past threshold → `ChargedStages[0]`, kill KB.
+- E tap → short PX delta; E hold → larger PX delta; target hit takes no hitstun (no stun).
+
+---
+
+### Phase 3 — R signature: charge-stock + homing + rising launcher + capped recovery
+*The one persistent-resource build. Charge pool must live on `CharacterState` (ability instances are recreated per activation).*
+
+1. `src/Shared/CharacterState.cs` — add `public byte RChargesLeft;` (+ optional `public ushort RChargeRegenTicks;`). Initialize to max (~2) on spawn/registration.
+2. `src/Shared/ServerSimulation.cs:PreTickAbilities` (gate near `:345`/`:407`) — when the activating slot is R (index 4) and `state.RChargesLeft == 0`, skip activation (treat as on cooldown). On successful R activation, decrement `RChargesLeft` (or decrement in `KistuRisingSlash.OnStart`). Optional: regen one charge every N ticks in the main sim loop.
+3. **New** `src/Shared/Abilities/KistuRisingSlash.cs : ServerAbility` — multi-phase (model on `FightGuyDragonKick`):
+   - **Rise/home phase:** `SetVelocity` upward (`s.VY = riseSpeed`); if a target is near, steer `s.VX/VZ` toward it — read `s.TargetEntityId` (client `PickScreenTarget` soft-locks nearest ≤20m) with a `SimulationStates` nearest-enemy scan fallback (DragonKick `:66-80`).
+   - **Hit window:** spawn upward `Launcher` hitbox (steep angle ~60-80° for a rising launch) via `SpawnHitbox`.
+   - **Recovery cap:** if it whiffs (no hit) in empty air, cap total upward `VY`/duration so it grants only limited height → *honestly exploitable recovery* (the designed flaw).
+   - **Refund:** override `OnHitEntity` → `RChargesLeft = min(max, RChargesLeft+1)` (refund on connect → sustains the juggle only while actually hitting). `AimMode = None`.
+4. Regression coverage for the new state field: add `RChargesLeft` to `tests/Shared.Tests/GoldenSnapshot.cs` `EntitySnapshot.FromState` **and** `KitScenarioTests.AssertEntityEqual` (else it won't be diffed).
+
+**Verify:** unit tests — R launches a grounded dummy upward (`KVY>0`, dummy `State=Hitstun`); homing steers toward off-axis target; hitting a target refunds a charge (fire R twice with a hit between → second activation allowed with only ~2 base); whiff in air caps self height below the on-hit height; `RChargesLeft==0` blocks activation.
+
+---
+
+### Phase 4 — Q Counter: new target-side interception infra
+*No counter/parry/damage-interception exists anywhere today. This is the deepest new build.*
+
+1. `src/Shared/Abilities/ServerAbility.cs` (~`:43`) — add a target-side virtual:
+   ```csharp
+   public virtual bool TryCounter(ref CharacterState defender, ref CharacterState attacker,
+       CharacterDefinition attackerDef, ref float damage, ref float knockback) => false;
+   ```
+2. `src/Shared/ServerSimulation.cs:ResolveHits` (`:654`) — at the **top** of the per-hit loop, **before** `ApplyKnockback` (`:681`): look up `_activeAbilities[hit.TargetEntityId]`; if it exists and `TryCounter(...)` returns true, **skip** the normal damage + `ApplyKnockback` on the defender for this hit and apply the riposte (launch the attacker via `Simulation.ApplyKnockback` on the attacker state, or spawn a riposte hitbox owned by the defender). Guard against self/owner and multi-hit double-counter (consume the window on first successful counter).
+3. **New** `src/Shared/Abilities/KistuCounter.cs : ServerAbility` — `OnStart` enters a parry stance and sets an instance `_windowTicks` (e.g. active frames `startup..startup+window`); `Tick` counts down and, if the window closes with no counter, plays out recovery endlag then `EndAbility` (whiff punish). `TryCounter` returns true only while within the active window; on success set a flag so `Tick` transitions to the riposte/recovery and applies the attacker launch (`Launcher`/`Kill` KB — no lingering stun, consistent with the zero-hard-CC pillar). Reachable via `_activeAbilities[targetId]` because it's an active ability on the defender.
+
+**Verify:** unit tests (two entities) — attacker hits Kistu **during** the window → attacker launched (`KVY>0`/`KVX`), Kistu takes 0 damage & no hitstun; hit **outside** the window → normal damage/knockback to Kistu, no riposte; window expires with no incoming hit → Kistu in recovery/vulnerable; counter fires **once** even against a multi-hit attack.
+
+---
+
+### Phase 5 — F ult: Blade Flurry (moving multi-slash → launch)
+*New subclass, no new infra beyond it.*
+
+- **New** `src/Shared/Abilities/KistuUltFlurry.cs : ServerAbility` — model on `FightGuyDragonKick.TickAttack` (`:126`): multi-phase moving loop that applies forward/slight-rising self-velocity and spawns a sequence of flurry hitboxes (modest per-hit damage), ending in a final **big-launch** hitbox (`Kill` or `Custom` high base, ~45° angle). Telegraphed startup, high `CooldownTicks` (ult range). `AimMode = None`.
+
+**Verify:** golden/unit — fires the flurry sequence (multiple hits land on a dummy), final hit launches hard, self-moves during the flurry, high cooldown applied on end.
+
+---
+
+### Phase 6 — Placeholder client config + smoke test
+*Zero client C# changes — confirm the data-driven path.*
+
+- Placeholder art fields already set in `KistuData.cs` (Phase 0): `ModelResourcePath = "Characters/FightGuy"`, `BakedDataPath = ""`. `CharSelectController.GetPlayableClasses` auto-enumerates the enum → Kistu appears with no UI edit; `SwapPreviewModel` falls back to a capsule if the prefab is absent.
+- Boot straight into Kistu for testing: set `TrainingMatch._playerClassOverride = Kistu` in the `Arena_Offline` scene Inspector, **or** change `MatchConfig.PlayerClass` default (`MatchConfig.cs:8`), **or** pick Kistu in char-select.
+- **Smoke test:** launch server + Unity client, select Kistu (T-pose stand-in), and exercise the full loop: LMB chain, RMB tap/hold, AirLMB/AirRMB in air, E dash, R rising launch + juggle sustain (refund-on-hit), Q counter vs an NPC attack, F flurry. Confirm the juggle loop (hit → R → chase → R → RMB kill) works with readable knockback.
+  *(If Unity is unavailable this session, substitute a scripted Shared-sim integration run driving the 8 slots against an NPC and asserting the juggle sequence — the sim is the authority; the client only renders.)*
+
+---
+
+### Phase 7 — Full verification + cleanup
+- `dotnet build src/Shared/ --nologo` (auto-copies DLL to Unity Plugins) then `dotnet test tests/Shared.Tests/ --nologo` (<3s, ~151 tests + new ones) — all green.
+- Regenerate goldens for new standard-ability scenarios: `REGENERATE_GOLDENS=1 dotnet test ...`, then re-run to confirm byte-stable.
+- Docs cleanup: add a **Kistu** column to the slot table in `docs/systems/ability-architecture.md`; note the counter as a new pattern; optionally promote the *predictable-KB / emergent-combos* pillar into `docs/systems/combat-systems.md` (flagged in the design doc). Flip `docs/characters/kistu.md` status from "Design" to "Implemented (sim; art pending)".
+
+---
+
+## 5. Dependency graph / parallelization
+
+```
+Phase 0 (scaffold)  ── prerequisite for all ──┐
+                                              ├─ Phase 1 (LMB/AirLMB/AirRMB data)   ┐
+                                              ├─ Phase 2 (RMB/E charge subclasses)  │  independent
+                                              ├─ Phase 3 (R: CharacterState + gate) │  (Phase 3 & 4 touch
+                                              ├─ Phase 4 (Q: ServerAbility + ResolveHits) │  different files)
+                                              └─ Phase 5 (F flurry)                 ┘
+Phases 1-5 ──> Phase 6 (client placeholder + smoke) ──> Phase 7 (test pass + cleanup)
+```
+
+Phase 0 is a hard prerequisite (everything imports the enum/registry/factory). Phases 1-5 are mutually independent and parallelizable after 0 (Phase 3 edits `CharacterState.cs`+`PreTickAbilities`; Phase 4 edits `ServerAbility.cs`+`ResolveHits` — distinct hunks). Phase 6 needs all abilities present; Phase 7 is the final gate.
+
+## 6. Risks / open notes
+- **Homing target source:** relies on `s.TargetEntityId` being populated server-side for the player (client feeds `PickScreenTarget` each tick). Confirm the server path sets it; the `SimulationStates` nearest-enemy scan is the fallback (DragonKick already does this).
+- **Binary charge:** E "distance scales with charge" is realized as two tiers (tap=short, hold=full), since `ChargeAttackAbility` charge is binary, not analog. Acceptable; note if analog is later wanted it's a base-class change.
+- **`AttackStage.MoveX/Y/Z` dead:** never consumed — all per-tick movement must be direct `s.VX/VY/VZ` writes or `LungeForce`.
+- **Numbers are placeholders:** damage / KB base+growth / charge counts / CDs / windows / refund cap tuned in a later balance pass against `character-kit-design-principles.md` and existing kits.
+- **New `CharacterState` field cost:** `RChargesLeft` adds to the struct; ensure it's included in any state serialization/rollback snapshot paths (netcode) and in golden `EntitySnapshot` — check `CharacterStatePacket` (44 bytes/entity) if the field must cross the wire, otherwise it's server-only sim state.

--- a/docs/systems/ability-architecture.md
+++ b/docs/systems/ability-architecture.md
@@ -59,16 +59,16 @@ All abilities spawn their own hitboxes in `Tick()` via `SpawnHitbox(ref s, evt)`
 
 ## Complete Slot Mapping
 
-| Slot | Manki | FightGuy | Shared |
-|------|-------|----------|--------|
-| LMB ground (0) | `LmbCombo` | `LmbCombo` | Shared via StageChainAbility |
-| LMB air (0) | `AirLmbCombo` | `AirLmbCombo` | Shared via StageChainAbility |
-| RMB ground (1) | `MankiAerosolFlame` | `FightGuyUppercut` | Per-character |
-| RMB air (1) | `AirRmbAttack` | `AirRmbAttack` | Shared single-hit spike |
-| Q (2) | `MankiRoundBomb` | `FightGuyKiShot` | Per-character |
-| E (3) | `MankiGrapple` | `FightGuyCycloneKick` | Per-character |
-| R (4) | `MankiBazooka` | `FightGuyDragonKick` | Per-character |
-| F (5) | `MankiOverclock` | `FightGuyTempest` | Per-character |
+| Slot | Manki | FightGuy | Kistu | Shared |
+|------|-------|----------|-------|--------|
+| LMB ground (0) | `LmbCombo` | `LmbCombo` | `LmbCombo` | Shared via StageChainAbility |
+| LMB air (0) | `AirLmbCombo` | `AirLmbCombo` | `AirLmbCombo` | Shared via StageChainAbility |
+| RMB ground (1) | `MankiAerosolFlame` | `FightGuyUppercut` | `KistuChargeAttack` | Per-character |
+| RMB air (1) | `AirRmbAttack` | `AirRmbAttack` | `AirRmbAttack` | Shared single-hit spike |
+| Q (2) | `MankiRoundBomb` | `FightGuyKiShot` | `KistuCounter` | Per-character |
+| E (3) | `MankiGrapple` | `FightGuyCycloneKick` | `KistuChargeAttack` | Per-character |
+| R (4) | `MankiBazooka` | `FightGuyDragonKick` | `KistuRisingSlash` | Per-character |
+| F (5) | `MankiOverclock` | `FightGuyTempest` | `KistuUltFlurry` | Per-character |
 
 ## Key Patterns
 

--- a/src/Shared/Abilities/AbilityFactory.cs
+++ b/src/Shared/Abilities/AbilityFactory.cs
@@ -18,6 +18,7 @@ public static class AbilityFactory
         {
             CharacterClass.Manki => CreateMankiAbility(slot, airborne),
             CharacterClass.FightGuy => CreateFightGuyAbility(slot, airborne),
+            CharacterClass.Kistu => CreateKistuAbility(slot, airborne),
             _ => null,
         };
     }
@@ -45,6 +46,19 @@ public static class AbilityFactory
         (3, _) => new FightGuyCycloneKick(),   // E
         (4, _) => new FightGuyDragonKick(),    // R
         (5, _) => new FightGuyTempest(),       // F
+        _ => null,
+    };
+
+    private static ServerAbility? CreateKistuAbility(byte slot, bool airborne) => (slot, airborne) switch
+    {
+        (0, false) => new LmbCombo(),          // LMB ground — light slash combo
+        (0, true) => new AirLmbCombo(),        // AirLMB — air slash combo
+        (1, false) => new KistuChargeAttack(), // RMB — charged spin (kill move)
+        (1, true) => new AirRmbAttack(),       // AirRMB — falling slash spike
+        (2, _) => new KistuCounter(),          // Q — counter/parry
+        (3, _) => new KistuChargeAttack(),     // E — charged dash slash
+        (4, _) => new KistuRisingSlash(),      // R — rising slash (signature)
+        (5, _) => new KistuUltFlurry(),        // F — blade flurry ult
         _ => null,
     };
 

--- a/src/Shared/Abilities/KistuChargeAttack.cs
+++ b/src/Shared/Abilities/KistuChargeAttack.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace SlopArena.Shared.Abilities;
+
+/// <summary>
+/// Kistu's charge-lunge slots (RMB Charged Spin, E Charged Dash Slash).
+///
+/// Reuses the ChargeAttackAbility hold-to-charge lifecycle. The only per-character
+/// behaviour is applying the chosen attack stage's LungeForce as a forward burst on
+/// release, giving:
+///   - RMB: tap = quick horizontal poke, hold = charged spin (bigger LungeForce/hitbox).
+///   - E:   tap = short reposition, hold = full gap-close (LungeForce doubles as recovery).
+///
+/// All damage/knockback/hitbox geometry is data-driven from the spec's Stages[1]
+/// (tap) and ChargedStages[0] (charged).
+/// </summary>
+public sealed class KistuChargeAttack : ChargeAttackAbility
+{
+    protected override void OnAttackStart(ref CharacterState s, CharacterDefinition def, AttackStage stage)
+    {
+        if (stage.LungeForce != 0f)
+            SetVelocityInFacing(ref s, stage.LungeForce);
+    }
+}

--- a/src/Shared/Abilities/KistuCounter.cs
+++ b/src/Shared/Abilities/KistuCounter.cs
@@ -1,0 +1,86 @@
+using System;
+
+namespace SlopArena.Shared.Abilities;
+
+/// <summary>
+/// Kistu's Q — Counter. A stationary parry with an active window.
+///
+/// If an incoming hit lands on Kistu while the window is open (TryCounter, called from
+/// ResolveHits before damage is applied), the hit is fully absorbed and a riposte is applied
+/// to the attacker: bonus %, then a launch (knockback, no lingering stun — consistent with the
+/// kit's pure-knockback design). Launching the attacker flips them to Hitstun, which interrupts
+/// their attack. Whiffing the window leaves Kistu in recovery.
+///
+/// Params: "duration", "window_start", "window_end", "riposte_damage",
+/// "riposte_base", "riposte_growth", "riposte_angle", "riposte_stun".
+/// </summary>
+public sealed class KistuCounter : ServerAbility
+{
+    private ushort _ticks;
+    private bool _countered;
+
+    private ushort _windowStart;
+    private ushort _windowEnd;
+    private float _riposteDamage;
+    private float _riposteBase;
+    private float _riposteGrowth;
+    private sbyte _riposteAngle;
+    private ushort _riposteStun;
+
+    public override void OnStart(ref CharacterState s, CharacterDefinition def)
+    {
+        _ticks = 0;
+        _countered = false;
+
+        s.State = ActionState.Attacking;
+        s.AttackSlot = (byte)(Slot + 1);
+        AnimIndex = 0;
+        s.ComboStage = 0;
+        s.AttackElapsedTicks = 0;
+        // Stationary parry — no residual movement.
+        SetVelocity(ref s, 0f, s.IsGrounded ? 0f : s.VY, 0f);
+
+        s.AnimLockTicks = (ushort)GetParam(def, "duration", 40f);
+
+        _windowStart = (ushort)GetParam(def, "window_start", 4f);
+        _windowEnd = (ushort)GetParam(def, "window_end", 18f);
+        _riposteDamage = GetParam(def, "riposte_damage", 12f);
+        _riposteBase = GetParam(def, "riposte_base", 12f);
+        _riposteGrowth = GetParam(def, "riposte_growth", 6f);
+        _riposteAngle = (sbyte)GetParam(def, "riposte_angle", 60f);
+        _riposteStun = (ushort)GetParam(def, "riposte_stun", 30f);
+    }
+
+    public override void Tick(ref CharacterState s, ref InputState input, CharacterDefinition def)
+    {
+        _ticks++;
+        // Riposte animation once countered, else parry stance.
+        AnimIndex = _countered ? (byte)1 : (byte)0;
+
+        if (_ticks >= s.AnimLockTicks)
+            EndAbility(ref s);
+    }
+
+    public override bool TryCounter(ref CharacterState defender, ref CharacterState attacker, float incomingDamage)
+    {
+        if (_countered) return false;
+        if (_ticks < _windowStart || _ticks > _windowEnd) return false;
+
+        _countered = true;
+
+        // Push the attacker away from the defender.
+        float dx = attacker.PX - defender.PX;
+        float dz = attacker.PZ - defender.PZ;
+        float dist = MathF.Sqrt(dx * dx + dz * dz);
+        float dirX, dirZ;
+        if (dist > 0.001f) { dirX = dx / dist; dirZ = dz / dist; }
+        else { dirX = MathF.Sin(defender.FacingYaw); dirZ = MathF.Cos(defender.FacingYaw); }
+
+        attacker.DamagePercent += (ushort)_riposteDamage;
+        if (attacker.DamagePercent > 999) attacker.DamagePercent = 999;
+        Simulation.ApplyKnockback(ref attacker, dirX, dirZ, _riposteAngle, _riposteBase, _riposteGrowth, _riposteStun);
+        attacker.HitstunTicks = _riposteStun;
+
+        return true;
+    }
+}

--- a/src/Shared/Abilities/KistuRisingSlash.cs
+++ b/src/Shared/Abilities/KistuRisingSlash.cs
@@ -1,0 +1,118 @@
+using System;
+
+namespace SlopArena.Shared.Abilities;
+
+/// <summary>
+/// Kistu's R — Rising Slash (signature). A homing rising uppercut-slash that launches.
+///
+/// - Rises vertically for "rise_ticks", carrying Kistu up (doubles as vertical recovery).
+/// - Homes horizontally toward the nearest enemy within "homing_range" so it tracks for juggles.
+/// - Spawns its launcher hitbox from the spec's Stages[0].HitboxEvents (authored in KistuData),
+///   like every other slot — the launch angle/damage/knockback live in the spec, not in code.
+/// - Limited by a refundable charge pool (see ServerSimulation charge-stock gate): each cast
+///   spends one charge; landing a hit refunds it (OnHitEntity) so a connected juggle sustains,
+///   while whiffing in empty air burns charges — capping recovery to the pool size.
+///
+/// Charge-pool params (read by the sim): "max_charges", "charge_regen_ticks".
+/// Movement params: "rise_speed", "rise_ticks", "homing_range", "homing_speed".
+/// </summary>
+public sealed class KistuRisingSlash : ServerAbility
+{
+    private ushort _ticks;
+
+    public override void OnStart(ref CharacterState s, CharacterDefinition def)
+    {
+        _ticks = 0;
+
+        s.State = ActionState.Attacking;
+        s.AttackSlot = (byte)(Slot + 1);
+        AnimIndex = 0;
+        s.ComboStage = 0;
+        s.AttackElapsedTicks = 0;
+
+        float riseSpeed = GetParam(def, "rise_speed", 16f);
+        SetVelocity(ref s, 0f, riseSpeed, 0f);
+        s.IsGrounded = false; // launch off the ground so the rise isn't clamped
+
+        var spec = def.GetSlotAbility(Slot, airborne: false);
+        s.AnimLockTicks = spec?.Stages is { Length: > 0 } ? spec.Stages[0].DurationTicks : (ushort)24;
+    }
+
+    public override void Tick(ref CharacterState s, ref InputState input, CharacterDefinition def)
+    {
+        _ticks++;
+
+        float riseSpeed = GetParam(def, "rise_speed", 16f);
+        ushort riseTicks = (ushort)GetParam(def, "rise_ticks", 18f);
+
+        // Vertical rise for the rise window, then hold (gravity resumes when the ability ends).
+        s.VY = _ticks <= riseTicks ? riseSpeed : 0f;
+
+        // Horizontal homing toward the nearest enemy in range.
+        float homingRange = GetParam(def, "homing_range", 7f);
+        float homingSpeed = GetParam(def, "homing_speed", 10f);
+        ulong closest = FindClosestEnemy(ref s, homingRange, out float cdx, out float cdz, out float cdist);
+        if (closest != 0 && cdist > 0.1f)
+        {
+            s.VX = (cdx / cdist) * homingSpeed;
+            s.VZ = (cdz / cdist) * homingSpeed;
+        }
+        else
+        {
+            s.VX = 0f;
+            s.VZ = 0f;
+        }
+
+        // Spawn the launcher hitbox from the spec (authored in KistuData).
+        var spec = def.GetSlotAbility(Slot, airborne: false);
+        if (spec?.Stages is { Length: > 0 })
+        {
+            foreach (var evt in spec.Stages[0].HitboxEvents)
+            {
+                if (evt.TriggerTick == _ticks)
+                    SpawnHitbox(ref s, evt);
+            }
+        }
+
+        if (_ticks >= s.AnimLockTicks)
+            EndAbility(ref s);
+    }
+
+    /// <summary>Refund the spent charge on a connect so a landed juggle keeps its charges.</summary>
+    public override void OnHitEntity(ref CharacterState attacker, ref CharacterState target,
+        CharacterDefinition attackerDef, ref float damage, ref float knockbackForce)
+    {
+        if (attacker.ChargeStockSpent > 0)
+        {
+            attacker.ChargeStockSpent--;
+            // Refunding to a full pool stops regen; clear the stale timer so the NEXT spend
+            // starts a fresh full regen period rather than reusing the partial countdown.
+            if (attacker.ChargeStockSpent == 0)
+                attacker.ChargeStockRegenTicks = 0;
+        }
+    }
+
+    private ulong FindClosestEnemy(ref CharacterState s, float range, out float dx, out float dz, out float dist)
+    {
+        dx = 0f; dz = 0f; dist = 0f;
+        if (SimulationStates == null) return 0;
+
+        ulong best = 0;
+        float bestSq = range * range;
+        foreach (var kvp in SimulationStates)
+        {
+            if (kvp.Key == s.EntityId) continue;
+            float ex = kvp.Value.PX - s.PX;
+            float ez = kvp.Value.PZ - s.PZ;
+            float sq = ex * ex + ez * ez;
+            if (sq <= bestSq)
+            {
+                bestSq = sq;
+                best = kvp.Key;
+                dx = ex; dz = ez;
+            }
+        }
+        if (best != 0) dist = MathF.Sqrt(dx * dx + dz * dz);
+        return best;
+    }
+}

--- a/src/Shared/Abilities/KistuUltFlurry.cs
+++ b/src/Shared/Abilities/KistuUltFlurry.cs
@@ -1,0 +1,56 @@
+using System;
+
+namespace SlopArena.Shared.Abilities;
+
+/// <summary>
+/// Kistu's F — Blade Flurry (ult). A committed forward-moving multi-slash that ends in a
+/// hard launch. Kept deliberately simple: moves forward for "move_ticks", spawns the spec's
+/// HitboxEvents at their TriggerTicks (the final event carries the big launch knockback),
+/// then ends. All hit geometry/damage/knockback is data-driven from the F spec's Stages[0].
+///
+/// Params: "forward_speed", "move_ticks".
+/// </summary>
+public sealed class KistuUltFlurry : ServerAbility
+{
+    private ushort _ticks;
+
+    public override void OnStart(ref CharacterState s, CharacterDefinition def)
+    {
+        _ticks = 0;
+
+        s.State = ActionState.Attacking;
+        s.AttackSlot = (byte)(Slot + 1);
+        AnimIndex = 0;
+        s.ComboStage = 0;
+        s.AttackElapsedTicks = 0;
+
+        var spec = def.GetSlotAbility(Slot, airborne: false);
+        s.AnimLockTicks = spec?.Stages is { Length: > 0 } ? spec.Stages[0].DurationTicks : (ushort)60;
+
+        SetVelocityInFacing(ref s, GetParam(def, "forward_speed", 6f));
+    }
+
+    public override void Tick(ref CharacterState s, ref InputState input, CharacterDefinition def)
+    {
+        _ticks++;
+
+        var spec = def.GetSlotAbility(Slot, airborne: false);
+        if (spec?.Stages is not { Length: > 0 }) { EndAbility(ref s); return; }
+        var stage = spec.Stages[0];
+
+        // Drive forward during the flurry, then plant for the finisher.
+        ushort moveTicks = (ushort)GetParam(def, "move_ticks", 30f);
+        if (_ticks <= moveTicks)
+            SetVelocityInFacing(ref s, GetParam(def, "forward_speed", 6f));
+        else { s.VX = 0f; s.VZ = 0f; }
+
+        foreach (var evt in stage.HitboxEvents)
+        {
+            if (evt.TriggerTick == _ticks)
+                SpawnHitbox(ref s, evt);
+        }
+
+        if (_ticks >= stage.DurationTicks)
+            EndAbility(ref s);
+    }
+}

--- a/src/Shared/Abilities/ServerAbility.cs
+++ b/src/Shared/Abilities/ServerAbility.cs
@@ -42,6 +42,17 @@ namespace SlopArena.Shared.Abilities
             ref float damage, ref float knockbackForce)
         {
         }
+
+        /// <summary>
+        /// Target-side hook: called in ResolveHits BEFORE damage/knockback is applied to the
+        /// defender, when the defender has this ability active. Return true to fully absorb the
+        /// incoming hit (no damage/knockback to the defender) — e.g. Kistu's Counter, which
+        /// riposte-launches the attacker. Default: no interception.
+        /// </summary>
+        public virtual bool TryCounter(ref CharacterState defender, ref CharacterState attacker, float incomingDamage)
+        {
+            return false;
+        }
         // ── Metadata (set by factory after construction) ──
 
         /// <summary>Which ability slot (0-5).</summary>

--- a/src/Shared/CharacterDefinition.cs
+++ b/src/Shared/CharacterDefinition.cs
@@ -8,7 +8,8 @@ namespace SlopArena.Shared
     {
         None,
         Manki,
-        FightGuy
+        FightGuy,
+        Kistu
     }
 
     [Serializable]
@@ -185,6 +186,7 @@ namespace SlopArena.Shared
                 default,            // None (placeholder)
                 BuildManki(),       // Manki
                 BuildFightGuy(),    // FightGuy
+                BuildKistu(),       // Kistu
             };
         }
     }

--- a/src/Shared/CharacterState.cs
+++ b/src/Shared/CharacterState.cs
@@ -78,6 +78,17 @@ namespace SlopArena.Shared
         /// aimed charge progress (0 = none, >0 = charging)
         /// </summary>
         public ushort ChargeTicks;
+        /// <summary>
+        /// ── Charge-stock pool (refundable ability charges, e.g. Kistu Rising Slash) ──
+        /// Number of charges currently spent/unavailable (0 = full pool). The pool max
+        /// and regen cadence come from the ability spec's "max_charges"/"charge_regen_ticks"
+        /// params. Refunded on hit by the ability's OnHitEntity. Server-sim only (not on the wire).
+        /// </summary>
+        public byte ChargeStockSpent;
+        /// <summary>Ticks until the next spent charge regenerates. 0 when nothing is regenerating.</summary>
+        public ushort ChargeStockRegenTicks;
+        /// <summary>Full regen period for one charge, cached from the ability spec at spend time.</summary>
+        public ushort ChargeStockRegenPeriod;
 
         /// <summary>
         /// ── Knockback ──

--- a/src/Shared/Characters/KistuData.cs
+++ b/src/Shared/Characters/KistuData.cs
@@ -1,0 +1,312 @@
+namespace SlopArena.Shared;
+
+/// <summary>
+/// ═══════════════════════════════════════
+/// KISTU — The Kitsune Blade (agile katana spacing duelist)
+/// ═══════════════════════════════════════
+/// In-your-face spacing duelist: disjointed blade reach in neutral, launch -> air-juggle payoff.
+/// Signature R (Rising Slash) is a homing launcher on a refundable charge pool.
+/// Placeholder art: reuses the FightGuy prefab + empty baked data (capsule hurtboxes) so the
+/// kit is fully playable in sim before its own model/animation assets exist.
+/// Numbers are first-pass placeholders — tune against character-kit-design-principles.md.
+/// </summary>
+public static partial class CharacterRegistry
+{
+    private static CharacterDefinition BuildKistu()
+    {
+        return new CharacterDefinition
+        {
+            Class = CharacterClass.Kistu,
+            DisplayName = "Kistu",
+            CapsuleRadius = 0.35f,
+            CapsuleHeight = 1.7f,
+            HipHeight = 0.82f,
+            HurtboxRadius = 1f,
+            Movement = new MovementStats
+            {
+                WalkSpeed = 11f,
+                SprintSpeed = 15f,
+                DashSpeed = 34f,
+                AirAcceleration = 18f,
+                JumpForce = 13f,
+                Gravity = 36f,
+                AirFloatGravity = 0f,
+                DashDurationTicks = 16,
+                DashCooldownTicks = 44,
+                GroundFriction = 16f,
+                AirFriction = 0.5f,
+                MaxFallSpeed = 48f,
+                MaxJumps = 2,
+                JumpSquatTicks = 4,
+                FloatWindowTicks = 35,
+                FallRampDuration = 10,
+            },
+
+            // No baked skeleton yet → capsule hurtbox fallback (placeholder, copied from FightGuy).
+            HurtboxBoneDefs = null,
+            HurtboxCapsules = new HurtboxCapsule[]
+            {
+                new(0f, 0.2f, 0f, 0f, 0.9f, 0f, 0.3f),
+                new(0f, 1.2f, 0f, 0f, 1.2f, 0f, 0.22f),
+                new(0.3f, 0.8f, 0f, 0.6f, 0.6f, 0.2f, 0.12f),
+                new(-0.3f, 0.8f, 0f, -0.6f, 0.6f, 0.2f, 0.12f),
+                new(0.15f, 0f, 0f, 0.15f, -0.8f, 0f, 0.16f),
+                new(-0.15f, 0f, 0f, -0.15f, -0.8f, 0f, 0.16f),
+            },
+            VisualScale = 1f,
+            HurtboxBoneScale = 1.0f,
+            ModelSoleOffset = 0f,
+            AutoModelYOffset = true,
+            ModelYOffset = 0f,
+            ModelResourcePath = "Characters/FightGuy", // placeholder stand-in prefab
+            BakedDataPath = "",                        // empty → capsule hurtboxes
+
+            // ═══ ABILITIES ═══
+
+            // LMB — Light Slash Combo (4 hits, reach-y capsule slashes, launcher finisher)
+            LMB = new AbilitySpec
+            {
+                Name = "Light Slash Combo",
+                Description = "Four-hit katana slash chain. Fast, disjointed reach; finisher launches.",
+                IconName = "lmb",
+                CooldownTicks = 0,
+                Stages = new AttackStage[]
+                {
+                    new() { DurationTicks = 30, ChainWindowTicks = 10, LungeForce = 6f,
+                            HitboxEvents = new[] { new HitboxEvent { TriggerTick = 6, DurationTicks = 5, Shape = HitboxShape.Capsule, Radius = 0.45f,
+                                    OffX = 0, OffY = 0.7f, OffZ = 0.7f, EndOffX = 0, EndOffY = 0.7f, EndOffZ = 1.8f,
+                                    Damage = 3f, Knockback = new() { Profile = KnockbackProfile.Light }, StunTicks = 16, Interruptible = true } },
+                            AttackRange = 4f, WarpRange = 0f, UseTargetLock = true, RotateTowardTarget = true, TrackingStrength = 0.85f },
+                    new() { DurationTicks = 28, ChainWindowTicks = 10, LungeForce = 6f,
+                            HitboxEvents = new[] { new HitboxEvent { TriggerTick = 5, DurationTicks = 5, Shape = HitboxShape.Capsule, Radius = 0.45f,
+                                    OffX = 0, OffY = 0.8f, OffZ = 0.7f, EndOffX = 0, EndOffY = 0.8f, EndOffZ = 1.9f,
+                                    Damage = 3f, Knockback = new() { Profile = KnockbackProfile.Light }, StunTicks = 18, Interruptible = true } },
+                            AttackRange = 4f, WarpRange = 0f, UseTargetLock = true, RotateTowardTarget = true, TrackingStrength = 0.85f },
+                    new() { DurationTicks = 30, ChainWindowTicks = 10, LungeForce = 8f,
+                            HitboxEvents = new[] { new HitboxEvent { TriggerTick = 6, DurationTicks = 5, Shape = HitboxShape.Capsule, Radius = 0.5f,
+                                    OffX = 0, OffY = 0.6f, OffZ = 0.7f, EndOffX = 0, EndOffY = 0.6f, EndOffZ = 2.0f,
+                                    Damage = 4f, Knockback = new() { Profile = KnockbackProfile.Light }, StunTicks = 20, Interruptible = true } },
+                            AttackRange = 4f, WarpRange = 0f, UseTargetLock = true, RotateTowardTarget = true, TrackingStrength = 0.8f },
+                    new() { DurationTicks = 42, ChainWindowTicks = 0, LungeForce = 10f,
+                            HitboxEvents = new[] { new HitboxEvent { TriggerTick = 10, DurationTicks = 6, Shape = HitboxShape.Capsule, Radius = 0.5f,
+                                    OffX = 0, OffY = 0.7f, OffZ = 0.8f, EndOffX = 0, EndOffY = 0.7f, EndOffZ = 2.0f,
+                                    Damage = 6f, Knockback = new() { Profile = KnockbackProfile.Launcher }, StunTicks = 30, Interruptible = true } },
+                            AttackRange = 4f, WarpRange = 0f, UseTargetLock = true, RotateTowardTarget = true, TrackingStrength = 0.8f },
+                },
+                AnimationNames = new[] { "spell_lmb_1", "spell_lmb_2", "spell_lmb_3", "spell_lmb_4" },
+                Params = new() { ["lunge_duration"] = 6f },
+            },
+
+            // AirLMB — Air Slash (3 hits, juggle sustain, near-neutral/up KB)
+            AirLMB = new AbilitySpec
+            {
+                Name = "Air Slash",
+                Description = "Three-hit aerial slash. Low commit; keeps enemies airborne for juggles.",
+                CooldownTicks = 0,
+                Stages = new AttackStage[]
+                {
+                    new() { DurationTicks = 24, ChainWindowTicks = 9, LungeForce = 3f,
+                            HitboxEvents = new[] { new HitboxEvent { TriggerTick = 5, DurationTicks = 5, Shape = HitboxShape.Capsule, Radius = 0.45f,
+                                    OffX = 0, OffY = 0.8f, OffZ = 0.6f, EndOffX = 0, EndOffY = 0.8f, EndOffZ = 1.6f,
+                                    Damage = 3f, Knockback = new() { Profile = KnockbackProfile.Light }, StunTicks = 16, Interruptible = true } },
+                            AttackRange = 4f, WarpRange = 0f, UseTargetLock = true, RotateTowardTarget = true, TrackingStrength = 0.8f },
+                    new() { DurationTicks = 24, ChainWindowTicks = 9, LungeForce = 3f,
+                            HitboxEvents = new[] { new HitboxEvent { TriggerTick = 5, DurationTicks = 5, Shape = HitboxShape.Capsule, Radius = 0.45f,
+                                    OffX = 0, OffY = 0.9f, OffZ = 0.6f, EndOffX = 0, EndOffY = 0.9f, EndOffZ = 1.6f,
+                                    Damage = 3f, Knockback = new() { Profile = KnockbackProfile.Light }, StunTicks = 18, Interruptible = true } },
+                            AttackRange = 4f, WarpRange = 0f, UseTargetLock = true, RotateTowardTarget = true, TrackingStrength = 0.8f },
+                    new() { DurationTicks = 30, ChainWindowTicks = 0, LungeForce = 4f,
+                            HitboxEvents = new[] { new HitboxEvent { TriggerTick = 7, DurationTicks = 6, Shape = HitboxShape.Capsule, Radius = 0.5f,
+                                    OffX = 0, OffY = 0.8f, OffZ = 0.6f, EndOffX = 0, EndOffY = 0.8f, EndOffZ = 1.7f,
+                                    Damage = 5f, Knockback = new() { Profile = KnockbackProfile.Launcher }, StunTicks = 26, Interruptible = true } },
+                            AttackRange = 4f, WarpRange = 0f, UseTargetLock = true, RotateTowardTarget = true, TrackingStrength = 0.8f },
+                },
+                AnimationNames = new[] { "spell_lmb_air_1", "spell_lmb_air_2", "spell_lmb_air_3" },
+            },
+
+            // RMB — Charged Spin: tap = horizontal poke, hold = charged kill (big horizontal launch)
+            RMB = new AbilitySpec
+            {
+                Name = "Charged Spin",
+                Description = "Hold to charge a spinning slash. Tap = quick poke; charged = blast-zone kill.",
+                IconName = "rmb",
+                CooldownTicks = 60,
+                Behavior = AbilityBehavior.ChargeAttack,
+                ChargeHoldTicks = 50,
+                Stages = new AttackStage[]
+                {
+                    // Stage 0: hold/charge phase (safety net 300 ticks)
+                    new() { DurationTicks = 300, ChainWindowTicks = 0, HitboxEvents = System.Array.Empty<HitboxEvent>(),
+                            LungeForce = 0f, AttackRange = 0f, WarpRange = 0f },
+                    // Stage 1: tap poke (quick, horizontal knockback)
+                    new() { DurationTicks = 30, ChainWindowTicks = 0, LungeForce = 3f,
+                            HitboxEvents = new[] { new HitboxEvent { TriggerTick = 6, DurationTicks = 5, Shape = HitboxShape.Capsule, Radius = 0.5f,
+                                    OffX = 0, OffY = 0.7f, OffZ = 0.7f, EndOffX = 0, EndOffY = 0.7f, EndOffZ = 1.9f,
+                                    Damage = 8f, Knockback = new() { Profile = KnockbackProfile.Medium }, StunTicks = 22, Interruptible = true } },
+                            AttackRange = 3f, WarpRange = 0f },
+                },
+                ChargedStages = new AttackStage[]
+                {
+                    // Charged: big horizontal-launch kill spin
+                    new() { DurationTicks = 44, ChainWindowTicks = 0, LungeForce = 5f,
+                            HitboxEvents = new[] { new HitboxEvent { TriggerTick = 12, DurationTicks = 7, Shape = HitboxShape.Capsule, Radius = 0.7f,
+                                    OffX = 0, OffY = 0.7f, OffZ = 0.6f, EndOffX = 0, EndOffY = 0.7f, EndOffZ = 2.1f,
+                                    Damage = 16f, Knockback = new() { Profile = KnockbackProfile.Custom, Angle = 15, BaseKnockback = 18, KnockbackGrowth = 10 },
+                                    StunTicks = 40, Interruptible = true } },
+                            AttackRange = 3f, WarpRange = 0f },
+                },
+                AnimationNames = new[] { "spell_rmb_loop", "spell_rmb_attack" },
+            },
+
+            // AirRMB — Falling Slash (downward spike)
+            AirRMB = new AbilitySpec
+            {
+                Name = "Falling Slash",
+                Description = "Committed downward air slash that spikes enemies toward the floor/blast zone.",
+                CooldownTicks = 0,
+                Stages = new AttackStage[]
+                {
+                    new() { DurationTicks = 26, ChainWindowTicks = 0, LungeForce = 0f,
+                            HitboxEvents = new[] { new HitboxEvent { TriggerTick = 6, DurationTicks = 14, Shape = HitboxShape.Capsule, Radius = 0.5f,
+                                    OffX = 0, OffY = 0.4f, OffZ = 0.6f, EndOffX = 0, EndOffY = -0.6f, EndOffZ = 1.4f,
+                                    Damage = 9f, Knockback = new() { Profile = KnockbackProfile.Spike }, StunTicks = 28, Interruptible = true } },
+                            AttackRange = 4f, WarpRange = 0f, UseTargetLock = true, RotateTowardTarget = true, TrackingStrength = 0.7f },
+                },
+                AnimationNames = new[] { "spell_air_rmb" },
+            },
+
+            // Q — Counter (parry window → launch riposte)
+            Q = new AbilitySpec
+            {
+                Name = "Counter",
+                Description = "Parry stance. If struck during the window, riposte-launches the attacker.",
+                IconName = "q",
+                CooldownTicks = 150,
+                Behavior = AbilityBehavior.MeleeCombo,
+                AimMode = AimMode.None,
+                Stages = new AttackStage[]
+                {
+                    new() { DurationTicks = 40, ChainWindowTicks = 0, HitboxEvents = System.Array.Empty<HitboxEvent>(),
+                            AttackRange = 0f, WarpRange = 0f },
+                },
+                AnimationNames = new[] { "spell_q_parry", "spell_q_riposte" },
+                Params = new()
+                {
+                    ["duration"] = 40f,
+                    ["window_start"] = 4f,
+                    ["window_end"] = 18f,
+                    ["riposte_damage"] = 12f,
+                    ["riposte_base"] = 12f,
+                    ["riposte_growth"] = 6f,
+                    ["riposte_angle"] = 60f,
+                    ["riposte_stun"] = 30f,
+                },
+            },
+
+            // E — Charged Dash Slash (gap-close / horizontal recovery, no stun)
+            E = new AbilitySpec
+            {
+                Name = "Charged Dash Slash",
+                Description = "Dash forward and slash. Tap = short reposition, hold = full gap-close. No stun.",
+                IconName = "e",
+                CooldownTicks = 90,
+                Behavior = AbilityBehavior.ChargeAttack,
+                ChargeHoldTicks = 30,
+                Stages = new AttackStage[]
+                {
+                    // Stage 0: hold/charge phase
+                    new() { DurationTicks = 120, ChainWindowTicks = 0, HitboxEvents = System.Array.Empty<HitboxEvent>(),
+                            LungeForce = 0f, AttackRange = 0f, WarpRange = 0f },
+                    // Stage 1: short dash slash
+                    new() { DurationTicks = 26, ChainWindowTicks = 0, LungeForce = 18f,
+                            HitboxEvents = new[] { new HitboxEvent { TriggerTick = 6, DurationTicks = 6, Shape = HitboxShape.Capsule, Radius = 0.5f,
+                                    OffX = 0, OffY = 0.7f, OffZ = 0.6f, EndOffX = 0, EndOffY = 0.7f, EndOffZ = 1.8f,
+                                    Damage = 6f, Knockback = new() { Profile = KnockbackProfile.Medium }, StunTicks = 20, Interruptible = true } },
+                            AttackRange = 3f, WarpRange = 0f },
+                },
+                ChargedStages = new AttackStage[]
+                {
+                    // Full gap-close dash slash
+                    new() { DurationTicks = 30, ChainWindowTicks = 0, LungeForce = 32f,
+                            HitboxEvents = new[] { new HitboxEvent { TriggerTick = 8, DurationTicks = 8, Shape = HitboxShape.Capsule, Radius = 0.55f,
+                                    OffX = 0, OffY = 0.7f, OffZ = 0.6f, EndOffX = 0, EndOffY = 0.7f, EndOffZ = 2.0f,
+                                    Damage = 9f, Knockback = new() { Profile = KnockbackProfile.Medium }, StunTicks = 24, Interruptible = true } },
+                            AttackRange = 3f, WarpRange = 0f },
+                },
+                AnimationNames = new[] { "spell_e_loop", "spell_e_attack" },
+            },
+
+            // R — Rising Slash (signature: homing launcher, refundable charge pool, vertical recovery)
+            R = new AbilitySpec
+            {
+                Name = "Rising Slash",
+                Description = "Homing rising slash that launches. Charges refund on hit (juggle) — 2-charge pool.",
+                IconName = "r",
+                CooldownTicks = 0, // limited by the charge pool, not a flat cooldown
+                Behavior = AbilityBehavior.MeleeCombo,
+                AimMode = AimMode.None,
+                Stages = new AttackStage[]
+                {
+                    new() { DurationTicks = 24, ChainWindowTicks = 0,
+                            HitboxEvents = new[] { new HitboxEvent { TriggerTick = 5, DurationTicks = 8, Shape = HitboxShape.Sphere, Radius = 1.1f,
+                                    OffX = 0, OffY = 1.0f, OffZ = 0.6f,
+                                    Damage = 7f, Knockback = new() { Profile = KnockbackProfile.Custom, Angle = 78, BaseKnockback = 7, KnockbackGrowth = 5 },
+                                    StunTicks = 30, Interruptible = true } },
+                            AttackRange = 0f, WarpRange = 0f },
+                },
+                AnimationNames = new[] { "spell_r" },
+                Params = new()
+                {
+                    ["max_charges"] = 2f,
+                    ["charge_regen_ticks"] = 240f, // 4s to recover one charge
+                    ["rise_speed"] = 16f,
+                    ["rise_ticks"] = 18f,
+                    ["homing_range"] = 7f,
+                    ["homing_speed"] = 10f,
+                },
+            },
+
+            // F — Blade Flurry (ult: moving multi-slash → hard launch)
+            F = new AbilitySpec
+            {
+                Name = "Blade Flurry",
+                Description = "Committed forward flurry of slashes ending in a hard launch.",
+                IconName = "f",
+                CooldownTicks = 540,
+                Behavior = AbilityBehavior.MeleeCombo,
+                AimMode = AimMode.None,
+                Stages = new AttackStage[]
+                {
+                    new() { DurationTicks = 64, ChainWindowTicks = 0,
+                            HitboxEvents = new HitboxEvent[]
+                            {
+                                new() { TriggerTick = 8, DurationTicks = 4, Shape = HitboxShape.Capsule, Radius = 0.6f,
+                                        OffX = 0, OffY = 0.7f, OffZ = 0.6f, EndOffX = 0, EndOffY = 0.7f, EndOffZ = 1.9f,
+                                        Damage = 3f, Knockback = new() { Profile = KnockbackProfile.Light }, StunTicks = 12, Interruptible = false },
+                                new() { TriggerTick = 16, DurationTicks = 4, Shape = HitboxShape.Capsule, Radius = 0.6f,
+                                        OffX = 0, OffY = 0.7f, OffZ = 0.6f, EndOffX = 0, EndOffY = 0.7f, EndOffZ = 1.9f,
+                                        Damage = 3f, Knockback = new() { Profile = KnockbackProfile.Light }, StunTicks = 12, Interruptible = false },
+                                new() { TriggerTick = 24, DurationTicks = 4, Shape = HitboxShape.Capsule, Radius = 0.6f,
+                                        OffX = 0, OffY = 0.7f, OffZ = 0.6f, EndOffX = 0, EndOffY = 0.7f, EndOffZ = 1.9f,
+                                        Damage = 3f, Knockback = new() { Profile = KnockbackProfile.Light }, StunTicks = 12, Interruptible = false },
+                                new() { TriggerTick = 32, DurationTicks = 4, Shape = HitboxShape.Capsule, Radius = 0.6f,
+                                        OffX = 0, OffY = 0.7f, OffZ = 0.6f, EndOffX = 0, EndOffY = 0.7f, EndOffZ = 1.9f,
+                                        Damage = 3f, Knockback = new() { Profile = KnockbackProfile.Light }, StunTicks = 12, Interruptible = false },
+                                // Finisher: hard launch
+                                new() { TriggerTick = 44, DurationTicks = 6, Shape = HitboxShape.Capsule, Radius = 0.7f,
+                                        OffX = 0, OffY = 0.8f, OffZ = 0.6f, EndOffX = 0, EndOffY = 0.8f, EndOffZ = 2.0f,
+                                        Damage = 12f, Knockback = new() { Profile = KnockbackProfile.Custom, Angle = 45, BaseKnockback = 14, KnockbackGrowth = 8 },
+                                        StunTicks = 40, Interruptible = false },
+                            },
+                            AttackRange = 4f, WarpRange = 0f },
+                },
+                AnimationNames = new[] { "spell_f" },
+                Params = new()
+                {
+                    ["forward_speed"] = 7f,
+                    ["move_ticks"] = 40f,
+                },
+            },
+        };
+    }
+}

--- a/src/Shared/ServerSimulation.cs
+++ b/src/Shared/ServerSimulation.cs
@@ -406,10 +406,35 @@ namespace SlopArena.Shared
 				// Create and activate server-side ability
 				if (_activeAbilities.ContainsKey(id)) continue;
 
+				// ── Charge-stock gate: abilities that declare a "max_charges" param are
+				// limited by a refundable charge pool (Kistu Rising Slash) rather than a flat
+				// cooldown. Blocked when the pool is exhausted. ──
+				int maxCharges = (spec.Params != null && spec.Params.TryGetValue("max_charges", out var mc)) ? (int)mc : 0;
+				if (maxCharges > 0 && state.ChargeStockSpent >= maxCharges)
+				{
+					// Consume the input so SimulateTick doesn't start a data-driven attack.
+					var blockedInput = input;
+					blockedInput.ActiveSlot = 0;
+					inputs[id] = blockedInput;
+					continue;
+				}
+
 				var ability = SlopArena.Shared.Abilities.AbilityFactory.CreateServer(def.Class, (byte)(input.ActiveSlot - 1), airborne);
 				if (ability == null) continue; // unsupported character or slot
 				SlopArena.Shared.Abilities.AbilityFactory.InitFromSpec(ability, spec, (byte)(input.ActiveSlot - 1));
 				ActivateAbility(id, ability, (byte)(input.ActiveSlot - 1), def);
+
+				// Spend a charge from the pool (refunded on hit by the ability's OnHitEntity).
+				if (maxCharges > 0 && _states.TryGetValue(id, out var afterState))
+				{
+					afterState.ChargeStockSpent++;
+					ushort regenPeriod = (ushort)(spec.Params.TryGetValue("charge_regen_ticks", out var rg) ? rg : 180f);
+					afterState.ChargeStockRegenPeriod = regenPeriod;
+					if (afterState.ChargeStockRegenTicks == 0)
+						afterState.ChargeStockRegenTicks = regenPeriod;
+					_states[id] = afterState;
+				}
+
 				// Consume input so SimulateTick doesn't also try to start an attack
 				var consumedInput = input;
 				consumedInput.ActiveSlot = 0;
@@ -654,6 +679,21 @@ namespace SlopArena.Shared
 			foreach (var hit in hits)
 			{
 				if (!_states.TryGetValue(hit.TargetEntityId, out var targetState)) continue;
+
+				// ── Counter interception (target-side): if the defender has an active
+				// ability that counters this hit, it absorbs the hit and applies its own
+				// riposte to the attacker. Skip normal damage/knockback for this hit. ──
+				if (hit.OwnerEntityId != hit.TargetEntityId
+				    && _activeAbilities.TryGetValue(hit.TargetEntityId, out var defenderAbility)
+				    && _states.TryGetValue(hit.OwnerEntityId, out var counterAttacker))
+				{
+					if (defenderAbility.TryCounter(ref targetState, ref counterAttacker, hit.Damage))
+					{
+						_states[hit.TargetEntityId] = targetState;
+						_states[hit.OwnerEntityId] = counterAttacker;
+						continue;
+					}
+				}
 
 				// Knockback direction: from attacker to target (not hitbox to target).
 				// The hitbox offset can place it past the target, inverting the direction.

--- a/src/Shared/Simulation.cs
+++ b/src/Shared/Simulation.cs
@@ -425,6 +425,19 @@ namespace SlopArena.Shared
             if (s.Cooldown4 > 0) s.Cooldown4--;
             if (s.Cooldown5 > 0) s.Cooldown5--;
 
+            // Charge-stock regen (refundable ability pools, e.g. Kistu Rising Slash).
+            // Only active when a charge is spent; recovers one charge per regen period.
+            if (s.ChargeStockSpent > 0)
+            {
+                if (s.ChargeStockRegenTicks > 0) s.ChargeStockRegenTicks--;
+                if (s.ChargeStockRegenTicks == 0)
+                {
+                    s.ChargeStockSpent--;
+                    if (s.ChargeStockSpent > 0)
+                        s.ChargeStockRegenTicks = s.ChargeStockRegenPeriod > 0 ? s.ChargeStockRegenPeriod : (ushort)180;
+                }
+            }
+
             // Buff timer
             if (s.BuffRemainingTicks > 0)
             {

--- a/tests/Shared.Tests/KistuAbilityTests.cs
+++ b/tests/Shared.Tests/KistuAbilityTests.cs
@@ -1,0 +1,264 @@
+using System;
+using Xunit;
+using SlopArena.Shared.Abilities;
+
+namespace SlopArena.Shared.Tests;
+
+/// <summary>
+/// Behaviour tests for Kistu's kit. Standard slots (activation + damage) plus the novel
+/// infra: RMB charge tap-vs-hold, E dash self-movement, R rising launcher + charge-stock
+/// (spend / block-when-empty / refund-on-hit), and Q counter (absorb + riposte-launch).
+/// </summary>
+public class KistuAbilityTests
+{
+    private static readonly float GroundPY = TestHelpers.GroundPY(TestHelpers.KistuDef);
+    private static CharacterDefinition Def => TestHelpers.KistuDef;
+
+    private static ServerSimulation SimWithPlayer(out CharacterState player)
+    {
+        var sim = TestHelpers.MakeSim();
+        player = TestHelpers.PlayerState();
+        player.PY = GroundPY;
+        TestHelpers.RegisterPlayer(sim, Def, player);
+        return sim;
+    }
+
+    // ── Activation of every slot ──
+
+    [Theory]
+    [InlineData((byte)1)] // LMB
+    [InlineData((byte)2)] // RMB
+    [InlineData((byte)3)] // Q
+    [InlineData((byte)4)] // E
+    [InlineData((byte)5)] // R
+    [InlineData((byte)6)] // F
+    public void GroundSlot_Activates(byte slot)
+    {
+        var sim = SimWithPlayer(out _);
+        var t0 = TestHelpers.TickN(sim, TestHelpers.Input(activeSlot: slot, aiming: true), 1);
+        Assert.Equal(ActionState.Attacking, t0.State);
+        Assert.Equal(slot, t0.AttackSlot);
+    }
+
+    [Theory]
+    [InlineData((byte)1)] // AirLMB
+    [InlineData((byte)2)] // AirRMB
+    public void AirSlot_Activates(byte slot)
+    {
+        var sim = TestHelpers.MakeSim();
+        var s = TestHelpers.PlayerState();
+        s.PY = GroundPY + 5f;
+        s.IsGrounded = false;
+        TestHelpers.RegisterPlayer(sim, Def, s);
+        var t0 = TestHelpers.TickN(sim, TestHelpers.Input(activeSlot: slot), 1);
+        Assert.Equal(ActionState.Attacking, t0.State);
+        Assert.Equal(slot, t0.AttackSlot);
+    }
+
+    // ── LMB: damage + reach ──
+
+    [Fact]
+    public void Lmb_DamagesEnemyInReach()
+    {
+        var sim = SimWithPlayer(out _);
+        var npc = TestHelpers.NpcState(0f, 1.5f);
+        npc.PY = GroundPY;
+        TestHelpers.RegisterNpc(sim, Def, npc);
+
+        sim.Tick(new() { { 1, TestHelpers.Input(activeSlot: 1) }, { 100, default } });
+        for (int i = 0; i < 12; i++) sim.Tick(new() { { 1, default }, { 100, default } });
+
+        Assert.True(sim.GetState(100).DamagePercent > 0);
+    }
+
+    // ── RMB: charged spin deals more than the tap poke ──
+
+    [Fact]
+    public void Rmb_ChargedHitsHarderThanTap()
+    {
+        // Tap: press then release immediately (uncharged Stages[1]).
+        var tapSim = SimWithPlayer(out _);
+        var tapNpc = TestHelpers.NpcState(0f, 1.4f); tapNpc.PY = GroundPY;
+        TestHelpers.RegisterNpc(tapSim, Def, tapNpc);
+        tapSim.Tick(new() { { 1, TestHelpers.Input(activeSlot: 2, aiming: true) }, { 100, default } });
+        for (int i = 0; i < 40; i++) tapSim.Tick(new() { { 1, default }, { 100, default } });
+        ushort tapDmg = tapSim.GetState(100).DamagePercent;
+
+        // Hold: keep aiming past the charge threshold (auto-releases charged).
+        var holdSim = SimWithPlayer(out _);
+        var holdNpc = TestHelpers.NpcState(0f, 1.4f); holdNpc.PY = GroundPY;
+        TestHelpers.RegisterNpc(holdSim, Def, holdNpc);
+        var hold = TestHelpers.Input(activeSlot: 2, aiming: true);
+        for (int i = 0; i < 100; i++) holdSim.Tick(new() { { 1, hold }, { 100, default } });
+        ushort holdDmg = holdSim.GetState(100).DamagePercent;
+
+        Assert.True(tapDmg > 0, $"tap should deal damage, got {tapDmg}");
+        Assert.True(holdDmg > tapDmg, $"charged ({holdDmg}) should exceed tap ({tapDmg})");
+    }
+
+    // ── E: charged dash travels farther than the tapped dash ──
+
+    [Fact]
+    public void E_ChargedDashTravelsFartherThanTap()
+    {
+        var tapSim = SimWithPlayer(out _);
+        tapSim.Tick(new() { { 1, TestHelpers.Input(activeSlot: 4) } });
+        for (int i = 0; i < 60; i++) tapSim.Tick(new() { { 1, default } });
+        float tapPZ = tapSim.GetState(1).PZ;
+
+        var holdSim = SimWithPlayer(out _);
+        var hold = TestHelpers.Input(activeSlot: 4, aiming: true);
+        for (int i = 0; i < 80; i++) holdSim.Tick(new() { { 1, hold } });
+        float holdPZ = holdSim.GetState(1).PZ;
+
+        // LungeForce is a decaying burst, so distances are modest; charged (32) must still
+        // out-travel the tap (18).
+        Assert.True(tapPZ > 0.4f, $"tap dash should move forward, got PZ={tapPZ:F2}");
+        Assert.True(holdPZ > tapPZ + 0.2f, $"charged dash ({holdPZ:F2}) should travel farther than tap ({tapPZ:F2})");
+    }
+
+    // ── R: rising slash lifts Kistu off the ground (vertical recovery) ──
+
+    [Fact]
+    public void R_RisesOffGround()
+    {
+        var sim = SimWithPlayer(out _);
+        sim.Tick(new() { { 1, TestHelpers.Input(activeSlot: 5) } });
+        for (int i = 0; i < 10; i++) sim.Tick(new() { { 1, default } });
+        var s = sim.GetState(1);
+        Assert.False(s.IsGrounded);
+        Assert.True(s.PY > GroundPY + 1f, $"expected Kistu to rise above {GroundPY + 1f:F2}, got {s.PY:F2}");
+    }
+
+    // ── R: launches a grounded enemy ──
+
+    [Fact]
+    public void R_LaunchesGroundedEnemy()
+    {
+        var sim = SimWithPlayer(out _);
+        var npc = TestHelpers.NpcState(0f, 1.0f); npc.PY = GroundPY;
+        TestHelpers.RegisterNpc(sim, Def, npc);
+        sim.Tick(new() { { 1, TestHelpers.Input(activeSlot: 5) }, { 100, default } });
+        for (int i = 0; i < 12; i++) sim.Tick(new() { { 1, default }, { 100, default } });
+        Assert.True(sim.GetState(100).DamagePercent > 0, "R should hit and damage the grounded enemy");
+    }
+
+    // ── R charge-stock: two whiffs exhaust the pool; the third cast is blocked ──
+
+    [Fact]
+    public void R_ChargePool_ExhaustsThenBlocks()
+    {
+        var sim = SimWithPlayer(out _);
+
+        sim.Tick(new() { { 1, TestHelpers.Input(activeSlot: 5) } });
+        for (int i = 0; i < 30; i++) sim.Tick(new() { { 1, default } });
+        Assert.Equal((byte)1, sim.GetState(1).ChargeStockSpent);
+
+        sim.Tick(new() { { 1, TestHelpers.Input(activeSlot: 5) } });
+        for (int i = 0; i < 30; i++) sim.Tick(new() { { 1, default } });
+        Assert.Equal((byte)2, sim.GetState(1).ChargeStockSpent);
+
+        // Pool exhausted (max_charges = 2): third cast must not activate or spend more.
+        sim.Tick(new() { { 1, TestHelpers.Input(activeSlot: 5) } });
+        var s = sim.GetState(1);
+        Assert.Equal((byte)2, s.ChargeStockSpent);
+        Assert.NotEqual((byte)5, s.AttackSlot);
+    }
+
+    // ── R charge-stock: landing a hit refunds the spent charge ──
+
+    [Fact]
+    public void R_RefundsChargeOnHit()
+    {
+        var sim = SimWithPlayer(out _);
+        var npc = TestHelpers.NpcState(0f, 1.0f); npc.PY = GroundPY;
+        TestHelpers.RegisterNpc(sim, Def, npc);
+
+        sim.Tick(new() { { 1, TestHelpers.Input(activeSlot: 5) }, { 100, default } });
+        for (int i = 0; i < 24; i++) sim.Tick(new() { { 1, default }, { 100, default } });
+
+        Assert.True(sim.GetState(100).DamagePercent > 0, "R should have connected");
+        Assert.Equal((byte)0, sim.GetState(1).ChargeStockSpent); // spent 1, refunded 1
+    }
+
+    // ── R charge-stock: refund-to-empty clears the regen timer (no stale partial) ──
+
+    [Fact]
+    public void R_RefundToEmpty_ClearsRegenTimer()
+    {
+        var sim = SimWithPlayer(out _);
+        var npc = TestHelpers.NpcState(0f, 1.0f); npc.PY = GroundPY;
+        TestHelpers.RegisterNpc(sim, Def, npc);
+
+        // Spend one charge, then land the hit — refund brings the pool back to full.
+        sim.Tick(new() { { 1, TestHelpers.Input(activeSlot: 5) }, { 100, default } });
+        for (int i = 0; i < 24; i++) sim.Tick(new() { { 1, default }, { 100, default } });
+
+        var s = sim.GetState(1);
+        Assert.Equal((byte)0, s.ChargeStockSpent);
+        // Timer must be cleared (not a stale partial countdown) so the next spend gets a full period.
+        Assert.Equal((ushort)0, s.ChargeStockRegenTicks);
+    }
+
+    // ── Q counter: absorbs a hit in the window and launches the attacker ──
+
+    [Fact]
+    public void Q_CounterAbsorbsAndRipostes()
+    {
+        var sim = TestHelpers.MakeSim();
+        var kistu = TestHelpers.PlayerState(0f, 0f);
+        kistu.PY = GroundPY;
+        kistu.FacingYaw = 0f; // facing +Z toward the attacker
+        TestHelpers.RegisterPlayer(sim, Def, kistu);
+
+        var attacker = TestHelpers.NpcState(0f, 1.0f);
+        attacker.PY = GroundPY;
+        attacker.FacingYaw = MathF.PI; // facing -Z toward Kistu
+        TestHelpers.RegisterNpc(sim, Def, attacker);
+
+        // Both act on tick 0: Kistu parries, attacker swings LMB (hitbox lands ~tick 6, inside window).
+        sim.Tick(new() { { 1, TestHelpers.Input(activeSlot: 3) }, { 100, TestHelpers.Input(activeSlot: 1) } });
+        for (int i = 0; i < 12; i++) sim.Tick(new() { { 1, default }, { 100, default } });
+
+        var kistuAfter = sim.GetState(1);
+        var attackerAfter = sim.GetState(100);
+        Assert.Equal((ushort)0, kistuAfter.DamagePercent); // hit absorbed
+        Assert.True(attackerAfter.DamagePercent > 0, "attacker should take riposte damage");
+        Assert.True(attackerAfter.HitstunTicks > 0, "attacker should be launched into hitstun");
+    }
+
+    // ── Q counter negative: without an active parry, the hit lands normally ──
+
+    [Fact]
+    public void Q_NoCounterWhenInactive_TakesDamage()
+    {
+        var sim = TestHelpers.MakeSim();
+        var kistu = TestHelpers.PlayerState(0f, 0f);
+        kistu.PY = GroundPY;
+        TestHelpers.RegisterPlayer(sim, Def, kistu);
+
+        var attacker = TestHelpers.NpcState(0f, 1.0f);
+        attacker.PY = GroundPY;
+        attacker.FacingYaw = MathF.PI;
+        TestHelpers.RegisterNpc(sim, Def, attacker);
+
+        // Kistu does nothing; attacker swings.
+        sim.Tick(new() { { 1, default }, { 100, TestHelpers.Input(activeSlot: 1) } });
+        for (int i = 0; i < 12; i++) sim.Tick(new() { { 1, default }, { 100, default } });
+
+        Assert.True(sim.GetState(1).DamagePercent > 0, "Kistu should take damage with no active counter");
+    }
+
+    // ── F: blade flurry deals damage ──
+
+    [Fact]
+    public void F_FlurryDamagesEnemy()
+    {
+        var sim = SimWithPlayer(out _);
+        var npc = TestHelpers.NpcState(0f, 1.3f); npc.PY = GroundPY;
+        TestHelpers.RegisterNpc(sim, Def, npc);
+        sim.Tick(new() { { 1, TestHelpers.Input(activeSlot: 6) }, { 100, default } });
+        for (int i = 0; i < 64; i++) sim.Tick(new() { { 1, default }, { 100, default } });
+        Assert.True(sim.GetState(100).DamagePercent > 0);
+    }
+}

--- a/tests/Shared.Tests/TestHelpers.cs
+++ b/tests/Shared.Tests/TestHelpers.cs
@@ -10,6 +10,8 @@ public static class TestHelpers
 
     public static CharacterDefinition FightGuyDef => CharacterRegistry.Get(CharacterClass.FightGuy);
 
+    public static CharacterDefinition KistuDef => CharacterRegistry.Get(CharacterClass.Kistu);
+
     /// <summary>
     /// Create a player state at (x, z). PY defaults to 0 — physics tests
     /// that need grounded must set PY = floorY + def.CapsuleHeight * 0.5f.


### PR DESCRIPTION
Adds the 3rd SlopArena character: **Kistu**, an agile katana **spacing duelist** (Marth × Amaterasu). Wins neutral with disjointed blade reach, converts hits into vertical air juggles. Server-sim only — plays now with a **placeholder** model (FightGuy prefab, capsule hurtboxes) since art/anim assets are pending.

## Kit (8 slots)
| Slot | Impl | Behaviour |
|---|---|---|
| LMB / AirLMB | `LmbCombo` / `AirLmbCombo` (reuse) | reach-y slash combos, launcher finisher / juggle-sustain |
| RMB / E | `KistuChargeAttack` (reuse `ChargeAttackAbility`) | tap poke vs charged **kill** spin / tap-hold dash gap-close |
| AirRMB | `AirRmbAttack` (reuse) | downward spike |
| **Q** | `KistuCounter` *(new infra)* | parry window → riposte-launches the attacker |
| **R** | `KistuRisingSlash` *(new infra)* | homing rising launcher, refundable 2-charge pool, doubles as vertical recovery |
| F | `KistuUltFlurry` | moving multi-slash → hard launch |

## New shared infra
- **Charge-stock pool** — `CharacterState.ChargeStockSpent/RegenTicks/RegenPeriod`; gated in `PreTickAbilities`, regenerated in `Simulation.TickTimers`, refunded in `KistuRisingSlash.OnHitEntity`. Mirrors the existing cooldown pattern. Charges refund on hit so a connected juggle sustains; whiffing burns them (capped recovery).
- **Counter hook** — `ServerAbility.TryCounter` virtual + target-side interception in `ServerSimulation.ResolveHits` (before knockback). Absorbs the hit, launches the attacker (interrupting their attack). No hard stun anywhere — pure knockback, per the kit's design pillar.

## Design pillars honoured
- **Predictable knockback, emergent combos** — no scripted launch-chains; every hit has a plain readable KB profile.
- **Recovery as a system** — E (horizontal) + AirLMB (stall) + R (capped vertical); deliberately exploitable.

## Tests
19 new `KistuAbilityTests` driving the real `ServerSimulation` end-to-end (slot activation, LMB/F damage, RMB tap-vs-charged, E dash distance, R rise + enemy launch + charge exhaust/block/refund + regen-timer regression, Q counter absorb+riposte and negative case). **310 total pass.**

## Review
Two-axis review (Standards + Spec) run and acted on:
- **Fixed** a charge-regen timing bug (refund-to-empty left a stale timer → R recovered faster than intended) + added a regression test.
- **Refactored** R's launcher hitbox out of loose params into `Stages[].HitboxEvents` for consistency with the other slots.

## Client
Zero new client code (fully data-driven). Char-select auto-enumerates the enum; placeholder art degrades gracefully. Not yet exercised in the Unity editor.

## Docs
- `docs/characters/kistu.md` (design, status → implemented)
- `docs/plans/2026-07-27-kistu-implementation.md` (implementation plan)
- `docs/systems/ability-architecture.md` (slot table + Kistu column)

## Follow-ups (deferred art/anim)
Model prefab, `Kistu_AnimConfig`, baked skeleton, VFX/foxfire, icons; balance tuning of placeholder numbers.