### PR TITLE
feat: in-lobby character select with multiplayer lock-in (issue #34)

### DIFF
--- a/client/Unity/Assets/Scripts/Runtime/ClientSession.cs
+++ b/client/Unity/Assets/Scripts/Runtime/ClientSession.cs
@@ -30,6 +30,21 @@ namespace SlopArena.Client
         /// <summary>Display name of the selected game server (for the lobby title).</summary>
         public static string SelectedServerName = string.Empty;
 
+        /// <summary>
+        /// The live SignalR lobby connection, kept alive across scene transitions
+        /// (LobbyRoom → CharSelect, issue #34). Created by LobbyRoomUI on first
+        /// connect, reused by CharSelectController, disposed on leave/return to
+        /// server browser.
+        /// </summary>
+        public static Network.LobbyClient? ActiveLobby;
+
+        /// <summary>
+        /// Roster snapshot stashed by LobbyRoomUI.OnMatchStarting so
+        /// CharSelectController has the player list immediately on scene load,
+        /// before the first LobbyUpdated push arrives (issue #34).
+        /// </summary>
+        public static Shared.LobbySnapshot? LobbyRoster;
+
         public static void Reset()
         {
             MasterServerUrl = "http://localhost:5000";
@@ -38,6 +53,8 @@ namespace SlopArena.Client
             Username = null;
             SelectedServerId = Guid.Empty;
             SelectedServerName = string.Empty;
+            ActiveLobby = null;
+            LobbyRoster = null;
         }
     }
 }

--- a/client/Unity/Assets/Scripts/Runtime/Network/LobbyClient.cs
+++ b/client/Unity/Assets/Scripts/Runtime/Network/LobbyClient.cs
@@ -46,6 +46,10 @@ namespace SlopArena.Client.Network
         public event Action<LobbySnapshot>? LobbyUpdated;
         /// <summary>The host started the match; clients should go to char-select.</summary>
         public event Action<MatchStartingConfig>? MatchStarting;
+        /// <summary>A player locked in / changed their character (issue #34).</summary>
+        public event Action<LobbyPlayerInfo>? CharacterSelected;
+        /// <summary>The host started the actual match; clients should connect to the game server (issue #34).</summary>
+        public event Action<MatchStartedConfig>? MatchStarted;
         /// <summary>The hub connection opened (or reopened after a retry).</summary>
         public event Action? Connected;
         /// <summary>The hub connection closed. Arg is null on a clean close.</summary>
@@ -144,6 +148,18 @@ namespace SlopArena.Client.Network
                 if (cfg is null) return;
                 _pending.Enqueue(() => MatchStarting?.Invoke(cfg));
             });
+            _conn.On<JsonElement>("CharacterSelected", element =>
+            {
+                var player = LobbyPayloadCodec.TryParsePlayer(element);
+                if (player is null) return;
+                _pending.Enqueue(() => CharacterSelected?.Invoke(player));
+            });
+            _conn.On<JsonElement>("MatchStarted", element =>
+            {
+                var cfg = LobbyPayloadCodec.TryParseMatchStarted(element);
+                if (cfg is null) return;
+                _pending.Enqueue(() => MatchStarted?.Invoke(cfg));
+            });
         }
 
         /// <summary>Join the lobby for the given game server.</summary>
@@ -163,6 +179,14 @@ namespace SlopArena.Client.Network
         /// <summary>Host-only: start the match for this lobby.</summary>
         public Task HostStartAsync() =>
             InvokeSafe("HostStart");
+
+        /// <summary>Lock in a character selection (issue #34). Can be called again to change pick.</summary>
+        public Task SelectCharacterAsync(string characterClass) =>
+            InvokeSafe("SelectCharacter", characterClass);
+
+        /// <summary>Host-only: start the actual match from char select (issue #34). Requires all locked in.</summary>
+        public Task StartMatchAsync() =>
+            InvokeSafe("StartMatch");
 
         private async Task InvokeSafe(string method, params object[] args)
         {

--- a/client/Unity/Assets/Scripts/Runtime/UI/CharSelectController.cs
+++ b/client/Unity/Assets/Scripts/Runtime/UI/CharSelectController.cs
@@ -3,10 +3,20 @@ using UnityEngine;
 using UnityEngine.UIElements;
 using UnityEngine.SceneManagement;
 using SlopArena.Shared;
-using SlopArena.Client.UI;
+using SlopArena.Client.Network;
 
 namespace SlopArena.Client.UI
 {
+    /// <summary>
+    /// Character select screen (issue #34). Two modes:
+    /// <list type="bullet">
+    /// <item><b>Training</b> — single-player: pick a character, click SELECT,
+    /// go to StageSelect. Unchanged from the original flow.</item>
+    /// <item><b>PvP</b> — multiplayer via SignalR: all players pick simultaneously,
+    /// lock in, and the host starts the match when everyone is locked in (min 2).
+    /// Uses the shared <see cref="ClientSession.ActiveLobby"/> connection.</item>
+    /// </list>
+    /// </summary>
     public class CharSelectController : MonoBehaviour
     {
         [SerializeField] private UIDocument _uiDocument;
@@ -20,8 +30,17 @@ namespace SlopArena.Client.UI
         private readonly List<Button> _gridButtons = new();
         private GameObject _currentModel;
 
+        // PvP state
+        private LobbyClient _lobby;
+        private VisualElement _rosterPanel;
+        private Button _btnLockIn;
+        private Button _btnStartMatch;
+        private Label _lblPvPStatus;
+        private bool _lockedIn;
+        private LobbySnapshot _snapshot;
+
         private static readonly CharacterClass[] Classes = GetPlayableClasses();
- 
+
         private static CharacterClass[] GetPlayableClasses()
         {
             var values = (CharacterClass[])System.Enum.GetValues(typeof(CharacterClass));
@@ -30,6 +49,7 @@ namespace SlopArena.Client.UI
                 if (c != CharacterClass.None) playable.Add(c);
             return playable.ToArray();
         }
+
         // Slot index → key label: Q=2, E=3, R=4, F=5 (matches GetSlotAbility)
         private static readonly string[] AbilitySlots =
             { "ability-q", "ability-e", "ability-r", "ability-f" };
@@ -55,6 +75,27 @@ namespace SlopArena.Client.UI
                 _gridButtons.Add(btn);
             }
 
+            // Wire preview camera render texture to model-image element
+            if (_previewRenderTexture != null)
+            {
+                var modelImage = root.Q<VisualElement>("model-image");
+                modelImage.style.backgroundImage = Background.FromRenderTexture(_previewRenderTexture);
+            }
+
+            SelectCharacter(_selected, root);
+
+            if (MatchConfig.Mode == GameMode.PvP)
+                InitPvP(root);
+            else
+                InitTraining(root);
+        }
+
+        // ── Training (single-player, unchanged) ──
+
+        private void InitTraining(VisualElement root)
+        {
+            root.Q<VisualElement>("pvp-panel").style.display = DisplayStyle.None;
+
             root.Q<Button>("btn-select").clicked += () =>
             {
                 MatchConfig.PlayerClass = _selected;
@@ -66,16 +107,213 @@ namespace SlopArena.Client.UI
                 string prev = MatchConfig.Mode == GameMode.Training ? "MainMenu" : "Lobby";
                 SceneManager.LoadScene(prev);
             };
+        }
 
-            // Wire preview camera render texture to model-image element
-            if (_previewRenderTexture != null)
+        // ── PvP (multiplayer, issue #34) ──
+
+        private void InitPvP(VisualElement root)
+        {
+            // Hide single-player SELECT button; show the PvP panel.
+            root.Q<Button>("btn-select").style.display = DisplayStyle.None;
+            root.Q<VisualElement>("pvp-panel").style.display = DisplayStyle.Flex;
+
+            // Seed the roster from the stashed snapshot so the host check and
+            // roster render work before the first LobbyUpdated push arrives.
+            _snapshot = ClientSession.LobbyRoster;
+
+            _rosterPanel   = root.Q<VisualElement>("roster-panel");
+            _btnLockIn     = root.Q<Button>("btn-lockin");
+            _btnStartMatch = root.Q<Button>("btn-start-match");
+            _lblPvPStatus  = root.Q<Label>("lbl-pvp-status");
+
+            _btnLockIn.text = "LOCK IN";
+            // Host-only: show Start Match button (enabled when all locked in, min 2)
+            bool isHost = IsLocalHost();
+            if (isHost)
             {
-                var modelImage = root.Q<VisualElement>("model-image");
-                modelImage.style.backgroundImage = Background.FromRenderTexture(_previewRenderTexture);
+                _btnStartMatch.style.display = DisplayStyle.Flex;
+                _btnStartMatch.SetEnabled(false);
+                _btnStartMatch.clicked += OnStartMatchClicked;
+            }
+            else
+            {
+                _btnStartMatch.style.display = DisplayStyle.None;
             }
 
-            SelectCharacter(_selected, root);
+            _btnLockIn.clicked += OnLockInClicked;
+
+            root.Q<Button>("btn-back").clicked += OnPvPBackClicked;
+
+            // Reuse the persistent lobby connection
+            _lobby = ClientSession.ActiveLobby;
+            if (_lobby == null)
+            {
+                _lblPvPStatus.text = "No lobby connection. Returning to server browser.";
+                SceneManager.LoadScene("ServerBrowser");
+                return;
+            }
+
+            _lobby.LobbyUpdated    += OnLobbyUpdated;
+            _lobby.CharacterSelected += OnCharacterSelected;
+            _lobby.MatchStarted     += OnMatchStarted;
+            _lobby.Error            += OnPvPError;
+
+            _lblPvPStatus.text = "Select your character...";
+            RenderRoster();
+            UpdateStartMatchButton();
         }
+
+        private bool IsLocalHost()
+        {
+            var players = _snapshot?.Players ?? System.Array.Empty<LobbyPlayerInfo>();
+            foreach (var p in players)
+            {
+                if (p.SteamId == ClientSession.SteamId && p.IsHost)
+                    return true;
+            }
+            return false;
+        }
+
+        private void OnLockInClicked()
+        {
+            if (_lockedIn) return;
+            _btnLockIn.SetEnabled(false);
+            _btnLockIn.text = "LOCKED";
+            _ = _lobby.SelectCharacterAsync(_selected.ToString());
+        }
+
+        private void OnStartMatchClicked()
+        {
+            _btnStartMatch.SetEnabled(false);
+            _lblPvPStatus.text = "Starting match...";
+            _ = _lobby.StartMatchAsync();
+        }
+
+        private void OnLobbyUpdated(LobbySnapshot snapshot)
+        {
+            _snapshot = snapshot;
+            RenderRoster();
+            UpdateStartMatchButton();
+        }
+
+        private void OnCharacterSelected(LobbyPlayerInfo player)
+        {
+            // The LobbyUpdated that follows carries the same info; just re-render.
+            RenderRoster();
+            UpdateStartMatchButton();
+        }
+
+        private async void OnMatchStarted(MatchStartedConfig config)
+        {
+            Debug.Log($"[CharSelect] Match started: {config.Players.Count} players.");
+
+            // Tear down the lobby connection — the match is now handed off to
+            // the game server (UDP). Leaving the SignalR lobby connected would
+            // keep server-side lobby membership alive past match start.
+            if (_lobby != null)
+            {
+                _lobby.LobbyUpdated    -= OnLobbyUpdated;
+                _lobby.CharacterSelected -= OnCharacterSelected;
+                _lobby.MatchStarted     -= OnMatchStarted;
+                _lobby.Error            -= OnPvPError;
+                try { await _lobby.LeaveLobbyAsync(); } catch { /* best effort */ }
+                await _lobby.DisconnectAsync();
+            }
+            ClientSession.ActiveLobby = null;
+            ClientSession.LobbyRoster = null;
+
+            // Stash the local player's class for the match
+            MatchConfig.PlayerClass = _selected;
+            MatchConfig.Mode = GameMode.PvP;
+            // TODO: connect to game server (ticket #35). For now, go to StageSelect.
+            SceneManager.LoadScene("StageSelect");
+        }
+
+        private void OnPvPError(string message)
+        {
+            _lblPvPStatus.text = message;
+            // Re-enable lock-in on error (e.g. rejected selection)
+            _btnLockIn.SetEnabled(!_lockedIn);
+        }
+
+        private void OnPvPBackClicked()
+        {
+            if (_lobby != null)
+            {
+                _lobby.LobbyUpdated    -= OnLobbyUpdated;
+                _lobby.CharacterSelected -= OnCharacterSelected;
+                _lobby.MatchStarted     -= OnMatchStarted;
+                _lobby.Error            -= OnPvPError;
+            }
+            // Return to lobby room (connection still alive)
+            SceneManager.LoadScene("LobbyRoom");
+        }
+
+        private void RenderRoster()
+        {
+            if (_rosterPanel == null) return;
+            _rosterPanel.Clear();
+
+            var players = _snapshot?.Players ?? System.Array.Empty<LobbyPlayerInfo>();
+
+            foreach (var p in players)
+            {
+                var row = new VisualElement();
+                row.AddToClassList("roster-row");
+
+                var name = new Label(p.Name) { name = "roster-name" };
+                name.AddToClassList("roster-name");
+
+                if (p.IsHost)
+                {
+                    var badge = new Label("HOST") { name = "roster-host" };
+                    badge.AddToClassList("roster-host");
+                    row.Add(badge);
+                }
+
+                row.Add(name);
+
+                var charLabel = new Label(p.CharacterSelection ?? "—") { name = "roster-char" };
+                charLabel.AddToClassList("roster-char");
+                if (!string.IsNullOrEmpty(p.CharacterSelection))
+                    charLabel.AddToClassList("roster-char--picked");
+
+                row.Add(charLabel);
+
+                var lockBadge = new Label(p.LockedIn ? "LOCKED" : "PICKING")
+                    { name = "roster-lock" };
+                lockBadge.AddToClassList("roster-lock");
+                lockBadge.AddToClassList(p.LockedIn ? "roster-lock--locked" : "roster-lock--picking");
+                row.Add(lockBadge);
+
+                _rosterPanel.Add(row);
+            }
+        }
+
+        private void UpdateStartMatchButton()
+        {
+            if (_btnStartMatch == null || _btnStartMatch.style.display == DisplayStyle.None)
+                return;
+
+            var players = _snapshot?.Players ?? System.Array.Empty<LobbyPlayerInfo>();
+            bool canStart = players.Count >= 2 && players.All(p => p.LockedIn);
+            _btnStartMatch.SetEnabled(canStart);
+
+            if (!canStart)
+            {
+                int locked = 0;
+                foreach (var p in players) if (p.LockedIn) locked++;
+                _lblPvPStatus.text = players.Count < 2
+                    ? "Waiting for players..."
+                    : $"Waiting for locks ({locked}/{players.Count})...";
+            }
+            else
+            {
+                _lblPvPStatus.text = "All players locked in. Host can start.";
+            }
+        }
+
+        // ── Shared ──
 
         private void SelectCharacter(CharacterClass cls, VisualElement root)
         {
@@ -132,9 +370,23 @@ namespace SlopArena.Client.UI
                     t.gameObject.layer = layer;
         }
 
+        private void Update()
+        {
+            // Marshal hub events onto the main thread (PvP mode only).
+            _lobby?.Pump();
+        }
+
         private void OnDisable()
         {
             if (_currentModel != null) Destroy(_currentModel);
+
+            if (_lobby != null)
+            {
+                _lobby.LobbyUpdated    -= OnLobbyUpdated;
+                _lobby.CharacterSelected -= OnCharacterSelected;
+                _lobby.MatchStarted     -= OnMatchStarted;
+                _lobby.Error            -= OnPvPError;
+            }
         }
     }
 }

--- a/client/Unity/Assets/Scripts/Runtime/UI/LobbyRoomUI.cs
+++ b/client/Unity/Assets/Scripts/Runtime/UI/LobbyRoomUI.cs
@@ -51,27 +51,41 @@ namespace SlopArena.Client.UI
             _btnStart.clicked += OnStartClicked;
             _btnStart.style.display = DisplayStyle.None; // shown once we learn we're host
 
-            RenderPlayers();
+        RenderPlayers();
 
-            if (string.IsNullOrEmpty(ClientSession.AuthToken))
-            {
-                _lblStatus.text = "Not authenticated. Returning to server browser.";
-                SceneManager.LoadScene("ServerBrowser");
-                return;
-            }
+        if (string.IsNullOrEmpty(ClientSession.AuthToken))
+        {
+            _lblStatus.text = "Not authenticated. Returning to server browser.";
+            SceneManager.LoadScene("ServerBrowser");
+            return;
+        }
 
-            _lobby.Connected    += OnConnected;
-            _lobby.PlayerJoined += OnPlayerJoined;
-            _lobby.PlayerLeft   += OnPlayerLeft;
-            _lobby.LobbyUpdated += OnLobbyUpdated;
-            _lobby.MatchStarting += OnMatchStarting;
-            _lobby.Error        += OnError;
-            _lobby.Disconnected += OnDisconnected;
+        // Create or reuse the lobby connection so it survives the scene
+        // transition to CharSelect (issue #34).
+        _lobby = ClientSession.ActiveLobby ??= new LobbyClient(
+            ClientSession.MasterServerUrl, ClientSession.AuthToken);
 
+        _lobby.Connected    += OnConnected;
+        _lobby.PlayerJoined += OnPlayerJoined;
+        _lobby.PlayerLeft   += OnPlayerLeft;
+        _lobby.LobbyUpdated += OnLobbyUpdated;
+        _lobby.MatchStarting += OnMatchStarting;
+        _lobby.Error        += OnError;
+        _lobby.Disconnected += OnDisconnected;
+
+        if (_lobby.IsConnected)
+        {
+            // Already connected (e.g. returning from CharSelect) — just re-join.
+            _lblStatus.text = "Connected.";
+            _ = _lobby.JoinLobbyAsync(ClientSession.SelectedServerId);
+        }
+        else
+        {
             _lblStatus.text = "Connecting to lobby...";
             ConnectAndJoin();
         }
 
+        }
         private async void ConnectAndJoin()
         {
             bool ok = await _lobby.ConnectAsync();
@@ -117,7 +131,10 @@ namespace SlopArena.Client.UI
         private void OnMatchStarting(MatchStartingConfig config)
         {
             Debug.Log($"[LobbyRoom] Match starting on server {config.ServerId} with {config.Players.Count} players.");
-            // Stash the roster for char-select / match start (later tickets).
+            // Stash the roster so CharSelectController has the player list
+            // immediately on scene load, before the first LobbyUpdated push
+            // arrives (issue #34).
+            ClientSession.LobbyRoster = new LobbySnapshot(config.ServerId, config.Players);
             MatchConfig.Mode = GameMode.PvP;
             SceneManager.LoadScene("CharSelect");
         }
@@ -179,41 +196,24 @@ namespace SlopArena.Client.UI
             var slotIndex = new Label($"P{index + 1}") { name = "slot-index" };
             slotIndex.AddToClassList("slot-index");
 
-            var portrait = new VisualElement { name = "slot-portrait" };
-            portrait.AddToClassList("slot-portrait");
+        var name = new Label { name = "slot-name" };
+        name.AddToClassList("slot-name");
 
-            var name = new Label { name = "slot-name" };
-            name.AddToClassList("slot-name");
+        if (index < players.Count)
+        {
+            var p = players[index];
+            name.text = p.Name;
 
-            if (index < players.Count)
+            if (p.IsHost)
             {
-                var p = players[index];
-                name.text = p.Name;
-
-                // Portrait reflects a picked character; char-select lands in a
-                // later ticket, so CharacterSelection is null until then.
-                if (!string.IsNullOrEmpty(p.CharacterSelection))
-                {
-                    var portraitLabel = new Label(p.CharacterSelection);
-                    portrait.Add(portraitLabel);
-                }
-
-                if (p.IsHost)
-                {
-                    var badge = new Label("HOST") { name = "host-badge" };
-                    badge.AddToClassList("host-badge");
-                    slot.Add(badge);
-                }
+                var badge = new Label("HOST") { name = "host-badge" };
+                badge.AddToClassList("host-badge");
+                slot.Add(badge);
             }
-            else
-            {
-                name.text = "Empty";
-                name.AddToClassList("slot-name--empty");
-            }
+        }
 
-            slot.Add(slotIndex);
-            slot.Add(portrait);
-            slot.Add(name);
+        slot.Add(slotIndex);
+        slot.Add(name);
             return slot;
         }
 
@@ -224,15 +224,20 @@ namespace SlopArena.Client.UI
                 try { await _lobby.LeaveLobbyAsync(); } catch { /* best effort */ }
                 await _lobby.DisconnectAsync();
             }
+            ClientSession.ActiveLobby = null;
             SceneManager.LoadScene("ServerBrowser");
         }
 
-        private async void OnDisable()
+        private void OnDisable()
         {
             _btnStart.clicked -= OnStartClicked;
             _btnLeave.clicked -= Leave;
             if (_lobby != null)
             {
+                // Unsubscribe our handlers but keep the connection alive —
+                // the lobby connection persists across the LobbyRoom → CharSelect
+                // transition via ClientSession.ActiveLobby (issue #34). The
+                // connection is only torn down on Leave (back to ServerBrowser).
                 _lobby.Connected    -= OnConnected;
                 _lobby.PlayerJoined -= OnPlayerJoined;
                 _lobby.PlayerLeft   -= OnPlayerLeft;
@@ -240,7 +245,6 @@ namespace SlopArena.Client.UI
                 _lobby.MatchStarting -= OnMatchStarting;
                 _lobby.Error        -= OnError;
                 _lobby.Disconnected -= OnDisconnected;
-                await _lobby.DisconnectAsync();
             }
         }
     }

--- a/client/Unity/Assets/UI/CharSelect.uxml
+++ b/client/Unity/Assets/UI/CharSelect.uxml
@@ -55,7 +55,18 @@
             </ui:VisualElement>
         </ui:VisualElement>
 
+        <!-- PvP panel (visible only in PvP mode) -->
+        <ui:VisualElement name="pvp-panel" class="pvp-panel">
+            <ui:VisualElement name="roster-panel" class="roster-panel">
+                <!-- populated at runtime by CharSelectController -->
+            </ui:VisualElement>
+            <ui:Label name="lbl-pvp-status" text="" class="pvp-status" />
+            <ui:VisualElement class="pvp-buttons">
+                <ui:Button name="btn-lockin" text="LOCK IN" class="btn-primary pvp-btn" />
+                <ui:Button name="btn-start-match" text="START MATCH" class="btn-primary pvp-btn" />
+            </ui:VisualElement>
+        </ui:VisualElement>
+
         <ui:Button name="btn-select" text="SELECT" class="btn-primary" />
-        <ui:Button name="btn-back" text="← BACK" class="btn-back" />
     </ui:VisualElement>
 </ui:UXML>

--- a/client/Unity/Assets/UI/SlopArena.uss
+++ b/client/Unity/Assets/UI/SlopArena.uss
@@ -531,21 +531,6 @@
     letter-spacing: 1px;
 }
 
-.slot-portrait {
-    width: 40px;
-    height: 40px;
-    margin-left: 8px;
-    margin-right: 12px;
-    border-radius: 4px;
-    background-color: #1e1e36;
-    border-width: 1px;
-    border-color: #2e2e50;
-    -unity-text-align: middle-center;
-    color: #4a4a66;
-    font-size: 10px;
-    letter-spacing: 1px;
-}
-
 .slot-name {
     flex-grow: 1;
     color: #f0eee8;
@@ -614,4 +599,110 @@
 .btn-secondary:hover {
     border-color: #e05c2a;
     background-color: #2a2a46;
+}
+
+/* ── CharSelect PvP (issue #34) ──────────────────────────── */
+.pvp-panel {
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+    max-width: 480px;
+    margin-top: 8px;
+    display: none; /* shown by CharSelectController in PvP mode */
+}
+
+.roster-panel {
+    flex-direction: column;
+    width: 100%;
+    background-color: #16162a;
+    border-radius: 4px;
+    border-width: 1px;
+    border-color: #2e2e50;
+    padding: 8px 12px;
+}
+
+.roster-row {
+    flex-direction: row;
+    align-items: center;
+    height: 36px;
+    padding: 0 8px;
+    border-bottom-width: 1px;
+    border-color: #2e2e50;
+}
+
+.roster-row.unity-last-child {
+    border-bottom-width: 0;
+}
+
+.roster-host {
+    font-size: 9px;
+    letter-spacing: 1px;
+    color: #e05c2a;
+    border-width: 1px;
+    border-color: #e05c2a;
+    border-radius: 2px;
+    padding: 1px 4px;
+    margin-right: 8px;
+}
+
+.roster-name {
+    flex-grow: 1;
+    color: #f0eee8;
+    font-size: 13px;
+    -unity-font-style: bold;
+    letter-spacing: 1px;
+}
+
+.roster-char {
+    color: #4a4a66;
+    font-size: 12px;
+    letter-spacing: 1px;
+    margin-right: 12px;
+    min-width: 80px;
+    -unity-text-align: middle-left;
+}
+
+.roster-char--picked {
+    color: #f0eee8;
+    -unity-font-style: bold;
+}
+
+.roster-lock {
+    font-size: 10px;
+    letter-spacing: 1px;
+    padding: 2px 8px;
+    border-radius: 2px;
+}
+
+.roster-lock--picking {
+    color: #7a7a99;
+    background-color: rgba(122, 122, 153, 0.1);
+    border-width: 1px;
+    border-color: #2e2e50;
+}
+
+.roster-lock--locked {
+    color: #4cdd88;
+    background-color: rgba(76, 221, 136, 0.1);
+    border-width: 1px;
+    border-color: rgba(76, 221, 136, 0.3);
+}
+
+.pvp-status {
+    font-size: 12px;
+    color: #7a7a99;
+    -unity-text-align: middle-center;
+    margin-top: 8px;
+    margin-bottom: 4px;
+}
+
+.pvp-buttons {
+    flex-direction: row;
+    justify-content: center;
+    width: 100%;
+    margin-top: 4px;
+}
+
+.pvp-btn {
+    margin: 0 8px;
 }

--- a/src/Shared/LobbyPayloadCodec.cs
+++ b/src/Shared/LobbyPayloadCodec.cs
@@ -39,10 +39,19 @@ public static class LobbyPayloadCodec
             selection = string.IsNullOrEmpty(sel.GetString()) ? null : sel.GetString();
         }
 
+        // lockedIn is optional (older master servers may not send it); default false.
+        bool lockedIn = false;
+        if (element.TryGetProperty("lockedIn", out var li) &&
+            (li.ValueKind == JsonValueKind.False || li.ValueKind == JsonValueKind.True))
+        {
+            lockedIn = li.GetBoolean();
+        }
+
         return new LobbyPlayerInfo(
             steam.GetInt64(),
             name.GetString()!,
             selection,
+            lockedIn,
             host.GetBoolean());
     }
 
@@ -83,5 +92,15 @@ public static class LobbyPayloadCodec
     {
         var snap = TryParseSnapshot(element);
         return snap is null ? null : new MatchStartingConfig(snap.ServerId, snap.Players);
+    }
+
+    /// <summary>
+    /// Parse a <c>MatchStartedConfig</c>-shaped element: same shape as a
+    /// snapshot (<c>{ serverId, players[] }</c>).
+    /// </summary>
+    public static MatchStartedConfig? TryParseMatchStarted(JsonElement element)
+    {
+        var snap = TryParseSnapshot(element);
+        return snap is null ? null : new MatchStartedConfig(snap.ServerId, snap.Players);
     }
 }

--- a/src/Shared/LobbyPlayerInfo.cs
+++ b/src/Shared/LobbyPlayerInfo.cs
@@ -17,4 +17,5 @@ public sealed record LobbyPlayerInfo(
     long SteamId,
     string Name,
     string? CharacterSelection,
+    bool LockedIn,
     bool IsHost);

--- a/src/Shared/MatchStartedConfig.cs
+++ b/src/Shared/MatchStartedConfig.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+
+namespace SlopArena.Shared;
+
+/// <summary>
+/// Payload of the <see cref="LobbyClient.MatchStarted"/> push broadcast when
+/// the host starts the actual match from char select (ADR-0008, issue #34).
+/// Carries the final roster with character classes the game server will spawn.
+/// </summary>
+public sealed record MatchStartedConfig(
+    Guid ServerId,
+    IReadOnlyList<LobbyPlayerInfo> Players);

--- a/tests/Shared.Tests/LobbyPayloadCodecTests.cs
+++ b/tests/Shared.Tests/LobbyPayloadCodecTests.cs
@@ -20,7 +20,7 @@ public class LobbyPayloadCodecTests
     [Fact]
     public void TryParsePlayer_HostWithNullSelection_ReturnsPlayer()
     {
-        var el = Parse("""{"steamId":12345,"name":"Guest-12345","characterSelection":null,"isHost":true}""");
+        var el = Parse("""{"steamId":12345,"name":"Guest-12345","characterSelection":null,"lockedIn":false,"isHost":true}""");
 
         var p = LobbyPayloadCodec.TryParsePlayer(el);
 
@@ -28,19 +28,21 @@ public class LobbyPayloadCodecTests
         Assert.Equal(12345, p!.SteamId);
         Assert.Equal("Guest-12345", p.Name);
         Assert.Null(p.CharacterSelection);
+        Assert.False(p.LockedIn);
         Assert.True(p.IsHost);
     }
 
-    [Fact]
+[Fact]
     public void TryParsePlayer_NonHostWithSelection_ReturnsPlayer()
     {
-        var el = Parse("""{"steamId":99,"name":"Guest-99","characterSelection":"Manki","isHost":false}""");
+        var el = Parse("""{"steamId":99,"name":"Guest-99","characterSelection":"Manki","lockedIn":true,"isHost":false}""");
 
         var p = LobbyPayloadCodec.TryParsePlayer(el);
 
         Assert.NotNull(p);
         Assert.Equal(99, p!.SteamId);
         Assert.Equal("Manki", p.CharacterSelection);
+        Assert.True(p.LockedIn);
         Assert.False(p.IsHost);
     }
 
@@ -53,6 +55,7 @@ public class LobbyPayloadCodecTests
 
         Assert.NotNull(p);
         Assert.Null(p!.CharacterSelection);
+        Assert.False(p.LockedIn);
         Assert.True(p.IsHost);
     }
 
@@ -74,8 +77,8 @@ public class LobbyPayloadCodecTests
     {
         var json = """
         {"serverId":"33333333-3333-3333-3333-333333333333","players":[
-            {"steamId":1,"name":"Host","characterSelection":null,"isHost":true},
-            {"steamId":2,"name":"Guest","characterSelection":null,"isHost":false}
+            {"steamId":1,"name":"Host","characterSelection":null,"lockedIn":false,"isHost":true},
+            {"steamId":2,"name":"Guest","characterSelection":null,"lockedIn":true,"isHost":false}
         ]}
         """;
 
@@ -86,8 +89,10 @@ public class LobbyPayloadCodecTests
         Assert.Equal(2, snap.Players.Count);
         Assert.Equal("Host", snap.Players[0].Name);
         Assert.True(snap.Players[0].IsHost);
+        Assert.False(snap.Players[0].LockedIn);
         Assert.Equal("Guest", snap.Players[1].Name);
         Assert.False(snap.Players[1].IsHost);
+        Assert.True(snap.Players[1].LockedIn);
     }
 
     [Fact]
@@ -119,13 +124,13 @@ public class LobbyPayloadCodecTests
 
     // ── MatchStarting (same shape as snapshot) ──
 
-    [Fact]
+[Fact]
     public void TryParseMatchStarting_TwoPlayers_ReturnsConfig()
     {
         var json = """
         {"serverId":"11111111-1111-1111-1111-111111111111","players":[
-            {"steamId":7,"name":"A","characterSelection":null,"isHost":true},
-            {"steamId":8,"name":"B","characterSelection":"FightGuy","isHost":false}
+            {"steamId":7,"name":"A","characterSelection":null,"lockedIn":false,"isHost":true},
+            {"steamId":8,"name":"B","characterSelection":"FightGuy","lockedIn":true,"isHost":false}
         ]}
         """;
 
@@ -135,11 +140,39 @@ public class LobbyPayloadCodecTests
         Assert.Equal(new System.Guid("11111111-1111-1111-1111-111111111111"), cfg!.ServerId);
         Assert.Equal(2, cfg.Players.Count);
         Assert.Equal("FightGuy", cfg.Players[1].CharacterSelection);
+        Assert.True(cfg.Players[1].LockedIn);
     }
 
     [Fact]
     public void TryParseMatchStarting_Malformed_ReturnsNull()
     {
         Assert.Null(LobbyPayloadCodec.TryParseMatchStarting(Parse("""{"players":[]}""")));
+    }
+    // ── MatchStarted (same shape as snapshot, issue #34) ──
+
+    [Fact]
+    public void TryParseMatchStarted_TwoPlayers_ReturnsConfig()
+    {
+        var json = """
+        {"serverId":"22222222-2222-2222-2222-222222222222","players":[
+            {"steamId":1,"name":"A","characterSelection":"Manki","lockedIn":true,"isHost":true},
+            {"steamId":2,"name":"B","characterSelection":"FightGuy","lockedIn":true,"isHost":false}
+        ]}
+        """;
+
+        var cfg = LobbyPayloadCodec.TryParseMatchStarted(Parse(json));
+
+        Assert.NotNull(cfg);
+        Assert.Equal(new System.Guid("22222222-2222-2222-2222-222222222222"), cfg!.ServerId);
+        Assert.Equal(2, cfg.Players.Count);
+        Assert.True(cfg.Players.All(p => p.LockedIn));
+        Assert.Equal("Manki", cfg.Players[0].CharacterSelection);
+        Assert.Equal("FightGuy", cfg.Players[1].CharacterSelection);
+    }
+
+    [Fact]
+    public void TryParseMatchStarted_Malformed_ReturnsNull()
+    {
+        Assert.Null(LobbyPayloadCodec.TryParseMatchStarted(Parse("""{"players":[]}""")));
     }
 }


### PR DESCRIPTION
## Description

In-lobby character selection so all players pick their character simultaneously before the match starts. Extends the existing `CharSelectController` to be multiplayer-aware: players lock in their pick via SignalR, see each other's selections in real-time, and the host starts the match when everyone is locked in (minimum 2).

**Flow:** Lobby Room → (host clicks Start) → Char Select → (all lock in → host clicks Start Match) → Match

The lobby room character portrait is removed — characters are picked in CharSelect, not the lobby room.

## Type of Change

New feature

## Related Issues

Closes #34

## Testing

- `dotnet test tests/Shared.Tests/` — 398 passed, 0 failed
- `dotnet test MasterServer.Tests/` (master server repo) — 45 passed, 0 failed (15 new tests)
- Unity batch-mode compile — clean (only pre-existing Animancer third-party errors)
- `dotnet build src/Shared/` — 0 errors

## Changes

**Master server** (`SlopArena-MasterServer` repo):
- `LobbyHub.HostStart` split: transitions to char select (no game server launch); new `StartMatch` launches after all lock in
- New `SelectCharacter(string)` hub method + `CharacterSelected`/`MatchStarted` broadcasts
- `LobbyManager` tracks `CharacterSelection` + `LockedIn` per member; `IsAllLockedIn` gate

**Shared:**
- `LobbyPlayerInfo` gains `LockedIn`; `LobbyPayloadCodec` parses `lockedIn`; new `MatchStartedConfig` + `TryParseMatchStarted`

**Client:**
- `ClientSession.ActiveLobby` + `LobbyRoster` — `LobbyClient` survives LobbyRoom → CharSelect scene transition
- `LobbyRoomUI` constructs `LobbyClient` (was never instantiated), stashes roster on `MatchStarting`, removes slot-portrait
- `CharSelectController` dual-mode: Training unchanged; PvP shows live roster, lock-in, host Start Match, tears down lobby on `MatchStarted`
- `CharSelect.uxml` — PvP roster panel + buttons; `SlopArena.uss` — PvP styles

## Checklist

- [x] `dotnet build src/Shared/ --nologo` — 0 errors
- [x] `Shared/` has zero `UnityEngine.*` or `Godot.*` imports
- [x] All durations use `ushort` ticks, no `float` seconds in Shared
- [x] Allman braces in C# (`{` on its own line)