### PR TITLE
feat(auth): guest JWT auth endpoint + client auth flow

### DIFF
--- a/docs/systems/master-server.md
+++ b/docs/systems/master-server.md
@@ -11,7 +11,7 @@ The master server is the matchmaking/meta API for online PvP. It runs **separate
 
 - ASP.NET Core 8 Web API (minimal API in `Program.cs`)
 - PostgreSQL via EF Core 8 + Npgsql
-- Bearer-token auth: `/servers/register` issues a plain `apiToken` GUID; heartbeat + match-result authenticate by timing-safe comparison of that raw GUID against the stored `GameServers.ApiToken`. JWT packages are referenced but **not wired yet** (no `AddAuthentication` in `Program.cs`) — guest JWT auth lands in roadmap Phase 1.1.
+- Bearer-token auth: `/servers/register` issues a plain `apiToken` GUID; heartbeat + match-result authenticate by timing-safe comparison of that raw GUID against the stored `GameServers.ApiToken`. Guest JWT auth is wired via `AddAuthentication().AddJwtBearer()` — `POST /auth/guest` issues a JWT containing the SteamId claim; `GET /auth/me` validates it. Two auth schemes coexist: raw GUID bearer for game servers, JWT bearer for clients.
 - SignalR registered, **no hubs yet** — lobby hub lands in a later ticket (roadmap Phase 2)
 
 ---
@@ -58,11 +58,13 @@ The game server (`src/Server`) points at the master server via `ServerConfig.Mas
 | Method | Path | Auth | Returns |
 |---|---|---|---|
 | GET | `/health` | none | `{ "status": "ok", "version": "0.1.0" }` |
+| POST | `/auth/guest` | none (issues JWT) | `{ "token": "<jwt>", "steamId": <long> }` |
+| GET | `/auth/me` | Bearer JWT | `{ "steamId": <long>, "username": "<string>", "mmr": <int> }` |
 | POST | `/servers/register` | none (issues token) | `{ "serverId": "<guid>", "apiToken": "<guid>" }` |
 | POST | `/servers/{serverId}/heartbeat` | Bearer `apiToken` | `{ "status": "ok" }` |
 | POST | `/match/result` | Bearer `apiToken` | `{ "status": "recorded", "mmrChange": <int> }` (match row must already exist, else 404) |
 
-**Not yet implemented** (later roadmap tickets): `POST /auth/guest` (Phase 1.1), `GET /servers` browser list (Phase 1.2), `LobbyHub` SignalR hub (Phase 2.1).
+**Not yet implemented** (later roadmap tickets): `GET /servers` browser list (Phase 1.2), `LobbyHub` SignalR hub (Phase 2.1).
 
 ### Smoke test
 
@@ -76,6 +78,19 @@ curl -s -X POST http://localhost:5000/servers/register \
   -H "Content-Type: application/json" \
   -d '{"name":"fake-eu-1","ipAddress":"127.0.0.1","port":9876,"region":"eu-west","isOfficial":false,"maxConcurrentMatches":15,"customRulesJson":null}'
 # → {"serverId":"...","apiToken":"..."}
+
+# Guest auth — get a JWT + temporary SteamId
+curl -s -X POST http://localhost:5000/auth/guest
+# → {"token":"<jwt>","steamId":12345678}
+
+# Use the JWT to hit an authed endpoint
+curl -s http://localhost:5000/auth/me \
+  -H "Authorization: Bearer <jwt>"
+# → {"steamId":12345678,"username":"Guest-12345","mmr":1000}
+
+# Without the JWT → 401
+curl -s http://localhost:5000/auth/me
+# → 401 Unauthorized
 ```
 
 ---
@@ -90,5 +105,4 @@ curl -s -X POST http://localhost:5000/servers/register \
 
 ## Notes
 
-- The master server is the **source of truth for matchmaking/meta only**. Match simulation stays server-authoritative on the game server over UDP — never replicate gameplay state to the master server.
-- The `Jwt__Secret` in `.env` is a placeholder for the future guest-auth flow (Phase 1.1) — not used by the current bearer-token auth. Dev-only; regenerate with `openssl rand -base64 64` for any non-local deployment.
+- The `Jwt__Secret` in `.env` signs guest JWTs (HMAC-SHA256). Dev-only; regenerate with `openssl rand -base64 64` for any non-local deployment.

--- a/src/Shared/GuestUserInfo.cs
+++ b/src/Shared/GuestUserInfo.cs
@@ -1,0 +1,10 @@
+namespace SlopArena.Shared
+{
+    /// <summary>User info returned by GET /auth/me.</summary>
+    public class GuestUserInfo
+    {
+        public long SteamId { get; set; }
+        public string Username { get; set; } = string.Empty;
+        public int Mmr { get; set; }
+    }
+}

--- a/src/Shared/MasterServerClient.cs
+++ b/src/Shared/MasterServerClient.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SlopArena.Shared
+{
+    /// <summary>
+    /// HTTP client for the SlopArena master server.
+    /// Handles anonymous guest authentication and includes the JWT as a
+    /// Bearer token in all subsequent master server requests.
+    /// </summary>
+    public class MasterServerClient : IDisposable
+    {
+        private readonly HttpClient _http;
+        private readonly bool _ownsHttpClient;
+
+        private string? _token;
+        private long? _steamId;
+
+        /// <summary>JWT bearer token, set after a successful AuthenticateGuestAsync.</summary>
+        public string? Token => _token;
+
+        /// <summary>Guest SteamId assigned by the master server, set after AuthenticateGuestAsync.</summary>
+        public long? SteamId => _steamId;
+
+        /// <summary>True after a successful guest auth call.</summary>
+        public bool IsAuthenticated => _token != null;
+
+        /// <summary>
+        /// Create a client pointing at the given master server URL.
+        /// </summary>
+        public MasterServerClient(string masterServerUrl = "http://localhost:5000")
+        {
+            _http = new HttpClient
+            {
+                BaseAddress = new Uri(masterServerUrl.TrimEnd('/') + "/"),
+                Timeout = TimeSpan.FromSeconds(5)
+            };
+            _ownsHttpClient = true;
+        }
+
+        /// <summary>
+        /// Create a client with a pre-configured HttpClient (for testing or DI).
+        /// The caller owns the HttpClient lifetime.
+        /// </summary>
+        public MasterServerClient(HttpClient httpClient)
+        {
+            _http = httpClient;
+            _ownsHttpClient = false;
+        }
+
+        /// <summary>
+        /// Authenticate as a guest: POST /auth/guest → receive JWT + SteamId.
+        /// Stores the token and attaches it as Bearer header for subsequent requests.
+        /// Returns false on network error or non-2xx response.
+        /// </summary>
+        public async Task<bool> AuthenticateGuestAsync(CancellationToken ct = default)
+        {
+            try
+            {
+                using var response = await _http.PostAsync("auth/guest", content: null, ct);
+                if (!response.IsSuccessStatusCode)
+                    return false;
+
+                var json = await response.Content.ReadAsStringAsync();
+                var token = ExtractStringField(json, "token");
+                var steamId = ExtractNumberField(json, "steamId");
+
+                if (string.IsNullOrEmpty(token) || steamId == null)
+                    return false;
+
+                _token = token;
+                _steamId = steamId;
+                _http.DefaultRequestHeaders.Authorization =
+                    new AuthenticationHeaderValue("Bearer", _token);
+                return true;
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Fetch the current user's info: GET /auth/me (requires prior auth).
+        /// Returns null if not authenticated, network error, or non-2xx response.
+        /// </summary>
+        public async Task<GuestUserInfo?> GetMeAsync(CancellationToken ct = default)
+        {
+            if (!IsAuthenticated)
+                return null;
+
+            try
+            {
+                using var response = await _http.GetAsync("auth/me", ct);
+                if (!response.IsSuccessStatusCode)
+                    return null;
+
+                var json = await response.Content.ReadAsStringAsync();
+                var steamId = ExtractNumberField(json, "steamId");
+                var username = ExtractStringField(json, "username");
+                var mmr = ExtractNumberField(json, "mmr");
+
+                if (steamId == null || username == null || mmr == null)
+                    return null;
+
+                return new GuestUserInfo
+                {
+                    SteamId = steamId.Value,
+                    Username = username,
+                    Mmr = (int)mmr.Value
+                };
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        // ── Lightweight JSON field extraction (avoids System.Text.Json dependency) ──
+        // Safe for controlled API responses: JWT tokens are base64url (no quotes),
+        // guest usernames are alphanumeric+dashes, numbers are non-negative integers.
+
+        private static string? ExtractStringField(string json, string fieldName)
+        {
+            var match = Regex.Match(json, $"\"{fieldName}\"\\s*:\\s*\"([^\"]*)\"");
+            return match.Success ? match.Groups[1].Value : null;
+        }
+
+        private static long? ExtractNumberField(string json, string fieldName)
+        {
+            var match = Regex.Match(json, $"\"{fieldName}\"\\s*:\\s*(\\d+)");
+            return match.Success ? long.Parse(match.Groups[1].Value) : null;
+        }
+
+        public void Dispose()
+        {
+            if (_ownsHttpClient)
+                _http.Dispose();
+        }
+    }
+}

--- a/tests/Shared.Tests/MasterServerClientTests.cs
+++ b/tests/Shared.Tests/MasterServerClientTests.cs
@@ -1,0 +1,211 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using SlopArena.Shared;
+using Xunit;
+
+namespace SlopArena.Tests
+{
+    /// <summary>
+    /// A delegating HTTP handler that returns canned responses for testing
+    /// without a real server.
+    /// </summary>
+    internal class MockHttpHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _responder;
+
+        public MockHttpHandler(Func<HttpRequestMessage, HttpResponseMessage> responder)
+        {
+            _responder = responder;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(_responder(request));
+        }
+    }
+
+    public class MasterServerClientTests
+    {
+        private const string SampleToken =
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWJfaWQiOiIxMjM0NTYif2.abc123";
+        private const long SampleSteamId = 42L;
+
+        private const string GuestAuthJson =
+            "{\"token\":\"" + SampleToken + "\",\"steamId\":42}";
+
+        private const string UserInfoJson =
+            "{\"steamId\":42,\"username\":\"Guest-12345\",\"mmr\":1000}";
+
+        // ── Helpers ──
+
+        private static MasterServerClient MakeClient(
+            Func<HttpRequestMessage, HttpResponseMessage> responder)
+        {
+            var handler = new MockHttpHandler(responder);
+            return new MasterServerClient(new HttpClient(handler)
+            {
+                BaseAddress = new Uri("http://test/")
+            });
+        }
+
+        private static HttpResponseMessage JsonOk(string json) =>
+            new(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json, Encoding.UTF8, "application/json")
+            };
+
+        private static HttpResponseMessage GuestAuthResponse() => JsonOk(GuestAuthJson);
+
+        // ── AuthenticateGuestAsync ──
+
+        [Fact]
+        public async Task AuthenticateGuest_StoresTokenAndSteamId()
+        {
+            using var client = MakeClient(req =>
+            {
+                Assert.Equal("http://test/auth/guest", req.RequestUri!.ToString());
+                Assert.Equal(HttpMethod.Post, req.Method);
+                return GuestAuthResponse();
+            });
+
+            bool ok = await client.AuthenticateGuestAsync();
+
+            Assert.True(ok);
+            Assert.Equal(SampleToken, client.Token);
+            Assert.Equal(SampleSteamId, client.SteamId);
+            Assert.True(client.IsAuthenticated);
+        }
+
+        [Fact]
+        public async Task AuthenticateGuest_ReturnsFalseOnServerError()
+        {
+            using var client = MakeClient(_ =>
+                new HttpResponseMessage(HttpStatusCode.InternalServerError));
+
+            bool ok = await client.AuthenticateGuestAsync();
+
+            Assert.False(ok);
+            Assert.Null(client.Token);
+            Assert.False(client.IsAuthenticated);
+        }
+
+        [Fact]
+        public async Task AuthenticateGuest_ReturnsFalseOnMissingToken()
+        {
+            using var client = MakeClient(_ =>
+                JsonOk($"{{\"steamId\":{SampleSteamId}}}"));
+
+            bool ok = await client.AuthenticateGuestAsync();
+
+            Assert.False(ok);
+            Assert.Null(client.Token);
+        }
+
+        // ── GetMeAsync ──
+
+        [Fact]
+        public async Task GetMe_ReturnsUserInfoAfterAuth()
+        {
+            string? capturedAuthHeader = null;
+            using var client = MakeClient(req =>
+            {
+                if (req.RequestUri!.ToString().Contains("auth/guest"))
+                    return GuestAuthResponse();
+
+                capturedAuthHeader = req.Headers.Authorization?.ToString();
+                return JsonOk(UserInfoJson);
+            });
+
+            await client.AuthenticateGuestAsync();
+            var info = await client.GetMeAsync();
+
+            Assert.NotNull(info);
+            Assert.Equal(SampleSteamId, info!.SteamId);
+            Assert.Equal("Guest-12345", info.Username);
+            Assert.Equal(1000, info.Mmr);
+            Assert.Equal($"Bearer {SampleToken}", capturedAuthHeader);
+        }
+
+        [Fact]
+        public async Task GetMe_ReturnsNullBeforeAuth()
+        {
+            using var client = MakeClient(_ => new HttpResponseMessage(HttpStatusCode.OK));
+
+            var info = await client.GetMeAsync();
+
+            Assert.Null(info);
+        }
+
+        [Fact]
+        public async Task GetMe_ReturnsNullOnUnauthorized()
+        {
+            using var client = MakeClient(req =>
+                req.RequestUri!.ToString().Contains("auth/guest")
+                    ? GuestAuthResponse()
+                    : new HttpResponseMessage(HttpStatusCode.Unauthorized));
+
+            await client.AuthenticateGuestAsync();
+            var info = await client.GetMeAsync();
+
+            Assert.Null(info);
+        }
+
+        // ── Bearer header propagation ──
+
+        [Fact]
+        public async Task AuthenticatedRequestsIncludeBearerHeader()
+        {
+            string? authHeader = null;
+            using var client = MakeClient(req =>
+            {
+                if (req.RequestUri!.ToString().Contains("auth/guest"))
+                    return GuestAuthResponse();
+
+                authHeader = req.Headers.Authorization?.ToString();
+                return JsonOk(UserInfoJson);
+            });
+
+            await client.AuthenticateGuestAsync();
+            await client.GetMeAsync();
+
+            Assert.Equal($"Bearer {SampleToken}", authHeader);
+        }
+
+        [Fact]
+        public async Task AuthenticateGuest_TokenIsNullBeforeAuth()
+        {
+            using var client = MakeClient(_ => GuestAuthResponse());
+
+            Assert.Null(client.Token);
+            Assert.False(client.IsAuthenticated);
+
+            await client.AuthenticateGuestAsync();
+
+            Assert.Equal(SampleToken, client.Token);
+            Assert.True(client.IsAuthenticated);
+        }
+
+        // ── Constructor ──
+
+        [Fact]
+        public async Task Constructor_SetsBaseAddressWithTrailingSlash()
+        {
+            var handler = new MockHttpHandler(req =>
+            {
+                Assert.Equal("http://localhost:5000/auth/guest", req.RequestUri!.ToString());
+                return GuestAuthResponse();
+            });
+
+            using var client = new MasterServerClient(new HttpClient(handler)
+            {
+                BaseAddress = new Uri("http://localhost:5000/")
+            });
+            Assert.True(await client.AuthenticateGuestAsync());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements anonymous guest authentication for the PvP demo (issue #30, epic #20).

Per ADR-0006, the master server gains a `POST /auth/guest` endpoint that issues a JWT with a temporary SteamId. The client (`MasterServerClient`) stores the JWT and includes it as a Bearer token in all master server requests.

## Master Server (separate repo — SlopArena-MasterServer)

- **JWT auth wired** — `AddAuthentication().AddJwtBearer()` using existing `Jwt:Secret/Issuer/Audience` config. Fail-fast guard on missing/empty secret.
- **`POST /auth/guest`** — generates a random guest `SteamId` (`long`, below real Steam ID range to avoid collision), creates a `User` record (MMR=1000), issues a JWT with the SteamId claim, returns `{ token, steamId }`.
- **`GET /auth/me`** — JWT-protected endpoint returning `{ steamId, username, mmr }`. Returns 401 without a valid JWT.
- **`GuestAuthResponse` / `GuestUserInfo`** DTOs.

## Client (this repo)

- **`src/Shared/MasterServerClient.cs`** — `HttpClient`-based class: `AuthenticateGuestAsync()` calls `POST /auth/guest`, stores the JWT, attaches it as `Authorization: Bearer` on subsequent requests. `GetMeAsync()` calls the authed endpoint. Uses regex JSON parsing to keep the zero-dependency Shared project free of NuGet packages.
- **`src/Shared/GuestUserInfo.cs`** — response model (one class per file per CONTRIBUTING.md).
- **9 unit tests** — mock HTTP handler covering auth success/failure, token storage, Bearer header propagation, pre-auth state, unauthorized response.
- **`docs/systems/master-server.md`** updated with new endpoints, smoke tests, and auth scheme description.

## Design notes

- The ADR assumed `SteamId` as `Guid`, but the actual `User.SteamId` is `long` (bigint, identity column). Used `long` to match the schema — real Steam IDs are 64-bit integers. Guest IDs are random longs below `76561197960265728`.
- `OperationCanceledException` is rethrown (not swallowed) so cancellation propagates correctly.
- `GET /auth/me` is idempotent — no DB writes (removed `LastLogin` side effect per code review).

## Acceptance criteria

- [x] `POST /auth/guest` returns a valid JWT and a SteamId
- [x] A `User` row is created in PostgreSQL with MMR=1000
- [x] Client stores the JWT and includes it as Bearer token in master server HTTP requests
- [x] Hitting an authed endpoint (`GET /auth/me`) with the guest JWT succeeds
- [x] Hitting an authed endpoint without the JWT returns 401

## Test verification

- Master server builds clean (0 warnings, 0 errors)
- Shared project builds, DLL auto-copied to Unity Plugins
- Full test suite: **378 passed, 0 failed** (369 existing + 9 new)

Closes #30