### PR TITLE
feat(server-browser): client UI + Shared server list (issue #31)

### DIFF
--- a/client/Unity/Assets/Scenes/ServerBrowser.unity
+++ b/client/Unity/Assets/Scenes/ServerBrowser.unity
@@ -1,0 +1,329 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 10
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 13
+  m_BakeOnSceneLoad: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 1
+    m_PVRFilteringGaussRadiusAO: 1
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 20201, guid: 0000000000000000f000000000000000, type: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &1100000000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1100000003}
+  - component: {fileID: 1100000002}
+  - component: {fileID: 1100000001}
+  m_Layer: 5
+  m_Name: ServerBrowser
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1100000001
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1100000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 17aeaf67bdc94b5c823d07e98f66af71, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _uiDocument: {fileID: 1100000002}
+  _masterServerUrl: http://localhost:5000
+--- !u!114 &1100000002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1100000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 19102, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_PanelSettings: {fileID: 11400000, guid: 375219e0f9be73791af68905fab77544, type: 2}
+  m_ParentUI: {fileID: 0}
+  sourceAsset: {fileID: 9197481963319205126, guid: c1e8ddbe8c1c459ca4fdc18d73bb2aa9, type: 3}
+  m_SortingOrder: 0
+  m_WorldSpaceSizeMode: 1
+  m_WorldSpaceWidth: 1920
+  m_WorldSpaceHeight: 1080
+--- !u!4 &1100000003
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1100000000}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1100000004
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1100000009}
+  - component: {fileID: 1100000008}
+  - component: {fileID: 1100000007}
+  - component: {fileID: 1100000006}
+  m_Layer: 0
+  m_Name: Camera
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1100000006
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1100000004}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_AllowHDROutput: 1
+  m_UseScreenCoordOverride: 0
+  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_Version: 2
+  m_TaaSettings:
+    m_Quality: 3
+    m_FrameInfluence: 0.1
+    m_JitterScale: 1
+    m_MipBias: 0
+    m_VarianceClampScale: 0.9
+    m_ContrastAdaptiveSharpening: 0
+--- !u!81 &1100000007
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1100000004}
+  m_Enabled: 1
+--- !u!20 &1100000008
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1100000004}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &1100000009
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1100000004}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 1100000003}
+  - {fileID: 1100000009}

--- a/client/Unity/Assets/Scenes/ServerBrowser.unity.meta
+++ b/client/Unity/Assets/Scenes/ServerBrowser.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: dfcf9f623a9648d79858c1ace3f1f31a
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/client/Unity/Assets/Scripts/Runtime/UI/MainMenuController.cs
+++ b/client/Unity/Assets/Scripts/Runtime/UI/MainMenuController.cs
@@ -20,6 +20,7 @@ namespace SlopArena.Client.UI
             var btnHost        = root.Q<Button>("btn-host");
             var btnJoin        = root.Q<Button>("btn-join");
             var ipField        = root.Q<TextField>("ip-field");
+            var btnServerBrowser = root.Q<Button>("btn-serverbrowser");
 
             btnTraining.clicked += () =>
             {
@@ -40,6 +41,11 @@ namespace SlopArena.Client.UI
                 MatchConfig.IsHost   = true;
                 MatchConfig.ServerIP = "127.0.0.1";
                 SceneManager.LoadScene("Lobby");
+            };
+
+            btnServerBrowser.clicked += () =>
+            {
+                SceneManager.LoadScene("ServerBrowser");
             };
 
             btnJoin.clicked += () =>

--- a/client/Unity/Assets/Scripts/Runtime/UI/ServerBrowserUI.cs
+++ b/client/Unity/Assets/Scripts/Runtime/UI/ServerBrowserUI.cs
@@ -1,0 +1,118 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UIElements;
+using UnityEngine.SceneManagement;
+using SlopArena.Shared;
+
+namespace SlopArena.Client.UI
+{
+    /// <summary>
+    /// Server browser screen: queries the master server for active game servers,
+    /// displays them, and lets the player join one.
+    /// </summary>
+    public class ServerBrowserUI : MonoBehaviour
+    {
+        [SerializeField] private UIDocument _uiDocument;
+        [SerializeField] private string _masterServerUrl = "http://localhost:5000";
+
+        private MasterServerClient _masterClient;
+        private VisualElement _serverList;
+        private Label _lblStatus;
+
+        private void OnEnable()
+        {
+            var root = _uiDocument.rootVisualElement;
+            _serverList = root.Q<VisualElement>("server-list");
+            _lblStatus   = root.Q<Label>("lbl-status");
+            var btnRefresh = root.Q<Button>("btn-refresh");
+            var btnBack    = root.Q<Button>("btn-back");
+
+            btnRefresh.clicked += RefreshServers;
+            btnBack.clicked += () => SceneManager.LoadScene("MainMenu");
+
+            _masterClient = new MasterServerClient(_masterServerUrl);
+            RefreshServers();
+        }
+
+        private async void RefreshServers()
+        {
+            _serverList.Clear();
+            _lblStatus.style.display = DisplayStyle.Flex;
+
+            if (!_masterClient.IsAuthenticated)
+            {
+                _lblStatus.text = "Authenticating...";
+                bool authed = await _masterClient.AuthenticateGuestAsync();
+                if (!authed)
+                {
+                    _lblStatus.text = "Failed to connect to master server.";
+                    return;
+                }
+            }
+
+            _lblStatus.text = "Loading servers...";
+            var servers = await _masterClient.GetServersAsync();
+            if (servers == null)
+            {
+                _lblStatus.text = "Failed to load server list.";
+                return;
+            }
+
+            if (servers.Count == 0)
+            {
+                _lblStatus.text = "No servers available.";
+                return;
+            }
+
+            _lblStatus.style.display = DisplayStyle.None;
+
+            foreach (var server in servers)
+                _serverList.Add(CreateServerRow(server));
+        }
+
+        private VisualElement CreateServerRow(ServerInfo server)
+        {
+            var row = new VisualElement();
+            row.AddToClassList("server-row");
+
+            var name = new Label(server.Name) { name = "server-name" };
+            name.AddToClassList("server-name");
+
+            var info = new Label($"{server.Region}  —  {server.CurrentMatches}/{server.MaxConcurrentMatches}")
+            {
+                name = "server-info"
+            };
+            info.AddToClassList("server-info");
+
+            var join = new Button(() => JoinServer(server))
+            {
+                text = "JOIN",
+                name = "btn-join"
+            };
+            join.AddToClassList("server-join");
+
+            row.Add(name);
+            row.Add(info);
+            row.Add(join);
+
+            return row;
+        }
+
+        private void JoinServer(ServerInfo server)
+        {
+            MatchConfig.Mode     = GameMode.PvP;
+            MatchConfig.IsHost   = false;
+            MatchConfig.ServerIP = server.IpAddress;
+            MatchConfig.ServerPort = server.Port;
+
+            Debug.Log($"[ServerBrowser] Joining server: {server.Name} ({server.IpAddress}:{server.Port})");
+
+            SceneManager.LoadScene("Lobby");
+        }
+
+        private void OnDisable()
+        {
+            _masterClient?.Dispose();
+        }
+    }
+}

--- a/client/Unity/Assets/Scripts/Runtime/UI/ServerBrowserUI.cs.meta
+++ b/client/Unity/Assets/Scripts/Runtime/UI/ServerBrowserUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 17aeaf67bdc94b5c823d07e98f66af71
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/client/Unity/Assets/UI/MainMenu.uxml
+++ b/client/Unity/Assets/UI/MainMenu.uxml
@@ -7,6 +7,7 @@
             <ui:Button name="btn-multiplayer" text="MULTIPLAYER ›" class="menu-item" />
             <ui:VisualElement name="submenu" class="submenu" style="display: none;">
                 <ui:Button name="btn-host" text="HOST GAME" class="menu-item menu-item--sub" />
+                <ui:Button name="btn-serverbrowser" text="SERVER BROWSER" class="menu-item menu-item--sub" />
                 <ui:VisualElement name="join-row" class="join-row">
                     <ui:Button name="btn-join" text="JOIN GAME" class="menu-item menu-item--sub" />
                     <ui:TextField name="ip-field" value="127.0.0.1" class="ip-input" />

--- a/client/Unity/Assets/UI/ServerBrowser.uxml
+++ b/client/Unity/Assets/UI/ServerBrowser.uxml
@@ -1,0 +1,10 @@
+<ui:UXML xmlns:ui="UnityEngine.UIElements">
+    <ui:Style src="SlopArena.uss" />
+    <ui:VisualElement name="root" class="screen">
+        <ui:Label name="title" text="SERVER BROWSER" class="title" />
+        <ui:VisualElement name="server-list" class="server-list" />
+        <ui:Label name="lbl-status" text="Loading..." class="subtitle" />
+        <ui:Button name="btn-refresh" text="REFRESH" class="btn-primary" />
+        <ui:Button name="btn-back" text="← BACK" class="btn-back" />
+    </ui:VisualElement>
+</ui:UXML>

--- a/client/Unity/Assets/UI/ServerBrowser.uxml.meta
+++ b/client/Unity/Assets/UI/ServerBrowser.uxml.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: c1e8ddbe8c1c459ca4fdc18d73bb2aa9
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 13804, guid: 0000000000000000e000000000000000, type: 0}

--- a/client/Unity/Assets/UI/SlopArena.uss
+++ b/client/Unity/Assets/UI/SlopArena.uss
@@ -432,3 +432,65 @@
     bottom: 32px;
     opacity: 0.35;
 }
+
+
+/* ── Server Browser ───────────────────────────────────────── */
+
+.server-list {
+    flex-direction: column;
+    width: 480px;
+    max-height: 360px;
+    overflow: scroll;
+    background-color: #16162a;
+    border-radius: 4px;
+    border-width: 1px;
+    border-color: #2e2e50;
+    padding: 8px 0;
+}
+
+.server-row {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    height: 48px;
+    border-bottom-width: 1px;
+    border-color: #2e2e50;
+    padding-left: 16px;
+    padding-right: 16px;
+}
+
+.server-row.unity-last-child {
+    border-bottom-width: 0;
+}
+
+.server-name {
+    font-size: 14px;
+    color: #f0eee8;
+    -unity-font-style: bold;
+    letter-spacing: 1px;
+    flex-grow: 1;
+}
+
+.server-info {
+    font-size: 12px;
+    color: #7a7a99;
+    letter-spacing: 1px;
+    margin-right: 12px;
+}
+
+.server-join {
+    width: 80px;
+    height: 32px;
+    border-radius: 3px;
+    background-color: #e05c2a;
+    border-width: 0;
+    color: #f0eee8;
+    font-size: 11px;
+    letter-spacing: 2px;
+    -unity-text-align: middle-center;
+    -unity-font-style: bold;
+}
+
+.server-join:hover {
+    background-color: #f07040;
+}

--- a/docs/systems/master-server.md
+++ b/docs/systems/master-server.md
@@ -63,8 +63,9 @@ The game server (`src/Server`) points at the master server via `ServerConfig.Mas
 | POST | `/servers/register` | none (issues token) | `{ "serverId": "<guid>", "apiToken": "<guid>" }` |
 | POST | `/servers/{serverId}/heartbeat` | Bearer `apiToken` | `{ "status": "ok" }` |
 | POST | `/match/result` | Bearer `apiToken` | `{ "status": "recorded", "mmrChange": <int> }` (match row must already exist, else 404) |
+| GET | `/servers` | Bearer JWT | `[ { id, name, ipAddress, port, region, currentMatches, maxConcurrentMatches, isOfficial } ]` — heartbeat-fresh (< 15s), non-full servers |
 
-**Not yet implemented** (later roadmap tickets): `GET /servers` browser list (Phase 1.2), `LobbyHub` SignalR hub (Phase 2.1).
+**Not yet implemented** (later roadmap tickets): `LobbyHub` SignalR hub (Phase 2.1).
 
 ### Smoke test
 

--- a/src/Shared/MasterServerClient.cs
+++ b/src/Shared/MasterServerClient.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -128,6 +129,80 @@ namespace SlopArena.Shared
             }
         }
 
+        /// <summary>
+        /// Fetch the server browser list: GET /servers (requires prior auth).
+        /// Returns null if not authenticated, network error, or non-2xx response.
+        /// Returns an empty list if the server is up but has no servers to list.
+        /// </summary>
+        public async Task<List<ServerInfo>?> GetServersAsync(CancellationToken ct = default)
+        {
+            if (!IsAuthenticated)
+                return null;
+
+            try
+            {
+                using var response = await _http.GetAsync("servers", ct);
+                if (!response.IsSuccessStatusCode)
+                    return null;
+
+                var json = await response.Content.ReadAsStringAsync();
+                return ParseServerList(json);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Parse a JSON array of flat server objects into ServerInfo list.
+        /// Objects are flat (no nesting), so regex block extraction is safe.
+        /// </summary>
+        private static List<ServerInfo> ParseServerList(string json)
+        {
+            var result = new List<ServerInfo>();
+
+            // Match each {...} block (objects are flat — no nested braces)
+            var blockMatches = Regex.Matches(json, @"\{[^{}]*\}");
+
+            foreach (Match block in blockMatches)
+            {
+                var obj = block.Value;
+
+                var idStr = ExtractStringField(obj, "id");
+                var name = ExtractStringField(obj, "name");
+                var ipAddress = ExtractStringField(obj, "ipAddress");
+                var port = ExtractNumberField(obj, "port");
+                var region = ExtractStringField(obj, "region");
+                var currentMatches = ExtractNumberField(obj, "currentMatches");
+                var maxConcurrentMatches = ExtractNumberField(obj, "maxConcurrentMatches");
+                var isOfficial = ExtractBoolField(obj, "isOfficial");
+
+                if (idStr == null || name == null || ipAddress == null ||
+                    port == null || region == null || currentMatches == null ||
+                    maxConcurrentMatches == null || isOfficial == null)
+                    continue;
+
+                result.Add(new ServerInfo
+                {
+                    Id = Guid.Parse(idStr),
+                    Name = name,
+                    IpAddress = ipAddress,
+                    Port = (int)port.Value,
+                    Region = region,
+                    CurrentMatches = (int)currentMatches.Value,
+                    MaxConcurrentMatches = (int)maxConcurrentMatches.Value,
+                    IsOfficial = isOfficial.Value
+                });
+            }
+
+            return result;
+        }
+
         // ── Lightweight JSON field extraction (avoids System.Text.Json dependency) ──
         // Safe for controlled API responses: JWT tokens are base64url (no quotes),
         // guest usernames are alphanumeric+dashes, numbers are non-negative integers.
@@ -142,6 +217,14 @@ namespace SlopArena.Shared
         {
             var match = Regex.Match(json, $"\"{fieldName}\"\\s*:\\s*(\\d+)");
             return match.Success ? long.Parse(match.Groups[1].Value) : null;
+        }
+
+        private static bool? ExtractBoolField(string json, string fieldName)
+        {
+            var match = Regex.Match(json, $"\"{fieldName}\"\\s*:\\s*(true|false)");
+            if (!match.Success)
+                return null;
+            return match.Groups[1].Value == "true";
         }
 
         public void Dispose()

--- a/src/Shared/ServerInfo.cs
+++ b/src/Shared/ServerInfo.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace SlopArena.Shared
+{
+    /// <summary>
+    /// A game server entry in the server browser list (GET /servers).
+    /// </summary>
+    public class ServerInfo
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string IpAddress { get; set; } = string.Empty;
+        public int Port { get; set; }
+        public string Region { get; set; } = string.Empty;
+        public int CurrentMatches { get; set; }
+        public int MaxConcurrentMatches { get; set; }
+        public bool IsOfficial { get; set; }
+    }
+}

--- a/tests/Shared.Tests/MasterServerClientTests.cs
+++ b/tests/Shared.Tests/MasterServerClientTests.cs
@@ -207,5 +207,99 @@ namespace SlopArena.Tests
             });
             Assert.True(await client.AuthenticateGuestAsync());
         }
+
+        // ── GetServersAsync ──
+
+        private const string ServerListJson =
+            "[{\"id\":\"a1b2c3d4-e5f6-7890-abcd-ef1234567890\"," +
+            "\"name\":\"Test EU Server\"," +
+            "\"ipAddress\":\"127.0.0.1\"," +
+            "\"port\":9876," +
+            "\"region\":\"eu-west\"," +
+            "\"currentMatches\":2," +
+            "\"maxConcurrentMatches\":15," +
+            "\"isOfficial\":true}," +
+            "{\"id\":\"b2c3d4e5-f6a7-8901-bcde-f12345678901\"," +
+            "\"name\":\"Community US\"," +
+            "\"ipAddress\":\"10.0.0.5\"," +
+            "\"port\":9877," +
+            "\"region\":\"us-east\"," +
+            "\"currentMatches\":0," +
+            "\"maxConcurrentMatches\":8," +
+            "\"isOfficial\":false}]";
+
+        [Fact]
+        public async Task GetServers_ReturnsServerListAfterAuth()
+        {
+            string? capturedAuthHeader = null;
+            using var client = MakeClient(req =>
+            {
+                if (req.RequestUri!.ToString().Contains("auth/guest"))
+                    return GuestAuthResponse();
+
+                Assert.Equal("http://test/servers", req.RequestUri!.ToString());
+                Assert.Equal(HttpMethod.Get, req.Method);
+                capturedAuthHeader = req.Headers.Authorization?.ToString();
+                return JsonOk(ServerListJson);
+            });
+
+            await client.AuthenticateGuestAsync();
+            var servers = await client.GetServersAsync();
+
+            Assert.NotNull(servers);
+            Assert.Equal(2, servers!.Count);
+            Assert.Equal($"Bearer {SampleToken}", capturedAuthHeader);
+
+            var s0 = servers[0];
+            Assert.Equal("a1b2c3d4-e5f6-7890-abcd-ef1234567890", s0.Id.ToString());
+            Assert.Equal("Test EU Server", s0.Name);
+            Assert.Equal("127.0.0.1", s0.IpAddress);
+            Assert.Equal(9876, s0.Port);
+            Assert.Equal("eu-west", s0.Region);
+            Assert.Equal(2, s0.CurrentMatches);
+            Assert.Equal(15, s0.MaxConcurrentMatches);
+            Assert.True(s0.IsOfficial);
+
+            var s1 = servers[1];
+            Assert.Equal("b2c3d4e5-f6a7-8901-bcde-f12345678901", s1.Id.ToString());
+            Assert.False(s1.IsOfficial);
+            Assert.Equal("us-east", s1.Region);
+        }
+
+        [Fact]
+        public async Task GetServers_ReturnsNullBeforeAuth()
+        {
+            using var client = MakeClient(_ => JsonOk("[]"));
+            var servers = await client.GetServersAsync();
+            Assert.Null(servers);
+        }
+
+        [Fact]
+        public async Task GetServers_ReturnsEmptyListWhenNoServers()
+        {
+            using var client = MakeClient(req =>
+                req.RequestUri!.ToString().Contains("auth/guest")
+                    ? GuestAuthResponse()
+                    : JsonOk("[]"));
+
+            await client.AuthenticateGuestAsync();
+            var servers = await client.GetServersAsync();
+
+            Assert.NotNull(servers);
+            Assert.Empty(servers!);
+        }
+
+        [Fact]
+        public async Task GetServers_ReturnsNullOnServerError()
+        {
+            using var client = MakeClient(req =>
+                req.RequestUri!.ToString().Contains("auth/guest")
+                    ? GuestAuthResponse()
+                    : new HttpResponseMessage(HttpStatusCode.InternalServerError));
+
+            await client.AuthenticateGuestAsync();
+            var servers = await client.GetServersAsync();
+            Assert.Null(servers);
+        }
     }
 }


### PR DESCRIPTION
## Summary

Client-side server browser for the PvP demo (issue #31). Pairs with [SlopArena-MasterServer PR #2](https://github.com/Binoui/SlopArena-MasterServer/pull/2).

### Shared (`src/Shared/`)
- **`ServerInfo.cs`** — flat data type matching the `GET /servers` response.
- **`MasterServerClient.GetServersAsync`** — fetches + parses the server list. Dependency-free regex JSON parsing (consistent with existing `ExtractStringField`/`ExtractNumberField`). TDD: 4 new tests (list parse, empty list, null-before-auth, server error). **382/382 tests pass.**

### Unity client (`client/Unity/`)
- **`ServerBrowserUI.cs`** — MonoBehaviour: guest auth → `GET /servers` → builds rows dynamically (server name, region, current/max players, JOIN button). Refresh + Back buttons. Join stores IP+port in `MatchConfig` and logs.
- **`ServerBrowser.uxml`** + USS styles + **`ServerBrowser.unity`** scene (mirrors `Lobby.unity` structure).
- **`MainMenuController.cs` + `MainMenu.uxml`** — "SERVER BROWSER" button in the multiplayer submenu → loads `ServerBrowser` scene.

### Docs
- `docs/systems/master-server.md` — `GET /servers` row added to endpoint table.

## Acceptance criteria

- [x] Client browser UI displays server name, region, and player count
- [x] Clicking "Join" stores the selected server's IP and port
- [x] Browser is reachable from the main menu (Multiplayer → Server Browser)

## Test plan

```bash
dotnet test tests/Shared.Tests/ --nologo
# → Passed: 382, Failed: 0
```

In Unity: MainMenu → Multiplayer → Server Browser → (with master server running) server list populates → click JOIN → Lobby scene loads with correct IP/port in MatchConfig.

Closes #31.