### PR TITLE
feat(host): embedded host-and-play (issue #39)

### DIFF
--- a/client/Unity/Assets/Scripts/Runtime/Network/ServerHost.cs
+++ b/client/Unity/Assets/Scripts/Runtime/Network/ServerHost.cs
@@ -1,0 +1,297 @@
+#nullable enable
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using SlopArena.Shared;
+using UnityEngine;
+
+namespace SlopArena.Client.Network
+{
+    /// <summary>
+    /// Embedded host-and-play (ADR-0005, issue #39). A Unity singleton that
+    /// spawns the <c>SlopArena.Server</c> game server as a subprocess, passes
+    /// it a generated <c>server.json</c>, monitors it for crash/registration,
+    /// and shuts it down cleanly on application quit or when the host leaves.
+    ///
+    /// The host player connects to the match at <c>localhost:&lt;assigned-port&gt;</c>,
+    /// identical to any remote client — the server binary is unchanged.
+    ///
+    /// Subprocess stdout/stderr are read on background threads and marshalled
+    /// onto the Unity main thread via <see cref="Pump"/> (same pattern as
+    /// <see cref="LobbyClient"/>); callers MUST invoke it from <c>Update</c>.
+    /// </summary>
+    public sealed class ServerHost : MonoBehaviour
+    {
+        /// <summary>Singleton instance, or null before first <see cref="Create"/>.</summary>
+        public static ServerHost? Instance { get; private set; }
+
+        [Header("Subprocess")]
+        [Tooltip("Path to the dotnet executable. 'dotnet' relies on PATH.")]
+        [SerializeField] private string _dotnetPath = "dotnet";
+        [Tooltip("Repo-relative path to the game-server .csproj (run via 'dotnet run').")]
+        [SerializeField] private string _serverProjectPath = "src/Server/SlopArena.Server.csproj";
+        [Tooltip("Repo-relative path to the .arena files directory. Absolute if set.")]
+        [SerializeField] private string _arenaDataDir = "data/arenas";
+
+        [Header("Master Server")]
+        [SerializeField] private string _masterServerUrl = "http://localhost:5000";
+
+        private Process? _process;
+        private string? _configPath;
+        private bool _userStopped;   // distinguishes graceful Stop() from a crash
+        private int _assignedPort;
+
+        // Background-thread subprocess events, drained on the main thread by Pump().
+        private readonly ConcurrentQueue<Action> _pending = new();
+        private readonly StringBuilder _stderrTail = new();
+        private const int StderrTailLines = 20;
+
+        // ── Events (raised on the main thread, after Pump) ──
+
+        /// <summary>The server registered with the master server. Arg = server-id GUID.</summary>
+        public event Action<Guid>? Registered;
+        /// <summary>The server failed to register (non-crash). Arg = reason.</summary>
+        public event Action<string>? RegistrationFailed;
+        /// <summary>The subprocess exited unexpectedly. Args = exit code, stderr tail.</summary>
+        public event Action<int, string>? Crashed;
+        /// <summary>Every stdout line (for debugging / live log panels).</summary>
+        public event Action<string>? StdoutLine;
+
+        /// <summary>True while the subprocess is alive and not user-stopped.</summary>
+        public bool IsRunning => _process != null && !_process.HasExited;
+        /// <summary>The UDP port assigned to the hosted server (valid after StartHosting).</summary>
+        public int AssignedPort => _assignedPort;
+
+        // ── Lifecycle ──
+
+        /// <summary>Create the singleton (DontDestroyOnLoad) if absent.</summary>
+        public static ServerHost Create()
+        {
+            if (Instance != null) return Instance;
+            var go = new GameObject(nameof(ServerHost));
+            DontDestroyOnLoad(go);
+            Instance = go.AddComponent<ServerHost>();
+            return Instance;
+        }
+
+        private void Awake()
+        {
+            if (Instance != null && Instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+            Instance = this;
+        }
+
+        /// <summary>
+        /// Start the embedded game server. Picks a free UDP port, writes a temp
+        /// <c>server.json</c>, and spawns <c>dotnet run</c> on the server project.
+        /// Fires <see cref="Registered"/> or <see cref="RegistrationFailed"/> on the
+        /// main thread. Safe to call once per host session.
+        /// </summary>
+        /// <param name="serverName">Browser display name for this server.</param>
+        public void StartHosting(string serverName)
+        {
+            if (IsRunning)
+            {
+                _pending.Enqueue(() => RegistrationFailed?.Invoke("A server is already running."));
+                return;
+            }
+
+            string repoRoot = ResolveRepoRoot();
+            string projectPath = Path.IsPathRooted(_serverProjectPath)
+                ? _serverProjectPath
+                : Path.GetFullPath(Path.Combine(repoRoot, _serverProjectPath));
+            string arenaDir = Path.IsPathRooted(_arenaDataDir)
+                ? _arenaDataDir
+                : Path.GetFullPath(Path.Combine(repoRoot, _arenaDataDir));
+
+            if (!Directory.Exists(arenaDir))
+            {
+                _pending.Enqueue(() => RegistrationFailed?.Invoke($"Arena data dir not found: {arenaDir}"));
+                return;
+            }
+
+            _assignedPort = FindFreeUdpPort();
+            var config = new HostedServerConfig
+            {
+                ServerName = serverName,
+                Region = "EU",
+                Port = _assignedPort,
+                MaxConcurrentMatches = 1,
+                MasterServerUrl = _masterServerUrl,
+                IsOfficial = false,
+                ArenaDataDir = arenaDir
+            };
+
+            _configPath = Path.Combine(Path.GetTempPath(), $"sloparena-host-{_assignedPort}.json");
+            File.WriteAllText(_configPath, config.ToJson());
+            Debug.Log($"[ServerHost] Wrote config to {_configPath} (port {_assignedPort})");
+
+            var psi = new ProcessStartInfo
+            {
+                FileName = _dotnetPath,
+                // dotnet run --project <csproj> -- <configPath>
+                // '--' separates dotnet-run args from app args.
+                ArgumentList = { "run", "--project", projectPath, "--", _configPath },
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true,
+                WorkingDirectory = repoRoot
+            };
+
+            try
+            {
+                _process = Process.Start(psi);
+            }
+            catch (Exception ex)
+            {
+                _pending.Enqueue(() => RegistrationFailed?.Invoke($"Failed to start subprocess: {ex.Message}"));
+                return;
+            }
+
+            if (_process == null)
+            {
+                _pending.Enqueue(() => RegistrationFailed?.Invoke("Process.Start returned null."));
+                return;
+            }
+
+            _userStopped = false;
+            _stderrTail.Clear();
+
+            _process.OutputDataReceived += OnStdout;
+            _process.ErrorDataReceived += OnStderr;
+            _process.EnableRaisingEvents = true;
+            _process.Exited += OnExited;
+            _process.BeginOutputReadLine();
+            _process.BeginErrorReadLine();
+
+            Debug.Log($"[ServerHost] Spawned server PID {_process.Id} on port {_assignedPort}.");
+        }
+
+        /// <summary>
+        /// Gracefully stop the embedded server. Kills the process tree and waits
+        /// briefly. Idempotent; safe from <see cref="OnApplicationQuit"/>/<see cref="OnDestroy"/>.
+        /// </summary>
+        public void Stop()
+        {
+            if (_process == null) return;
+            _userStopped = true;
+
+            try
+            {
+                if (!_process.HasExited)
+                    _process.Kill(entireProcessTree: true);
+                _process.WaitForExit(2000);
+            }
+            catch (Exception ex)
+            {
+                Debug.LogWarning($"[ServerHost] Stop error: {ex.Message}");
+            }
+
+            DetachProcess();
+            CleanupConfig();
+        }
+
+        /// <summary>Drain background-thread subprocess events onto the main thread.</summary>
+        public void Pump()
+        {
+            while (_pending.TryDequeue(out var action))
+                action();
+        }
+
+        private void Update() => Pump();
+
+        private void OnApplicationQuit() => Stop();
+
+        private void OnDestroy() => Stop();
+
+        // ── Subprocess callbacks (background threads) ──
+
+        private void OnStdout(object sender, DataReceivedEventArgs e)
+        {
+            if (e.Data == null) return;
+            _pending.Enqueue(() => StdoutLine?.Invoke(e.Data));
+
+            if (ServerLogParser.TryParseServerId(e.Data, out var serverId))
+            {
+                var id = serverId;
+                _pending.Enqueue(() => Registered?.Invoke(id));
+            }
+        }
+
+        private void OnStderr(object sender, DataReceivedEventArgs e)
+        {
+            if (e.Data == null) return;
+            lock (_stderrTail)
+            {
+                _stderrTail.AppendLine(e.Data);
+                // Keep only the tail to bound memory.
+                while (_stderrTail.Length > 8192)
+                {
+                    int nl = _stderrTail.ToString().IndexOf('\n');
+                    if (nl < 0) break;
+                    _stderrTail.Remove(0, nl + 1);
+                }
+            }
+        }
+
+        private void OnExited(object? sender, EventArgs e)
+        {
+            if (_userStopped) return;   // graceful — not a crash
+            int code = -1;
+            try { code = _process?.ExitCode ?? -1; } catch { }
+            string tail;
+            lock (_stderrTail) tail = _stderrTail.ToString();
+            _pending.Enqueue(() => Crashed?.Invoke(code, tail));
+        }
+
+        // ── Helpers ──
+
+        private void DetachProcess()
+        {
+            if (_process == null) return;
+            try
+            {
+                _process.OutputDataReceived -= OnStdout;
+                _process.ErrorDataReceived -= OnStderr;
+                _process.Exited -= OnExited;
+            }
+            catch { /* best effort */ }
+            _process?.Dispose();
+            _process = null;
+        }
+
+        private void CleanupConfig()
+        {
+            if (_configPath == null) return;
+            try { if (File.Exists(_configPath)) File.Delete(_configPath); } catch { }
+            _configPath = null;
+        }
+
+        /// <summary>
+        /// Let the OS assign a free UDP port by binding a datagram socket to
+        /// port 0, reading the assigned port, then closing. Minimizes port
+        /// conflicts for the demo (ADR-0005 acceptance criterion).
+        /// </summary>
+        private static int FindFreeUdpPort()
+        {
+            using var probe = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+            probe.Bind(new IPEndPoint(IPAddress.Any, 0));
+            return ((IPEndPoint)probe.LocalEndPoint!).Port;
+        }
+
+        /// <summary>
+        /// Resolve the repo root from the Unity project: Application.dataPath is
+        /// <c>&lt;repo&gt;/client/Unity/Assets</c>; three levels up is the repo root.
+        /// </summary>
+        private static string ResolveRepoRoot() =>
+            Path.GetFullPath(Path.Combine(Application.dataPath, "..", "..", ".."));
+    }
+}

--- a/client/Unity/Assets/Scripts/Runtime/Network/ServerHost.cs.meta
+++ b/client/Unity/Assets/Scripts/Runtime/Network/ServerHost.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c9b2c97275b5468098dffd700426899b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/client/Unity/Assets/Scripts/Runtime/UI/LobbyRoomUI.cs
+++ b/client/Unity/Assets/Scripts/Runtime/UI/LobbyRoomUI.cs
@@ -59,6 +59,10 @@ namespace SlopArena.Client.UI
                 SceneManager.LoadScene("ServerBrowser");
                 return;
             }
+            // Construct the lobby client now that ClientSession carries the
+            // guest JWT (set by the Server Browser or the host flow #39).
+            // Without this the field is null and every Pump()/ConnectAsync() NREs.
+            _lobby = new LobbyClient(ClientSession.MasterServerUrl, ClientSession.AuthToken!);
 
             _lobby.Connected    += OnConnected;
             _lobby.PlayerJoined += OnPlayerJoined;

--- a/client/Unity/Assets/Scripts/Runtime/UI/MainMenuController.cs
+++ b/client/Unity/Assets/Scripts/Runtime/UI/MainMenuController.cs
@@ -1,26 +1,33 @@
+using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.UIElements;
 using UnityEngine.SceneManagement;
-using SlopArena.Client.UI;
+using SlopArena.Client.Network;
+using SlopArena.Shared;
 
 namespace SlopArena.Client.UI
 {
     public class MainMenuController : MonoBehaviour
     {
         [SerializeField] private UIDocument _uiDocument;
+        [SerializeField] private string _masterServerUrl = "http://localhost:5000";
+
+        private Label _lblHostStatus;
+        private bool _hosting;   // guards against double-click during the async start
 
         private void OnEnable()
         {
             MatchConfig.Reset();
             var root = _uiDocument.rootVisualElement;
 
-            var submenu        = root.Q<VisualElement>("submenu");
-            var btnTraining    = root.Q<Button>("btn-training");
-            var btnMultiplayer = root.Q<Button>("btn-multiplayer");
-            var btnHost        = root.Q<Button>("btn-host");
-            var btnJoin        = root.Q<Button>("btn-join");
-            var ipField        = root.Q<TextField>("ip-field");
+            var submenu          = root.Q<VisualElement>("submenu");
+            var btnTraining      = root.Q<Button>("btn-training");
+            var btnMultiplayer   = root.Q<Button>("btn-multiplayer");
+            var btnHost          = root.Q<Button>("btn-host");
+            var btnJoin          = root.Q<Button>("btn-join");
+            var ipField          = root.Q<TextField>("ip-field");
             var btnServerBrowser = root.Q<Button>("btn-serverbrowser");
+            _lblHostStatus       = root.Q<Label>("lbl-host-status");
 
             btnTraining.clicked += () =>
             {
@@ -35,13 +42,10 @@ namespace SlopArena.Client.UI
                 submenu.style.display = visible ? DisplayStyle.None : DisplayStyle.Flex;
             };
 
-            btnHost.clicked += () =>
-            {
-                MatchConfig.Mode     = GameMode.PvP;
-                MatchConfig.IsHost   = true;
-                MatchConfig.ServerIP = "127.0.0.1";
-                SceneManager.LoadScene("Lobby");
-            };
+            // Embedded host-and-play (ADR-0005, issue #39): start the game
+            // server as a subprocess, guest-auth with the master server, wait
+            // for registration, then auto-join our own lobby at localhost.
+            btnHost.clicked += OnHostClicked;
 
             btnServerBrowser.clicked += () =>
             {
@@ -58,5 +62,118 @@ namespace SlopArena.Client.UI
                 SceneManager.LoadScene("Lobby");
             };
         }
+
+        private void OnHostClicked()
+        {
+            if (_hosting) return;
+            _hosting = true;
+            _lblHostStatus.style.display = DisplayStyle.Flex;
+            _lblHostStatus.text = "Starting game server...";
+            StartHostingFlow();
+        }
+
+        private async void StartHostingFlow()
+        {
+            // Embedded host-and-play (ADR-0005): spawn the game server as a
+            // subprocess, wait for it to register with the master server, then
+            // auto-join our own lobby at localhost.
+            var host = ServerHost.Create();
+
+            // Guest auth (needed to join the lobby). The server registers with
+            // the master server independently; we only need its server-id.
+            string? authToken = null;
+            long steamId = 0;
+            using (var masterClient = new MasterServerClient(_masterServerUrl))
+            {
+                ClientSession.MasterServerUrl = _masterServerUrl;
+                bool authed = await masterClient.AuthenticateGuestAsync();
+                if (!authed)
+                {
+                    _hosting = false;
+                    _lblHostStatus.text = "Failed to authenticate with master server.";
+                    return;
+                }
+                authToken = masterClient.Token;
+                steamId = masterClient.SteamId ?? 0;
+            }
+
+            var tcs = new TaskCompletionSource<bool>();
+            Guid registeredServerId = Guid.Empty;
+            string? registrationError = null;
+            int? crashCode = null;
+            string? crashStderr = null;
+
+            Action<Guid> onRegistered = id =>
+            {
+                registeredServerId = id;
+                tcs.TrySetResult(true);
+            };
+            Action<string> onRegFailed = reason =>
+            {
+                registrationError = reason;
+                tcs.TrySetResult(false);
+            };
+            Action<int, string> onCrashed = (code, stderr) =>
+            {
+                crashCode = code;
+                crashStderr = stderr;
+                tcs.TrySetResult(false);
+            };
+
+            host.Registered        += onRegistered;
+            host.RegistrationFailed += onRegFailed;
+            host.Crashed            += onCrashed;
+
+            // Spawn the server subprocess now that listeners are wired.
+            host.StartHosting(GenerateServerName());
+
+            // Wait for registration, crash, or a 15s timeout. Pump() runs in
+            // ServerHost.Update, so events fire on the main thread.
+            Task winner = await Task.WhenAny(tcs.Task, Task.Delay(15000));
+
+            host.Registered         -= onRegistered;
+            host.RegistrationFailed  -= onRegFailed;
+            host.Crashed             -= onCrashed;
+
+            if (winner != tcs.Task)
+            {
+                _hosting = false;
+                _lblHostStatus.text = "Server did not register in time. Is the master server running?";
+                host.Stop();
+                return;
+            }
+
+            if (registeredServerId != Guid.Empty)
+            {
+                // Host auto-joins their own lobby at localhost.
+                MatchConfig.Mode     = GameMode.PvP;
+                MatchConfig.IsHost   = true;
+                MatchConfig.ServerIP = "127.0.0.1";
+                MatchConfig.ServerPort = host.AssignedPort;
+
+                ClientSession.AuthToken           = authToken;
+                ClientSession.SteamId             = steamId;
+                ClientSession.SelectedServerId    = registeredServerId;
+                ClientSession.SelectedServerName  = GenerateServerName();
+
+                Debug.Log($"[MainMenu] Hosted server registered (ID {registeredServerId}) on port {host.AssignedPort}. Joining lobby.");
+                SceneManager.LoadScene("LobbyRoom");
+                return;
+            }
+
+            // Failure: registration failed or crash — no silent failure.
+            _hosting = false;
+            if (crashCode != null)
+                _lblHostStatus.text = $"Server crashed (code {crashCode}). {Truncate(crashStderr)}";
+            else
+                _lblHostStatus.text = $"Could not start server: {registrationError}";
+            host.Stop();
+        }
+
+        private static string GenerateServerName() =>
+            $"{System.Environment.MachineName}'s Server";
+
+        private static string Truncate(string? s) =>
+            string.IsNullOrEmpty(s) ? string.Empty : (s.Length > 200 ? s.Substring(0, 200) + "…" : s);
     }
 }

--- a/client/Unity/Assets/UI/MainMenu.uxml
+++ b/client/Unity/Assets/UI/MainMenu.uxml
@@ -2,6 +2,7 @@
     <ui:Style src="SlopArena.uss" />
     <ui:VisualElement name="root" class="screen">
         <ui:Label name="title" text="SLOPARENA" class="title" />
+        <ui:Label name="lbl-host-status" text="" class="subtitle" style="display: none;" />
         <ui:VisualElement name="menu" class="menu-list">
             <ui:Button name="btn-training" text="TRAINING MODE" class="menu-item menu-item--active" />
             <ui:Button name="btn-multiplayer" text="MULTIPLAYER ›" class="menu-item" />

--- a/src/Shared/HostedServerConfig.cs
+++ b/src/Shared/HostedServerConfig.cs
@@ -1,0 +1,53 @@
+using System.Text.Json;
+
+namespace SlopArena.Shared;
+
+/// <summary>
+/// Pure, Unity-free description of the <c>server.json</c> the embedded
+/// host-and-play flow (ADR-0005, issue #39) writes to a temp file before
+/// spawning <c>SlopArena.Server</c> as a subprocess. The server's
+/// <c>ServerConfig.Load</c> deserializes case-insensitively, so the emitted
+/// camelCase keys map onto its PascalCase properties.
+///
+/// Kept in Shared (not <c>SlopArena.Server</c>) so the Unity client can build
+/// it without referencing the server project, and so it is unit-testable from
+/// <c>tests/Shared.Tests</c>.
+/// </summary>
+public sealed record HostedServerConfig
+{
+    /// <summary>Display name in the server browser (e.g. "Binoui's Server").</summary>
+    public string ServerName { get; init; } = "SlopArena Hosted";
+
+    /// <summary>Region tag advertised to the master server.</summary>
+    public string Region { get; init; } = "EU";
+
+    /// <summary>Base UDP port for match instances. The host connects here.</summary>
+    public int Port { get; init; } = 9876;
+
+    /// <summary>
+    /// One match per host for the demo; the orchestrator allocates
+    /// <c>port .. port + MaxConcurrentMatches - 1</c>.
+    /// </summary>
+    public int MaxConcurrentMatches { get; init; } = 1;
+
+    /// <summary>Master server base URL (e.g. http://localhost:5000).</summary>
+    public string MasterServerUrl { get; init; } = "http://localhost:5000";
+
+    /// <summary>Hosted servers are never official.</summary>
+    public bool IsOfficial { get; init; } = false;
+
+    /// <summary>
+    /// Absolute path to the directory holding <c>.arena</c> files. Must be
+    /// absolute because the subprocess runs with a different working directory.
+    /// </summary>
+    public string ArenaDataDir { get; init; } = string.Empty;
+
+    private static readonly JsonSerializerOptions s_jsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true
+    };
+
+    /// <summary>Serialize to the <c>server.json</c> text the server expects.</summary>
+    public string ToJson() => JsonSerializer.Serialize(this, s_jsonOptions);
+}

--- a/src/Shared/ServerLogParser.cs
+++ b/src/Shared/ServerLogParser.cs
@@ -1,0 +1,41 @@
+using System.Text.RegularExpressions;
+
+namespace SlopArena.Shared;
+
+/// <summary>
+/// Parses the embedded game-server subprocess's stdout/stderr to detect the
+/// moment it has registered with the master server (ADR-0005, issue #39).
+///
+/// The server logs the assigned <c>server_id</c> GUID to stdout on a
+/// successful <c>POST /servers/register</c>. Two known line shapes carry it:
+/// <list type="bullet">
+/// <item><c>Registered successfully (Server ID: &lt;guid&gt;).</c> — from <c>Program.cs</c></item>
+/// <item><c>[Registration] Registered as '&lt;name&gt;' (ID: &lt;guid&gt;, IP: &lt;ip&gt;)</c> — from <c>GameServerRegistration</c></item>
+/// </list>
+/// This extracts the GUID generically so log wording changes don't break the
+/// host flow. Pure and Unity-free so it is unit-testable.
+/// </summary>
+public static class ServerLogParser
+{
+    private static readonly Regex s_guid = new(
+        @"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
+        RegexOptions.CultureInvariant);
+
+    /// <summary>
+    /// Try to extract a registration server-id GUID from one stdout/stderr
+    /// line. Returns true and sets <paramref name="serverId"/> on the first
+    /// GUID found; false if the line carries none.
+    /// </summary>
+    public static bool TryParseServerId(string line, out Guid serverId)
+    {
+        serverId = Guid.Empty;
+        if (string.IsNullOrEmpty(line))
+            return false;
+
+        var match = s_guid.Match(line);
+        if (!match.Success)
+            return false;
+
+        return Guid.TryParse(match.Value, out serverId);
+    }
+}

--- a/tests/Shared.Tests/HostedServerConfigTests.cs
+++ b/tests/Shared.Tests/HostedServerConfigTests.cs
@@ -1,0 +1,99 @@
+using System.Text.Json;
+using SlopArena.Shared;
+using Xunit;
+
+namespace SlopArena.Tests;
+
+/// <summary>
+/// Tests for <see cref="HostedServerConfig"/>: the pure builder that emits the
+/// <c>server.json</c> the embedded host-and-play flow (ADR-0005, issue #39)
+/// feeds to <c>SlopArena.Server</c>. Pins the contract the server's
+/// <c>ServerConfig.Load</c> deserializes.
+/// </summary>
+public class HostedServerConfigTests
+{
+    // ── JSON shape the server's ServerConfig.Load expects ──
+
+    [Fact]
+    public void ToJson_EmitsAllRequiredKeys_InCamelCase()
+    {
+        var cfg = new HostedServerConfig
+        {
+            ServerName = "Binoui's Server",
+            Region = "EU",
+            Port = 7777,
+            MaxConcurrentMatches = 1,
+            MasterServerUrl = "http://localhost:5000",
+            ArenaDataDir = "/abs/data/arenas"
+        };
+
+        var doc = JsonDocument.Parse(cfg.ToJson()).RootElement;
+
+        Assert.Equal("Binoui's Server", doc.GetProperty("serverName").GetString());
+        Assert.Equal("EU", doc.GetProperty("region").GetString());
+        Assert.Equal(7777, doc.GetProperty("port").GetInt32());
+        Assert.Equal(1, doc.GetProperty("maxConcurrentMatches").GetInt32());
+        Assert.Equal("http://localhost:5000", doc.GetProperty("masterServerUrl").GetString());
+        Assert.False(doc.GetProperty("isOfficial").GetBoolean());
+        Assert.Equal("/abs/data/arenas", doc.GetProperty("arenaDataDir").GetString());
+    }
+
+    [Fact]
+    public void ToJson_Defaults_AreDemoSafe()
+    {
+        var cfg = new HostedServerConfig { ArenaDataDir = "/x" };
+
+        var doc = JsonDocument.Parse(cfg.ToJson()).RootElement;
+
+        // A demo host: one match slot, not official, sensible port.
+        Assert.Equal(1, doc.GetProperty("maxConcurrentMatches").GetInt32());
+        Assert.False(doc.GetProperty("isOfficial").GetBoolean());
+        Assert.Equal(9876, doc.GetProperty("port").GetInt32());
+    }
+
+    [Fact]
+    public void ToJson_RoundTrips_ThroughServerConfigShape()
+    {
+        // The server deserializes with PropertyNameCaseInsensitive = true, so
+        // our camelCase keys must populate its PascalCase properties. We can't
+        // reference SlopArena.Server here, so mirror its shape and prove the
+        // round-trip via a case-insensitive deserialize.
+        var cfg = new HostedServerConfig
+        {
+            ServerName = "H",
+            Region = "US",
+            Port = 8000,
+            MaxConcurrentMatches = 2,
+            MasterServerUrl = "http://m:5000",
+            IsOfficial = true,
+            ArenaDataDir = "/arenas"
+        };
+
+        var server = JsonSerializer.Deserialize<ServerConfigMirror>(
+            cfg.ToJson(),
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        Assert.NotNull(server);
+        Assert.Equal("H", server!.ServerName);
+        Assert.Equal("US", server.Region);
+        Assert.Equal(8000, server.Port);
+        Assert.Equal(2, server.MaxConcurrentMatches);
+        Assert.Equal("http://m:5000", server.MasterServerUrl);
+        Assert.True(server.IsOfficial);
+        Assert.Equal("/arenas", server.ArenaDataDir);
+    }
+
+    // Mirrors SlopArena.Server.ServerConfig's property names/types so the test
+    // can prove HostedServerConfig's JSON deserializes into the server's config
+    // without referencing the server project.
+    private sealed class ServerConfigMirror
+    {
+        public string ServerName { get; set; } = string.Empty;
+        public string Region { get; set; } = string.Empty;
+        public int Port { get; set; }
+        public int MaxConcurrentMatches { get; set; }
+        public string MasterServerUrl { get; set; } = string.Empty;
+        public bool IsOfficial { get; set; }
+        public string ArenaDataDir { get; set; } = string.Empty;
+    }
+}

--- a/tests/Shared.Tests/ServerLogParserTests.cs
+++ b/tests/Shared.Tests/ServerLogParserTests.cs
@@ -1,0 +1,69 @@
+using SlopArena.Shared;
+using Xunit;
+
+namespace SlopArena.Tests;
+
+/// <summary>
+/// Tests for <see cref="ServerLogParser"/>: the pure seam that detects the
+/// embedded game server's successful master-server registration (ADR-0005,
+/// issue #39) by scanning its stdout for the assigned server-id GUID.
+/// </summary>
+public class ServerLogParserTests
+{
+    // ── Known log line shapes from the server ──
+
+    [Fact]
+    public void TryParseServerId_ProgramCsShape_ReturnsGuid()
+    {
+        var line = "Registered successfully (Server ID: 12345678-1234-1234-1234-1234567890ab).";
+
+        bool ok = ServerLogParser.TryParseServerId(line, out var id);
+
+        Assert.True(ok);
+        Assert.Equal(Guid.Parse("12345678-1234-1234-1234-1234567890ab"), id);
+    }
+
+    [Fact]
+    public void TryParseServerId_RegistrationShape_ReturnsGuid()
+    {
+        var line = "[Registration] Registered as 'SlopArena Local Dev' (ID: aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee, IP: 127.0.0.1)";
+
+        bool ok = ServerLogParser.TryParseServerId(line, out var id);
+
+        Assert.True(ok);
+        Assert.Equal(Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"), id);
+    }
+
+    [Theory]
+    [InlineData("")]                       // empty
+    [InlineData("no guid here")]           // plain text
+    [InlineData("[Registration] Failed: 404")]
+    [InlineData("Server listening on 9876")]
+    public void TryParseServerId_NoGuid_ReturnsFalse(string line)
+    {
+        bool ok = ServerLogParser.TryParseServerId(line, out var id);
+
+        Assert.False(ok);
+        Assert.Equal(Guid.Empty, id);
+    }
+
+    [Fact]
+    public void TryParseServerId_PicksFirstGuid_WhenMultiple()
+    {
+        // Defensive: a line should only carry one GUID, but the parser must
+        // not crash if it ever carries two.
+        var line = "ID: 11111111-1111-1111-1111-111111111111 then 22222222-2222-2222-2222-222222222222";
+
+        bool ok = ServerLogParser.TryParseServerId(line, out var id);
+
+        Assert.True(ok);
+        Assert.Equal(Guid.Parse("11111111-1111-1111-1111-111111111111"), id);
+    }
+
+    [Fact]
+    public void TryParseServerId_Null_DoesNotThrow()
+    {
+        // The Unity caller may pass a null line from a malformed stderr read.
+        Assert.False(ServerLogParser.TryParseServerId(null!, out _));
+    }
+}


### PR DESCRIPTION
## Summary

Implements issue #39 — embedded host-and-play (ADR-0005). A player can now host the game server from within the Unity client; others join via the server browser, and the host connects to their own match at localhost.

Closes #39.

## What's in this PR

**Shared (pure, unit-tested):**
- `HostedServerConfig` — builds the `server.json` the spawned server consumes (camelCase keys map to `ServerConfig`'s PascalCase properties, deserialized case-insensitively).
- `ServerLogParser` — extracts the registration server-id GUID from the server's stdout (`Registered successfully (Server ID: …)` and the `GameServerRegistration` line shape).

**Unity client:**
- `ServerHost` MonoBehaviour singleton (`Runtime/Network/ServerHost.cs`) — spawns `dotnet run --project src/Server/SlopArena.Server.csproj` with a generated `server.json`, picks a free UDP port, reads stdout/stderr on background threads, raises `Registered` / `RegistrationFailed` / `Crashed` events on the main thread via `Pump()`, and kills the process tree on application quit.
- `MainMenuController` Host button — guest-auths with the master server, starts the server subprocess, waits for registration (15s timeout), sets `ClientSession` / `MatchConfig`, and loads `LobbyRoom` so the host auto-joins their own lobby. Surfaces auth/timeout/crash errors in a status label (no silent failure).
- `LobbyRoomUI` — constructs the `LobbyClient` in `OnEnable` (was null; NRE'd every `Pump()`). One-line fix on the critical path the host flow depends on (completes #33).
- `MainMenu.uxml` — host status label.

## Acceptance criteria (#39)

- [x] Player clicks Host → game server starts and registers with master
- [x] Hosted server appears in the server browser (existing registration + heartbeat)
- [x] Host auto-joins own lobby (`LobbyRoom` load + `ClientSession.SelectedServerId`)
- [x] Host connects to localhost for the match (`ServerIP=127.0.0.1`)
- [x] Server subprocess shuts down cleanly on quit (`OnApplicationQuit` → `Stop()`)
- [x] Crash → client shows an error (no silent failure)

## Verification

- `dotnet build src/Shared/` — 0 warnings, 0 errors
- `dotnet test tests/Shared.Tests/` — 407/407 pass (incl. 11 new cases)
- Shared DLL ships to `client/Unity/Assets/Plugins/SlopArena.Shared/` with both new types (verified via `monodis`).
- Unity editor was closed during this work, so Assembly-CSharp was not compiled from CLI — needs an in-Editor import/compile check before testing the Host flow live.

## Notes / non-blockers

- Cold first host (`dotnet run` rebuilds) may exceed the 15s registration timeout on a never-built server; warm cache is fine. Could pre-build or bump the timeout later.
- `FindFreeUdpPort` has a probe→close→bind TOCTOU window; the server's `ReuseAddress` mitigates. Fine for the localhost/LAN demo per ADR-0005.
