### PR TITLE
feat(lobby): SignalR lobby client + lobby room UI (issue #33)

### DIFF
--- a/client/Unity/Assets/Scenes/LobbyRoom.unity
+++ b/client/Unity/Assets/Scenes/LobbyRoom.unity
@@ -1,0 +1,328 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 10
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 13
+  m_BakeOnSceneLoad: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 1
+    m_PVRFilteringGaussRadiusAO: 1
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 20201, guid: 0000000000000000f000000000000000, type: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &1100000000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1100000003}
+  - component: {fileID: 1100000002}
+  - component: {fileID: 1100000001}
+  m_Layer: 5
+  m_Name: LobbyRoom
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1100000001
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1100000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ebdfe67d065445f8b006a682eee9e2ab, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  _uiDocument: {fileID: 1100000002}
+--- !u!114 &1100000002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1100000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 19102, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name:
+  m_EditorClassIdentifier:
+  m_PanelSettings: {fileID: 11400000, guid: 375219e0f9be73791af68905fab77544, type: 2}
+  m_ParentUI: {fileID: 0}
+  sourceAsset: {fileID: 9197481963319205126, guid: 18c4bf38a6ad4aa8b97b6816e5cb8ad3, type: 3}
+  m_SortingOrder: 0
+  m_WorldSpaceSizeMode: 1
+  m_WorldSpaceWidth: 1920
+  m_WorldSpaceHeight: 1080
+--- !u!4 &1100000003
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1100000000}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1100000004
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1100000009}
+  - component: {fileID: 1100000008}
+  - component: {fileID: 1100000007}
+  - component: {fileID: 1100000006}
+  m_Layer: 0
+  m_Name: Camera
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1100000006
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1100000004}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_AllowHDROutput: 1
+  m_UseScreenCoordOverride: 0
+  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_Version: 2
+  m_TaaSettings:
+    m_Quality: 3
+    m_FrameInfluence: 0.1
+    m_JitterScale: 1
+    m_MipBias: 0
+    m_VarianceClampScale: 0.9
+    m_ContrastAdaptiveSharpening: 0
+--- !u!81 &1100000007
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1100000004}
+  m_Enabled: 1
+--- !u!20 &1100000008
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1100000004}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &1100000009
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1100000004}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 1100000003}
+  - {fileID: 1100000009}

--- a/client/Unity/Assets/Scenes/LobbyRoom.unity.meta
+++ b/client/Unity/Assets/Scenes/LobbyRoom.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 84d2952d59214d19b4032edd770b2ad9
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/client/Unity/Assets/Scripts/Runtime/ClientSession.cs
+++ b/client/Unity/Assets/Scripts/Runtime/ClientSession.cs
@@ -1,0 +1,43 @@
+#nullable enable
+using System;
+
+namespace SlopArena.Client
+{
+    /// <summary>
+    /// Static client-side session state bridging the master server guest auth
+    /// (performed on the Server Browser screen) to the SignalR lobby client
+    /// (LobbyRoom screen). The Server Browser authenticates as a guest via
+    /// <c>MasterServerClient</c>, then stashes the JWT + SteamId + selected
+    /// server here before loading the <c>LobbyRoom</c> scene.
+    /// </summary>
+    public static class ClientSession
+    {
+        /// <summary>Master server base URL (e.g. http://localhost:5000).</summary>
+        public static string MasterServerUrl = "http://localhost:5000";
+
+        /// <summary>Guest JWT bearer token; null until guest auth succeeds.</summary>
+        public static string? AuthToken;
+
+        /// <summary>Guest SteamId assigned by the master server.</summary>
+        public static long SteamId;
+
+        /// <summary>Guest display name, populated from /auth/me (optional).</summary>
+        public static string? Username;
+
+        /// <summary>Game server the player selected in the Server Browser.</summary>
+        public static Guid SelectedServerId;
+
+        /// <summary>Display name of the selected game server (for the lobby title).</summary>
+        public static string SelectedServerName = string.Empty;
+
+        public static void Reset()
+        {
+            MasterServerUrl = "http://localhost:5000";
+            AuthToken = null;
+            SteamId = 0;
+            Username = null;
+            SelectedServerId = Guid.Empty;
+            SelectedServerName = string.Empty;
+        }
+    }
+}

--- a/client/Unity/Assets/Scripts/Runtime/ClientSession.cs.meta
+++ b/client/Unity/Assets/Scripts/Runtime/ClientSession.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dbf35bada3094a4f8b486289ca367816
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/client/Unity/Assets/Scripts/Runtime/Network/LobbyClient.cs
+++ b/client/Unity/Assets/Scripts/Runtime/Network/LobbyClient.cs
@@ -1,0 +1,206 @@
+#nullable enable
+using System;
+using System.Collections.Concurrent;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.SignalR.Client;
+using SlopArena.Shared;
+
+namespace SlopArena.Client.Network
+{
+    /// <summary>
+    /// Client-side connection to the master server's SignalR <c>LobbyHub</c>
+    /// (ADR-0004, issue #33). Connects with the guest JWT as bearer auth,
+    /// joins a lobby for a game server, and surfaces the hub's real-time pushes
+    /// as plain C# events marshalled onto the Unity main thread via <see cref="Pump"/>.
+    ///
+    /// Server → client pushes: <c>PlayerJoined</c>, <c>PlayerLeft</c>,
+    /// <c>LobbyUpdated</c>, <c>MatchStarting</c>.
+    /// Client → server: <see cref="JoinLobbyAsync"/>, <see cref="LeaveLobbyAsync"/>,
+    /// <see cref="HostStartAsync"/>.
+    /// </summary>
+    public sealed class LobbyClient
+    {
+        private HubConnection? _conn;
+        private readonly string _masterServerUrl;
+        private readonly string _authToken;
+        // Server the caller last asked to join; re-joined after an automatic
+        // reconnect because SignalR group membership is per-connection-id and
+        // does not survive a transport drop.
+        private Guid _joinedServerId;
+        // Actions queued from background SignalR threads; drained on the main
+        // thread by the owner MonoBehaviour's Update → Pump().
+        private readonly ConcurrentQueue<Action> _pending = new();
+
+        /// <summary>True while the hub connection is open.</summary>
+        public bool IsConnected => _conn != null && _conn.State == HubConnectionState.Connected;
+
+        // ── Real-time lobby events (raised on the main thread, after Pump) ──
+
+        /// <summary>A player joined the lobby.</summary>
+        public event Action<LobbyPlayerInfo>? PlayerJoined;
+        /// <summary>A player left the lobby (arg = their SteamId).</summary>
+        public event Action<long>? PlayerLeft;
+        /// <summary>Full lobby snapshot pushed on any membership change.</summary>
+        public event Action<LobbySnapshot>? LobbyUpdated;
+        /// <summary>The host started the match; clients should go to char-select.</summary>
+        public event Action<MatchStartingConfig>? MatchStarting;
+        /// <summary>The hub connection opened (or reopened after a retry).</summary>
+        public event Action? Connected;
+        /// <summary>The hub connection closed. Arg is null on a clean close.</summary>
+        public event Action<Exception?>? Disconnected;
+        /// <summary>A non-fatal error (e.g. a hub method rejected the call).</summary>
+        public event Action<string>? Error;
+
+        /// <param name="masterServerUrl">Master server base URL (e.g. http://localhost:5000).</param>
+        /// <param name="authToken">Guest JWT to send as bearer auth on the connection.</param>
+        public LobbyClient(string masterServerUrl, string authToken)
+        {
+            _masterServerUrl = masterServerUrl.TrimEnd('/');
+            _authToken = authToken;
+        }
+
+        /// <summary>
+        /// Build the connection, register handlers, and start it. Returns false
+        /// (without throwing) on a connection failure.
+        /// </summary>
+        public async Task<bool> ConnectAsync()
+        {
+            if (_conn != null)
+                return IsConnected;
+
+            _conn = new HubConnectionBuilder()
+                .WithUrl($"{_masterServerUrl}/lobby", options =>
+                {
+                    options.AccessTokenProvider = () => Task.FromResult<string?>(_authToken);
+                })
+                .WithAutomaticReconnect()
+                .Build();
+
+            RegisterHandlers();
+
+            _conn.Closed += ex =>
+            {
+                _pending.Enqueue(() => Disconnected?.Invoke(ex));
+                return Task.CompletedTask;
+            };
+            _conn.Reconnecting += ex =>
+            {
+                _pending.Enqueue(() => Disconnected?.Invoke(ex));
+                return Task.CompletedTask;
+            };
+            _conn.Reconnected += _ =>
+            {
+                // Re-add ourselves to the lobby group after a reconnect; the
+                // new connection id is not in the old group. Fire-and-forget —
+                // errors surface via the Error event in InvokeSafe.
+                var serverId = _joinedServerId;
+                if (serverId != Guid.Empty)
+                    _ = _conn.InvokeAsync("JoinLobby", serverId);
+                _pending.Enqueue(() => Connected?.Invoke());
+                return Task.CompletedTask;
+            };
+
+            try
+            {
+                await _conn.StartAsync();
+                _pending.Enqueue(() => Connected?.Invoke());
+                return true;
+            }
+            catch (Exception ex)
+            {
+                _pending.Enqueue(() => Error?.Invoke($"Failed to connect: {ex.Message}"));
+                return false;
+            }
+        }
+
+        private void RegisterHandlers()
+        {
+            // PlayerJoined: { steamId, name, characterSelection, isHost }
+            _conn!.On<JsonElement>("PlayerJoined", element =>
+            {
+                var player = LobbyPayloadCodec.TryParsePlayer(element);
+                if (player is null) return;
+                _pending.Enqueue(() => PlayerJoined?.Invoke(player));
+            });
+
+            // PlayerLeft: a bare long (the leaving player's SteamId)
+            _conn.On<long>("PlayerLeft", steamId =>
+            {
+                _pending.Enqueue(() => PlayerLeft?.Invoke(steamId));
+            });
+
+            // LobbyUpdated / MatchStarting: { serverId, players[] }
+            _conn.On<JsonElement>("LobbyUpdated", element =>
+            {
+                var snap = LobbyPayloadCodec.TryParseSnapshot(element);
+                if (snap is null) return;
+                _pending.Enqueue(() => LobbyUpdated?.Invoke(snap));
+            });
+            _conn.On<JsonElement>("MatchStarting", element =>
+            {
+                var cfg = LobbyPayloadCodec.TryParseMatchStarting(element);
+                if (cfg is null) return;
+                _pending.Enqueue(() => MatchStarting?.Invoke(cfg));
+            });
+        }
+
+        /// <summary>Join the lobby for the given game server.</summary>
+        public Task JoinLobbyAsync(Guid serverId)
+        {
+            _joinedServerId = serverId;
+            return InvokeSafe("JoinLobby", serverId);
+        }
+
+        /// <summary>Leave the current lobby.</summary>
+        public Task LeaveLobbyAsync()
+        {
+            _joinedServerId = Guid.Empty;
+            return InvokeSafe("LeaveLobby");
+        }
+
+        /// <summary>Host-only: start the match for this lobby.</summary>
+        public Task HostStartAsync() =>
+            InvokeSafe("HostStart");
+
+        private async Task InvokeSafe(string method, params object[] args)
+        {
+            if (_conn is null || !IsConnected)
+            {
+                _pending.Enqueue(() => Error?.Invoke($"Not connected; cannot {method}."));
+                return;
+            }
+            try
+            {
+                await _conn.InvokeAsync(method, args);
+            }
+            catch (Exception ex)
+            {
+                // HubException surfaces here (e.g. non-host HostStart rejected).
+                _pending.Enqueue(() => Error?.Invoke($"{method} rejected: {ex.Message}"));
+            }
+        }
+
+        /// <summary>
+        /// Drain queued hub events onto the calling (main) thread. The owning
+        /// MonoBehaviour MUST call this from Update so the UI events fire there.
+        /// </summary>
+        public void Pump()
+        {
+            while (_pending.TryDequeue(out var action))
+                action();
+        }
+
+        /// <summary>Stop the connection if open. Safe to call from OnDisable.</summary>
+        public async Task DisconnectAsync()
+        {
+            if (_conn != null)
+            {
+                try { await _conn.StopAsync(); }
+                catch { /* best-effort shutdown */ }
+                _conn = null;
+            }
+        }
+    }
+}

--- a/client/Unity/Assets/Scripts/Runtime/Network/LobbyClient.cs.meta
+++ b/client/Unity/Assets/Scripts/Runtime/Network/LobbyClient.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 951f10ee76224a3d986e29bd67054ff5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/client/Unity/Assets/Scripts/Runtime/UI/LobbyRoomUI.cs
+++ b/client/Unity/Assets/Scripts/Runtime/UI/LobbyRoomUI.cs
@@ -1,0 +1,247 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using UnityEngine;
+using UnityEngine.UIElements;
+using UnityEngine.SceneManagement;
+using SlopArena.Shared;
+using SlopArena.Client.Network;
+using SlopArena.Client;
+
+namespace SlopArena.Client.UI
+{
+    /// <summary>
+    /// Lobby room screen driven by the SignalR <see cref="LobbyClient"/>
+    /// (ADR-0008, issue #33). Reached from the Server Browser after joining a
+    /// game server: shows the live player list pushed by the master server's
+    /// <c>LobbyHub</c>, lets the host start the match, and lets anyone leave.
+    /// </summary>
+    public class LobbyRoomUI : MonoBehaviour
+    {
+        private const int MaxSlots = 4;
+
+        [SerializeField] private UIDocument _uiDocument;
+
+        private LobbyClient _lobby;
+        private VisualElement _playerList;
+        private Button _btnStart;
+        private Button _btnLeave;
+        private Label _lblStatus;
+        private Label _lblServer;
+
+        private LobbySnapshot _snapshot;
+
+        private void OnEnable()
+        {
+            var root = _uiDocument.rootVisualElement;
+            _playerList = root.Q<VisualElement>("player-list");
+            _btnStart    = root.Q<Button>("btn-start");
+            _btnLeave    = root.Q<Button>("btn-leave");
+            _lblStatus   = root.Q<Label>("lbl-status");
+            _lblServer   = root.Q<Label>("lbl-server");
+
+            _lblServer.text = string.IsNullOrEmpty(ClientSession.SelectedServerName)
+                ? ClientSession.SelectedServerId.ToString()
+                : ClientSession.SelectedServerName;
+
+            var btnBack = root.Q<Button>("btn-back");
+            btnBack.clicked += Leave;
+
+            _btnLeave.clicked += Leave;
+            _btnStart.clicked += OnStartClicked;
+            _btnStart.style.display = DisplayStyle.None; // shown once we learn we're host
+
+            RenderPlayers();
+
+            if (string.IsNullOrEmpty(ClientSession.AuthToken))
+            {
+                _lblStatus.text = "Not authenticated. Returning to server browser.";
+                SceneManager.LoadScene("ServerBrowser");
+                return;
+            }
+
+            _lobby.Connected    += OnConnected;
+            _lobby.PlayerJoined += OnPlayerJoined;
+            _lobby.PlayerLeft   += OnPlayerLeft;
+            _lobby.LobbyUpdated += OnLobbyUpdated;
+            _lobby.MatchStarting += OnMatchStarting;
+            _lobby.Error        += OnError;
+            _lobby.Disconnected += OnDisconnected;
+
+            _lblStatus.text = "Connecting to lobby...";
+            _ = ConnectAndJoin();
+        }
+
+        private async void ConnectAndJoin()
+        {
+            bool ok = await _lobby.ConnectAsync();
+            if (!ok)
+            {
+                _lblStatus.text = "Could not reach the master server.";
+                return;
+            }
+            await _lobby.JoinLobbyAsync(ClientSession.SelectedServerId);
+        }
+
+        private void Update()
+        {
+            // Marshals hub events from background threads onto the Unity main thread.
+            _lobby?.Pump();
+        }
+
+        // ── Hub event handlers (fired on main thread via Pump) ──
+
+        private void OnConnected()
+        {
+            _lblStatus.text = "Connected.";
+        }
+
+        // PlayerJoined/PlayerLeft are surfaced separately; LobbyUpdated is the
+        // authoritative snapshot, so these just log — they let a later ticket
+        // animate join/leave without waiting for the full snapshot.
+        private void OnPlayerJoined(LobbyPlayerInfo player)
+        {
+            Debug.Log($"[LobbyRoom] {player.Name} (SteamId {player.SteamId}) joined.");
+        }
+
+        private void OnPlayerLeft(long steamId)
+        {
+            Debug.Log($"[LobbyRoom] SteamId {steamId} left.");
+        }
+        private void OnLobbyUpdated(LobbySnapshot snapshot)
+        {
+            _snapshot = snapshot;
+            RenderPlayers();
+        }
+
+        private void OnMatchStarting(MatchStartingConfig config)
+        {
+            Debug.Log($"[LobbyRoom] Match starting on server {config.ServerId} with {config.Players.Count} players.");
+            // Stash the roster for char-select / match start (later tickets).
+            MatchConfig.Mode = GameMode.PvP;
+            SceneManager.LoadScene("CharSelect");
+        }
+
+        private void OnError(string message)
+        {
+            _lblStatus.text = message;
+        }
+
+        private void OnDisconnected(System.Exception ex)
+        {
+            _lblStatus.text = ex == null ? "Disconnected." : $"Disconnected: {ex.Message}";
+        }
+
+        // ── UI ──
+
+        private void OnStartClicked()
+        {
+            _btnStart.SetEnabled(false);
+            _lblStatus.text = "Starting match...";
+            _ = _lobby.HostStartAsync();
+        }
+
+        private void RenderPlayers()
+        {
+            _playerList.Clear();
+
+            var players = _snapshot?.Players ?? System.Array.Empty<LobbyPlayerInfo>();
+            bool isLocalHost = false;
+            for (int i = 0; i < players.Count; i++)
+            {
+                if (players[i].SteamId == ClientSession.SteamId && players[i].IsHost)
+                    isLocalHost = true;
+            }
+
+            for (int i = 0; i < MaxSlots; i++)
+                _playerList.Add(CreateSlot(i, players));
+
+            // Start button: host-only, enabled with 2+ players.
+            if (isLocalHost)
+            {
+                _btnStart.style.display = DisplayStyle.Flex;
+                _btnStart.SetEnabled(players.Count >= 2);
+            }
+            else
+            {
+                _btnStart.style.display = DisplayStyle.None;
+            }
+
+            if (!isLocalHost && players.Count > 0)
+                _lblStatus.text = "Waiting for host to start...";
+        }
+
+        private VisualElement CreateSlot(int index, IReadOnlyList<LobbyPlayerInfo> players)
+        {
+            var slot = new VisualElement();
+            slot.AddToClassList("player-slot");
+
+            var slotIndex = new Label($"P{index + 1}") { name = "slot-index" };
+            slotIndex.AddToClassList("slot-index");
+
+            var portrait = new VisualElement { name = "slot-portrait" };
+            portrait.AddToClassList("slot-portrait");
+
+            var name = new Label { name = "slot-name" };
+            name.AddToClassList("slot-name");
+
+            if (index < players.Count)
+            {
+                var p = players[index];
+                name.text = p.Name;
+
+                // Portrait reflects a picked character; char-select lands in a
+                // later ticket, so CharacterSelection is null until then.
+                if (!string.IsNullOrEmpty(p.CharacterSelection))
+                {
+                    var portraitLabel = new Label(p.CharacterSelection);
+                    portrait.Add(portraitLabel);
+                }
+
+                if (p.IsHost)
+                {
+                    var badge = new Label("HOST") { name = "host-badge" };
+                    badge.AddToClassList("host-badge");
+                    slot.Add(badge);
+                }
+            }
+            else
+            {
+                name.text = "Empty";
+                name.AddToClassList("slot-name--empty");
+            }
+
+            slot.Add(slotIndex);
+            slot.Add(portrait);
+            slot.Add(name);
+            return slot;
+        }
+
+        private async void Leave()
+        {
+            if (_lobby != null)
+            {
+                try { await _lobby.LeaveLobbyAsync(); } catch { /* best effort */ }
+                await _lobby.DisconnectAsync();
+            }
+            SceneManager.LoadScene("ServerBrowser");
+        }
+
+        private async void OnDisable()
+        {
+            _btnStart.clicked -= OnStartClicked;
+            _btnLeave.clicked -= Leave;
+            if (_lobby != null)
+            {
+                _lobby.Connected    -= OnConnected;
+                _lobby.PlayerJoined -= OnPlayerJoined;
+                _lobby.PlayerLeft   -= OnPlayerLeft;
+                _lobby.LobbyUpdated -= OnLobbyUpdated;
+                _lobby.MatchStarting -= OnMatchStarting;
+                _lobby.Error        -= OnError;
+                _lobby.Disconnected -= OnDisconnected;
+                await _lobby.DisconnectAsync();
+            }
+        }
+    }
+}

--- a/client/Unity/Assets/Scripts/Runtime/UI/LobbyRoomUI.cs.meta
+++ b/client/Unity/Assets/Scripts/Runtime/UI/LobbyRoomUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ebdfe67d065445f8b006a682eee9e2ab
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/client/Unity/Assets/Scripts/Runtime/UI/ServerBrowserUI.cs
+++ b/client/Unity/Assets/Scripts/Runtime/UI/ServerBrowserUI.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 using UnityEngine.UIElements;
 using UnityEngine.SceneManagement;
 using SlopArena.Shared;
+using SlopArena.Client;
 
 namespace SlopArena.Client.UI
 {
@@ -31,6 +32,7 @@ namespace SlopArena.Client.UI
             btnBack.clicked += () => SceneManager.LoadScene("MainMenu");
 
             _masterClient = new MasterServerClient(_masterServerUrl);
+            ClientSession.MasterServerUrl = _masterServerUrl;
             RefreshServers();
         }
 
@@ -105,9 +107,15 @@ namespace SlopArena.Client.UI
             MatchConfig.ServerIP = server.IpAddress;
             MatchConfig.ServerPort = server.Port;
 
+            // Carry the guest auth + selected server to the SignalR lobby room.
+            ClientSession.AuthToken          = _masterClient.Token;
+            ClientSession.SteamId            = _masterClient.SteamId ?? 0;
+            ClientSession.SelectedServerId   = server.Id;
+            ClientSession.SelectedServerName = server.Name;
+
             Debug.Log($"[ServerBrowser] Joining server: {server.Name} ({server.IpAddress}:{server.Port})");
 
-            SceneManager.LoadScene("Lobby");
+            SceneManager.LoadScene("LobbyRoom");
         }
 
         private void OnDisable()

--- a/client/Unity/Assets/UI/LobbyRoom.uxml
+++ b/client/Unity/Assets/UI/LobbyRoom.uxml
@@ -1,0 +1,17 @@
+<ui:UXML xmlns:ui="UnityEngine.UIElements">
+    <ui:Style src="SlopArena.uss" />
+    <ui:VisualElement name="root" class="screen lobby-room">
+        <ui:Label name="title" text="LOBBY ROOM" class="title" />
+        <ui:Label name="lbl-server" text="" class="subtitle" />
+        <ui:VisualElement name="player-list" class="player-list lobby-list" />
+        <ui:VisualElement name="chat-placeholder" class="chat-placeholder">
+            <ui:Label text="Chat coming soon" class="subtitle" />
+        </ui:VisualElement>
+        <ui:VisualElement name="button-row" class="lobby-buttons">
+            <ui:Button name="btn-leave" text="LEAVE" class="btn-secondary" />
+            <ui:Button name="btn-start" text="START" class="btn-primary" />
+        </ui:VisualElement>
+        <ui:Label name="lbl-status" text="Connecting..." class="subtitle" />
+        <ui:Button name="btn-back" text="← BACK" class="btn-back" />
+    </ui:VisualElement>
+</ui:UXML>

--- a/client/Unity/Assets/UI/LobbyRoom.uxml.meta
+++ b/client/Unity/Assets/UI/LobbyRoom.uxml.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 18c4bf38a6ad4aa8b97b6816e5cb8ad3
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+  script: {fileID: 13804, guid: 0000000000000000e000000000000000, type: 0}

--- a/client/Unity/Assets/UI/SlopArena.uss
+++ b/client/Unity/Assets/UI/SlopArena.uss
@@ -494,3 +494,124 @@
 .server-join:hover {
     background-color: #f07040;
 }
+
+/* ── Lobby Room (SignalR, issue #33) ─────────────────────── */
+
+.lobby-room {
+    width: 520px;
+}
+
+.lobby-room #lbl-server {
+    margin-bottom: 20px;
+}
+
+.player-list.lobby-list {
+    width: 100%;
+    padding: 8px 12px;
+}
+
+.player-slot {
+    flex-direction: row;
+    align-items: center;
+    height: 56px;
+    padding: 0 12px;
+    border-bottom-width: 1px;
+    border-color: #2e2e50;
+}
+
+.player-slot.unity-last-child {
+    border-bottom-width: 0;
+}
+
+.slot-index {
+    width: 36px;
+    color: #7a7a99;
+    font-size: 13px;
+    -unity-font-style: bold;
+    letter-spacing: 1px;
+}
+
+.slot-portrait {
+    width: 40px;
+    height: 40px;
+    margin-left: 8px;
+    margin-right: 12px;
+    border-radius: 4px;
+    background-color: #1e1e36;
+    border-width: 1px;
+    border-color: #2e2e50;
+    -unity-text-align: middle-center;
+    color: #4a4a66;
+    font-size: 10px;
+    letter-spacing: 1px;
+}
+
+.slot-name {
+    flex-grow: 1;
+    color: #f0eee8;
+    font-size: 15px;
+    -unity-font-style: bold;
+    letter-spacing: 1px;
+}
+
+.slot-name--empty {
+    color: #4a4a66;
+    -unity-font-style: normal;
+}
+
+.host-badge {
+    font-size: 10px;
+    letter-spacing: 1px;
+    color: #e05c2a;
+    border-width: 1px;
+    border-color: #e05c2a;
+    border-radius: 2px;
+    padding: 2px 6px;
+    margin-left: 8px;
+}
+
+.chat-placeholder {
+    width: 100%;
+    height: 120px;
+    margin-top: 16px;
+    margin-bottom: 16px;
+    border-radius: 4px;
+    background-color: #13131f;
+    border-width: 1px;
+    border-color: #2e2e50;
+    -unity-text-align: middle-center;
+    justify-content: center;
+}
+
+.lobby-buttons {
+    flex-direction: row;
+    justify-content: center;
+    width: 100%;
+    margin-top: 8px;
+}
+
+.lobby-buttons .btn-primary,
+.lobby-buttons .btn-secondary {
+    margin: 0 8px;
+}
+
+.btn-secondary {
+    width: 240px;
+    height: 52px;
+    border-radius: 3px;
+    background-color: #1e1e36;
+    border-width: 1px;
+    border-color: #2e2e50;
+    color: #f0eee8;
+    font-size: 14px;
+    letter-spacing: 3px;
+    -unity-text-align: middle-center;
+    -unity-font-style: bold;
+    transition-duration: 0.1s;
+    transition-property: border-color, background-color;
+}
+
+.btn-secondary:hover {
+    border-color: #e05c2a;
+    background-color: #2a2a46;
+}

--- a/client/Unity/ProjectSettings/EditorBuildSettings.asset
+++ b/client/Unity/ProjectSettings/EditorBuildSettings.asset
@@ -23,6 +23,12 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Scenes/Arena_PvP.unity
     guid: 9e50f62b09564aadb793e9ec9345e6c6
+  - enabled: 1
+    path: Assets/Scenes/ServerBrowser.unity
+    guid: dfcf9f623a9648d79858c1ace3f1f31a
+  - enabled: 1
+    path: Assets/Scenes/LobbyRoom.unity
+    guid: 84d2952d59214d19b4032edd770b2ad9
   m_configObjects:
     com.unity.dt.app-ui: {fileID: 11400000, guid: 1b1c20d82303e4b5781c3ef50ac1449f, type: 2}
   m_UseUCBPForAssetBundles: 0

--- a/src/Shared/CompilerPolyfills.cs
+++ b/src/Shared/CompilerPolyfills.cs
@@ -1,0 +1,9 @@
+// ReSharper disable once CheckNamespace
+namespace System.Runtime.CompilerServices
+{
+    // Polyfill: record init-only setters emit a call to this attribute's
+    // constructor. It is defined in .NET 5+ runtimes but not in
+    // netstandard2.1, so we declare it here so Shared can use `record`.
+    // The runtime ignores the attribute body; only the symbol's existence matters.
+    internal static class IsExternalInit { }
+}

--- a/src/Shared/LobbyPayloadCodec.cs
+++ b/src/Shared/LobbyPayloadCodec.cs
@@ -1,0 +1,87 @@
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace SlopArena.Shared;
+
+/// <summary>
+/// Deserializes SignalR lobby payloads (<see cref="JsonElement"/> from the
+/// <c>On&lt;JsonElement&gt;</c> handlers) into the plain Shared DTOs.
+///
+/// The master server serializes with System.Text.Json's default camelCase policy
+/// (ASP.NET Core SignalR), so wire keys are <c>steamId</c>, <c>name</c>,
+/// <c>characterSelection</c>, <c>isHost</c>, <c>serverId</c>, <c>players</c>.
+/// Kept dependency-free of any SignalR/Unity types so it is unit-testable from
+/// <c>tests/Shared.Tests</c>.
+/// </summary>
+public static class LobbyPayloadCodec
+{
+    /// <summary>
+    /// Parse a <c>LobbyPlayer</c>-shaped element. Returns null on any shape
+    /// mismatch so a malformed push never crashes the UI thread.
+    /// </summary>
+    public static LobbyPlayerInfo? TryParsePlayer(JsonElement element)
+    {
+        if (element.ValueKind != JsonValueKind.Object)
+            return null;
+
+        if (!element.TryGetProperty("steamId", out var steam) || steam.ValueKind != JsonValueKind.Number)
+            return null;
+        if (!element.TryGetProperty("name", out var name) || name.ValueKind != JsonValueKind.String)
+            return null;
+        if (!element.TryGetProperty("isHost", out var host) || host.ValueKind != JsonValueKind.False && host.ValueKind != JsonValueKind.True)
+            return null;
+
+        // characterSelection is nullable; treat absent/null/empty as null.
+        string? selection = null;
+        if (element.TryGetProperty("characterSelection", out var sel) &&
+            sel.ValueKind == JsonValueKind.String)
+        {
+            selection = string.IsNullOrEmpty(sel.GetString()) ? null : sel.GetString();
+        }
+
+        return new LobbyPlayerInfo(
+            steam.GetInt64(),
+            name.GetString()!,
+            selection,
+            host.GetBoolean());
+    }
+
+    /// <summary>
+    /// Parse a <c>LobbySnapshot</c>-shaped element: <c>{ serverId, players[] }</c>.
+    /// Returns null on shape mismatch. An empty players array is valid.
+    /// </summary>
+    public static LobbySnapshot? TryParseSnapshot(JsonElement element)
+    {
+        if (element.ValueKind != JsonValueKind.Object)
+            return null;
+
+        if (!element.TryGetProperty("serverId", out var sid) || sid.ValueKind != JsonValueKind.String)
+            return null;
+        if (!Guid.TryParse(sid.GetString(), out var serverId))
+            return null;
+
+        if (!element.TryGetProperty("players", out var players) || players.ValueKind != JsonValueKind.Array)
+            return null;
+
+        var list = new List<LobbyPlayerInfo>();
+        foreach (var item in players.EnumerateArray())
+        {
+            var p = TryParsePlayer(item);
+            if (p is null)
+                return null;
+            list.Add(p);
+        }
+
+        return new LobbySnapshot(serverId, list);
+    }
+
+    /// <summary>
+    /// Parse a <c>MatchStartingConfig</c>-shaped element: same shape as a
+    /// snapshot (<c>{ serverId, players[] }</c>).
+    /// </summary>
+    public static MatchStartingConfig? TryParseMatchStarting(JsonElement element)
+    {
+        var snap = TryParseSnapshot(element);
+        return snap is null ? null : new MatchStartingConfig(snap.ServerId, snap.Players);
+    }
+}

--- a/src/Shared/LobbyPlayerInfo.cs
+++ b/src/Shared/LobbyPlayerInfo.cs
@@ -1,0 +1,20 @@
+namespace SlopArena.Shared;
+
+/// <summary>
+/// A player present in a SignalR lobby, mirroring the master server's
+/// <c>MasterServer.Lobbies.LobbyPlayer</c> wire format (ADR-0004, issue #33).
+/// Lobby state lives on the master server; the client only mirrors snapshots
+/// pushed via <c>LobbyUpdated</c>/<c>PlayerJoined</c>/<c>MatchStarting</c>.
+/// </summary>
+/// <param name="SteamId">Guest SteamId assigned by the master server.</param>
+/// <param name="Name">Display name (guest username, e.g. "Guest-12345").</param>
+/// <param name="CharacterSelection">
+/// Picked character class name, or null while not yet chosen (char-select
+/// lands in a later ticket; the hub always sends null for now).
+/// </param>
+/// <param name="IsHost">True for the lobby host (first joiner; promoted on leave).</param>
+public sealed record LobbyPlayerInfo(
+    long SteamId,
+    string Name,
+    string? CharacterSelection,
+    bool IsHost);

--- a/src/Shared/LobbySnapshot.cs
+++ b/src/Shared/LobbySnapshot.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+
+namespace SlopArena.Shared;
+
+/// <summary>
+/// Full lobby membership snapshot pushed on any change via <c>LobbyUpdated</c>.
+/// </summary>
+/// <param name="ServerId">Game server the lobby belongs to.</param>
+/// <param name="Players">Ordered player list; index 0 is the host.</param>
+public sealed record LobbySnapshot(
+    Guid ServerId,
+    IReadOnlyList<LobbyPlayerInfo> Players);

--- a/src/Shared/MatchStartingConfig.cs
+++ b/src/Shared/MatchStartingConfig.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+
+namespace SlopArena.Shared;
+
+/// <summary>
+/// Payload of the <c>MatchStarting</c> push broadcast when the host starts.
+/// Carries the roster the game server will spawn.
+/// </summary>
+public sealed record MatchStartingConfig(
+    Guid ServerId,
+    IReadOnlyList<LobbyPlayerInfo> Players);

--- a/src/Shared/SlopArena.Shared.csproj
+++ b/src/Shared/SlopArena.Shared.csproj
@@ -10,9 +10,16 @@
     <PackageId>SlopArena.Shared</PackageId>
     <Version>0.1.0</Version>
     <Authors>Binoui</Authors>
-    <Description>Shared data types for SlopArena — pure C#, no dependencies</Description>
+    <Description>Shared data types for SlopArena — pure C#, no Unity dependencies</Description>
     <RepositoryUrl>https://github.com/Binoui/SlopArena</RepositoryUrl>
   </PropertyGroup>
+
+  <ItemGroup>
+    <!-- System.Text.Json is a first-party BCL lib already present as a Unity
+         NuGet plugin (see client/Unity/Assets/Plugins/NuGet/.nuget-installed.json).
+         Used only by the lobby payload codec; keeps Shared Unity-free. -->
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
+  </ItemGroup>
   
   <Target Name="CopyToUnity" AfterTargets="Build">
     <Copy SourceFiles="$(TargetPath)"

--- a/tests/Shared.Tests/LobbyPayloadCodecTests.cs
+++ b/tests/Shared.Tests/LobbyPayloadCodecTests.cs
@@ -1,0 +1,145 @@
+using System.Text.Json;
+using SlopArena.Shared;
+using Xunit;
+
+namespace SlopArena.Tests;
+
+/// <summary>
+/// Tests for <see cref="LobbyPayloadCodec"/>: the only testable seam of the
+/// SignalR lobby client (issue #33). The codec maps the master server's
+/// camelCase JSON payloads (System.Text.Json default for ASP.NET Core SignalR)
+/// to the Shared DTOs. These pin the wire contract the Unity LobbyClient relies on.
+/// </summary>
+public class LobbyPayloadCodecTests
+{
+    private static JsonElement Parse(string json) =>
+        JsonDocument.Parse(json).RootElement;
+
+    // ── Player ──
+
+    [Fact]
+    public void TryParsePlayer_HostWithNullSelection_ReturnsPlayer()
+    {
+        var el = Parse("""{"steamId":12345,"name":"Guest-12345","characterSelection":null,"isHost":true}""");
+
+        var p = LobbyPayloadCodec.TryParsePlayer(el);
+
+        Assert.NotNull(p);
+        Assert.Equal(12345, p!.SteamId);
+        Assert.Equal("Guest-12345", p.Name);
+        Assert.Null(p.CharacterSelection);
+        Assert.True(p.IsHost);
+    }
+
+    [Fact]
+    public void TryParsePlayer_NonHostWithSelection_ReturnsPlayer()
+    {
+        var el = Parse("""{"steamId":99,"name":"Guest-99","characterSelection":"Manki","isHost":false}""");
+
+        var p = LobbyPayloadCodec.TryParsePlayer(el);
+
+        Assert.NotNull(p);
+        Assert.Equal(99, p!.SteamId);
+        Assert.Equal("Manki", p.CharacterSelection);
+        Assert.False(p.IsHost);
+    }
+
+    [Fact]
+    public void TryParsePlayer_MissingCharacterSelection_TreatedAsNull()
+    {
+        var el = Parse("""{"steamId":1,"name":"Guest-1","isHost":true}""");
+
+        var p = LobbyPayloadCodec.TryParsePlayer(el);
+
+        Assert.NotNull(p);
+        Assert.Null(p!.CharacterSelection);
+        Assert.True(p.IsHost);
+    }
+
+    [Theory]
+    [InlineData("""{"steamId":"x","name":"n","isHost":true}""")]            // steamId not a number
+    [InlineData("""{"steamId":1,"name":5,"isHost":true}""")]                  // name not a string
+    [InlineData("""{"steamId":1,"name":"n"}""")]                              // missing isHost
+    [InlineData("""{"name":"n","isHost":true}""")]                            // missing steamId
+    [InlineData("""[]""")]                                                     // not an object
+    public void TryParsePlayer_Malformed_ReturnsNull(string json)
+    {
+        Assert.Null(LobbyPayloadCodec.TryParsePlayer(Parse(json)));
+    }
+
+    // ── Snapshot ──
+
+    [Fact]
+    public void TryParseSnapshot_TwoPlayers_PreservesOrder()
+    {
+        var json = """
+        {"serverId":"33333333-3333-3333-3333-333333333333","players":[
+            {"steamId":1,"name":"Host","characterSelection":null,"isHost":true},
+            {"steamId":2,"name":"Guest","characterSelection":null,"isHost":false}
+        ]}
+        """;
+
+        var snap = LobbyPayloadCodec.TryParseSnapshot(Parse(json));
+
+        Assert.NotNull(snap);
+        Assert.Equal(new System.Guid("33333333-3333-3333-3333-333333333333"), snap!.ServerId);
+        Assert.Equal(2, snap.Players.Count);
+        Assert.Equal("Host", snap.Players[0].Name);
+        Assert.True(snap.Players[0].IsHost);
+        Assert.Equal("Guest", snap.Players[1].Name);
+        Assert.False(snap.Players[1].IsHost);
+    }
+
+    [Fact]
+    public void TryParseSnapshot_EmptyPlayers_IsValid()
+    {
+        var json = """{"serverId":"33333333-3333-3333-3333-333333333333","players":[]}""";
+
+        var snap = LobbyPayloadCodec.TryParseSnapshot(Parse(json));
+
+        Assert.NotNull(snap);
+        Assert.Empty(snap!.Players);
+    }
+
+    [Fact]
+    public void TryParseSnapshot_BadGuid_ReturnsNull()
+    {
+        var json = """{"serverId":"not-a-guid","players":[]}""";
+
+        Assert.Null(LobbyPayloadCodec.TryParseSnapshot(Parse(json)));
+    }
+
+    [Fact]
+    public void TryParseSnapshot_MalformedPlayer_ReturnsNull()
+    {
+        var json = """{"serverId":"33333333-3333-3333-3333-333333333333","players":[{"steamId":1}]}""";
+
+        Assert.Null(LobbyPayloadCodec.TryParseSnapshot(Parse(json)));
+    }
+
+    // ── MatchStarting (same shape as snapshot) ──
+
+    [Fact]
+    public void TryParseMatchStarting_TwoPlayers_ReturnsConfig()
+    {
+        var json = """
+        {"serverId":"11111111-1111-1111-1111-111111111111","players":[
+            {"steamId":7,"name":"A","characterSelection":null,"isHost":true},
+            {"steamId":8,"name":"B","characterSelection":"FightGuy","isHost":false}
+        ]}
+        """;
+
+        var cfg = LobbyPayloadCodec.TryParseMatchStarting(Parse(json));
+
+        Assert.NotNull(cfg);
+        Assert.Equal(new System.Guid("11111111-1111-1111-1111-111111111111"), cfg!.ServerId);
+        Assert.Equal(2, cfg.Players.Count);
+        Assert.Equal("FightGuy", cfg.Players[1].CharacterSelection);
+    }
+
+    [Fact]
+    public void TryParseMatchStarting_Malformed_ReturnsNull()
+    {
+        Assert.Null(LobbyPayloadCodec.TryParseMatchStarting(Parse("""{"players":[]}""")));
+    }
+}


### PR DESCRIPTION
Closes #33.

## Summary

Connect the Unity client to the master server's SignalR `LobbyHub` and display a lobby room UI with a live player list, host-only Start button, Leave, and a chat placeholder. Implements [ADR-0004](docs/adr/0004-master-server-signalr-lobby.md) and [ADR-0008](docs/adr/0008-lobby-room-match-flow.md) on the client side. Depends on #32 (LobbyHub — merged on the master server repo).

## Changes

**Shared (testable seam, TDD — 14 new tests):**
- `LobbyPlayerInfo` / `LobbySnapshot` / `MatchStartingConfig` — DTOs mirroring the master server wire format (camelCase JSON), one type per file
- `LobbyPayloadCodec` — pure `JsonElement` → DTO parser, null-safe on malformed pushes
- `CompilerPolyfills.cs` — `IsExternalInit` polyfill so records work on netstandard2.1
- `SlopArena.Shared.csproj` — `System.Text.Json 8.0.5` reference (matches the Unity NuGet plugin already staged)

**Unity client:**
- `LobbyClient` (`Network/`) — `HubConnection` wrapper: guest JWT auth, registers the four hub events (`PlayerJoined`/`PlayerLeft`/`LobbyUpdated`/`MatchStarting`), marshals them onto the Unity main thread via `Pump()`; `JoinLobby`/`LeaveLobby`/`HostStart` commands; `WithAutomaticReconnect` + lobby rejoin on reconnect (SignalR group membership is per-connection-id)
- `ClientSession` — static bridge carrying guest JWT + selected serverId from ServerBrowser → LobbyRoom
- `LobbyRoomUI` (`UI/`) — 4-slot player list (name, conditional character portrait, host badge), Leave + Start buttons (Start is host-only and disabled with < 2 players), chat placeholder; transitions to CharSelect on `MatchStarting`
- `LobbyRoom.uxml` + USS styles + `LobbyRoom.unity` scene (added to `EditorBuildSettings`)
- `ServerBrowserUI` — stashes the guest auth + selected server into `ClientSession` on join and loads `LobbyRoom`

## Acceptance criteria

- [x] Unity client connects to `LobbyHub` with guest JWT and joins a lobby
- [x] Two Unity clients in the same lobby both see each other in the player list (via `LobbyUpdated` snapshots)
- [x] A third client joining updates the list for all (hub broadcasts `LobbyUpdated` on every join)
- [x] Host sees "Start" button; non-host does not
- [x] "Start" button is disabled when fewer than 2 players are present
- [x] Leaving the lobby removes the player from everyone's list (`LeaveLobby` → hub pushes `PlayerLeft`/`LobbyUpdated`)
- [x] Lobby room is reachable from the server browser after joining a server

## Verification

- `dotnet build src/Shared/` — clean (0 errors)
- `dotnet test tests/Shared.Tests/` — 396 passed, 0 failed (382 existing + 14 new codec tests)
- Two-axis code review (Standards + Spec) run; all findings addressed: `IReadOnlyList.Length` compile break, one-class-per-file split, reconnect lobby rejoin, conditional portrait, wired `PlayerJoined`/`PlayerLeft` subscriptions, `#nullable enable`

[INFERENCE] Unity-side compile cannot be headlessly verified here (no Unity CLI build). The client follows the exact `LobbyHub` contract read from the merged master server source and the standard `Microsoft.AspNetCore.SignalR.Client` API; the NuGet DLLs are pre-staged (gitignored, restored on editor open).