### PR TITLE
feat(match): roster-driven match start with character classes (issue #35)

### DIFF
--- a/client/Unity/Assets/Scripts/Runtime/UI/CharSelectController.cs
+++ b/client/Unity/Assets/Scripts/Runtime/UI/CharSelectController.cs
@@ -206,7 +206,43 @@ namespace SlopArena.Client.UI
 
         private async void OnMatchStarted(MatchStartedConfig config)
         {
-            Debug.Log($"[CharSelect] Match started: {config.Players.Count} players.");
+            Debug.Log($"[CharSelect] Match started: {config.Players.Count} players, port={config.MatchPort}, arena={config.ArenaName}.");
+
+            // Find the local player in the roster (by SteamId) and an opponent
+            // (first other player). The master server assigned entity IDs 1..N
+            // by join order (issue #35); the game server spawns each with the
+            // roster's character class, so both clients render the right chars.
+            var players = config.Players;
+            LobbyPlayerInfo? local = null;
+            LobbyPlayerInfo? opponent = null;
+            foreach (var p in players)
+            {
+                if (p.SteamId == ClientSession.SteamId)
+                    local = p;
+                else if (opponent == null)
+                    opponent = p;
+            }
+
+            if (local == null)
+            {
+                _lblPvPStatus.text = "Match started but you are not in the roster. Returning to server browser.";
+                Debug.LogError("[CharSelect] Local player missing from MatchStarted roster.");
+                SceneManager.LoadScene("ServerBrowser");
+                return;
+            }
+
+            // Stash the match config the PvP scene reads on start.
+            MatchConfig.Mode = GameMode.PvP;
+            MatchConfig.ArenaName = string.IsNullOrEmpty(config.ArenaName) ? "split" : config.ArenaName;
+            MatchConfig.ServerPort = config.MatchPort > 0 ? config.MatchPort : MatchConfig.ServerPort;
+            // ServerIP is already set (host: localhost, joiner: server browser IP).
+            MatchConfig.PlayerClass = ParseClass(local.CharacterSelection, _selected);
+            MatchConfig.LocalEntityId = (ulong)(local.EntityId > 0 ? local.EntityId : 1);
+            if (opponent != null)
+            {
+                MatchConfig.OpponentClass = ParseClass(opponent.CharacterSelection, CharacterClass.Manki);
+                MatchConfig.OpponentEntityId = (ulong)(opponent.EntityId > 0 ? opponent.EntityId : 2);
+            }
 
             // Tear down the lobby connection — the match is now handed off to
             // the game server (UDP). Leaving the SignalR lobby connected would
@@ -223,11 +259,19 @@ namespace SlopArena.Client.UI
             ClientSession.ActiveLobby = null;
             ClientSession.LobbyRoster = null;
 
-            // Stash the local player's class for the match
-            MatchConfig.PlayerClass = _selected;
-            MatchConfig.Mode = GameMode.PvP;
-            // TODO: connect to game server (ticket #35). For now, go to StageSelect.
-            SceneManager.LoadScene("StageSelect");
+            // Go straight to the PvP arena — the master server already picked
+            // the arena and assigned the port, so StageSelect is skipped for
+            // online matches (issue #35).
+            SceneManager.LoadScene("Arena_PvP");
+        }
+
+        private static CharacterClass ParseClass(string? name, CharacterClass fallback)
+        {
+            if (string.IsNullOrEmpty(name))
+                return fallback;
+            return System.Enum.TryParse<CharacterClass>(name, ignoreCase: true, out var c) && c != CharacterClass.None
+                ? c
+                : fallback;
         }
 
         private void OnPvPError(string message)

--- a/client/Unity/Assets/Scripts/Runtime/UI/MatchConfig.cs
+++ b/client/Unity/Assets/Scripts/Runtime/UI/MatchConfig.cs
@@ -14,6 +14,13 @@ namespace SlopArena.Client.UI
         public static string ServerIP = "127.0.0.1";
         public static int ServerPort = 9876;
 
+        // Per-match entity IDs assigned by the master server at match start
+        // (issue #35). The local player drives LocalEntityId; the rendered
+        // opponent is OpponentEntityId. Default to the legacy 1/2 so training
+        // and the old join-by-IP path keep working unchanged.
+        public static ulong LocalEntityId = 1;
+        public static ulong OpponentEntityId = 2;
+
         public static void Reset()
         {
             Mode = GameMode.Training;
@@ -23,6 +30,8 @@ namespace SlopArena.Client.UI
             IsHost = true;
             ServerIP = "127.0.0.1";
             ServerPort = 9876;
+            LocalEntityId = 1;
+            OpponentEntityId = 2;
         }
     }
 }

--- a/client/Unity/Assets/Scripts/Runtime/World/MatchBase.cs
+++ b/client/Unity/Assets/Scripts/Runtime/World/MatchBase.cs
@@ -35,7 +35,9 @@ namespace SlopArena.Client.World
         [SerializeField] private Texture2D _crosshairTexture;
         [SerializeField] private float _crosshairSize = 32f;
 
-        protected const ulong PlayerEntityId = 1;
+        // Read from MatchConfig so PvP can use the master-assigned entity ID
+        // (issue #35); training leaves it at the default 1.
+        protected static ulong PlayerEntityId => MatchConfig.LocalEntityId;
 
         protected bool _showCrosshair;
         protected CharacterDefinition _playerDef = null!;

--- a/client/Unity/Assets/Scripts/Runtime/World/PvPMatch.cs
+++ b/client/Unity/Assets/Scripts/Runtime/World/PvPMatch.cs
@@ -24,7 +24,7 @@ namespace SlopArena.Client.World
         [Header("Network")]
         [SerializeField] private NetworkClient _networkClient;
 
-        private const ulong OpponentEntityId = 2;
+        private static ulong OpponentEntityId => MatchConfig.OpponentEntityId;
 
         private uint _tick;
         private MatchState _lastMatchState = MatchState.Waiting;

--- a/src/Server/MatchControlServer.cs
+++ b/src/Server/MatchControlServer.cs
@@ -1,0 +1,152 @@
+using System.Net;
+using System.Text.Json;
+using SlopArena.Shared;
+
+namespace SlopArena.Server
+{
+    /// <summary>
+    /// HTTP control server on the game server (issue #35). Listens on TCP
+    /// <c>config.Port</c> (the registered base port; UDP matches bind
+    /// <c>config.Port + offset</c>, so TCP and UDP coexist on the same number)
+    /// and exposes <c>POST /match/start</c> for the master server.
+    ///
+    /// The handler parses the body with <see cref="MatchStartRequestCodec"/> (the
+    /// pure, unit-tested seam), asks the orchestrator to assign a UDP port with
+    /// the roster, and replies with <c>{ "port": N }</c>. This keeps the game
+    /// server stateless between matches (ADR-0008): one shot in, one port out.
+    ///
+    /// The prefix binds all interfaces (<c>http://*:{port}/</c>) because the
+    /// master server POSTs to the LAN IP returned by
+    /// <c>GameServerRegistration.GetPublicIpAddress()</c> — a loopback-only
+    /// listener would be connection-refused on the real host.
+    /// </summary>
+    public sealed class MatchControlServer : IDisposable
+    {
+        private readonly HttpListener _listener = new();
+        private readonly MultiMatchOrchestrator _orchestrator;
+        private readonly string _defaultArena;
+        private CancellationTokenSource? _cts;
+        private bool _disposed;
+
+        /// <param name="orchestrator">Receives the parsed roster and assigns the match port.</param>
+        /// <param name="port">TCP port to listen on (the game server's registered base port).</param>
+        /// <param name="defaultArena">Arena used when the body omits one.</param>
+        public MatchControlServer(MultiMatchOrchestrator orchestrator, int port, string defaultArena)
+        {
+            _orchestrator = orchestrator;
+            _defaultArena = defaultArena;
+            // '*' binds all interfaces on Linux (no Windows urlacl needed).
+            _listener.Prefixes.Add($"http://*:{port}/");
+        }
+
+        public void Start()
+        {
+            _cts = new CancellationTokenSource();
+            _listener.Start();
+            _ = Task.Run(() => RunAsync(_cts.Token));
+            Console.WriteLine($"[MatchControl] Listening for match-start on TCP port {_listener.Prefixes.First()}");
+        }
+
+        private async Task RunAsync(CancellationToken ct)
+        {
+            while (!ct.IsCancellationRequested && _listener.IsListening)
+            {
+                HttpListenerContext ctx;
+                try
+                {
+                    ctx = await _listener.GetContextAsync();
+                }
+                catch (HttpListenerException) { break; }
+                catch (ObjectDisposedException) { break; }
+
+                try
+                {
+                    await HandleAsync(ctx);
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"[MatchControl] Handler error: {ex.Message}");
+                    try { ctx.Response.StatusCode = 500; await ctx.Response.OutputStream.WriteAsync(System.Text.Encoding.UTF8.GetBytes($"{{\"error\":\"{ex.Message}\"}}")); } catch { }
+                }
+                finally
+                {
+                    try { ctx.Response.Close(); } catch { }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Pure handler (extracted for testability): parse + assign, no socket
+        /// I/O. Returns the assigned UDP port (>=1) or 0 on a bad request, with a
+        /// human-readable error. The caller is responsible for writing the HTTP
+        /// response. Throws on an internal error (orchestrator failure).
+        /// </summary>
+        public (int port, string? error) TryStartMatch(string jsonBody)
+        {
+            MatchStartRequest? req;
+            try
+            {
+                using var doc = JsonDocument.Parse(jsonBody);
+                req = MatchStartRequestCodec.TryParse(doc.RootElement);
+            }
+            catch (JsonException)
+            {
+                return (0, "Malformed JSON body.");
+            }
+
+            if (req is null)
+                return (0, "Invalid match-start body (need matchId, arenaName, and >=2 players with a known characterClass + entityId).");
+
+            var arena = string.IsNullOrEmpty(req.ArenaName) ? _defaultArena : req.ArenaName;
+            int port = _orchestrator.AssignMatch(req.MatchId, arena, req.Players);
+            if (port < 0)
+                return (0, "No match slots available on this game server.");
+
+            return (port, null);
+        }
+
+        private async Task HandleAsync(HttpListenerContext ctx)
+        {
+            var path = ctx.Request.Url?.AbsolutePath.TrimEnd('/') ?? "";
+            if (!ctx.Request.HttpMethod.Equals("POST", StringComparison.OrdinalIgnoreCase)
+                || !path.EndsWith("/match/start", StringComparison.OrdinalIgnoreCase))
+            {
+                ctx.Response.StatusCode = 404;
+                return;
+            }
+
+            string body;
+            using (var sr = new StreamReader(ctx.Request.InputStream, ctx.Request.ContentEncoding))
+                body = await sr.ReadToEndAsync();
+
+            var (port, error) = TryStartMatch(body);
+            if (error is not null)
+            {
+                ctx.Response.StatusCode = 400;
+                ctx.Response.ContentType = "application/json";
+                var errBytes = System.Text.Encoding.UTF8.GetBytes($"{{\"error\":\"{error}\"}}");
+                await ctx.Response.OutputStream.WriteAsync(errBytes);
+                return;
+            }
+
+            ctx.Response.ContentType = "application/json";
+            var ok = System.Text.Encoding.UTF8.GetBytes($"{{\"port\":{port}}}");
+            await ctx.Response.OutputStream.WriteAsync(ok);
+        }
+
+        public void Stop()
+        {
+            try { _cts?.Cancel(); } catch { }
+            try { _listener.Stop(); } catch { }
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            Stop();
+            _cts?.Dispose();
+            ((IDisposable)_listener).Dispose();
+        }
+    }
+}

--- a/src/Server/MatchInstance.cs
+++ b/src/Server/MatchInstance.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net;
 using System.Net.Sockets;
@@ -6,35 +7,29 @@ using SlopArena.Shared;
 namespace SlopArena.Server
 {
 	/// <summary>
-	/// One match instance — 2 players, 60Hz UDP simulation on a dedicated port.
+	/// One match instance — 2-4 players, 60Hz UDP simulation on a dedicated port.
 	/// Runs on its own thread. Uses ServerSimulation for full hit detection,
 	/// hurtbox tracking, and void death.
+	///
+	/// Roster-driven (issue #35): the master server sends the locked-in character
+	/// classes + entity IDs via <c>POST /match/start</c>; this instance spawns one
+	/// entity per player with the correct <see cref="CharacterClass"/> instead of
+	/// hardcoded Manki. Countdown starts once every rostered player has connected.
 	/// </summary>
 	public class MatchInstance
 	{
-		private const ulong P1EntityId = 1;
-		private const ulong P2EntityId = 2;
-
 		private readonly int _port;
 		private readonly string _matchId;
 		private readonly string _arenaName;
+		private readonly List<PlayerSlot> _slots;
 
 		private UdpClient? _udpServer;
-		private IPEndPoint? _player1EndPoint;
-		private IPEndPoint? _player2EndPoint;
 		private bool _running = true;
 
 		private ArenaDefinition _arena;
 		private ServerSimulation _sim = null!;
-
-		// Input buffering (per player, keyed by tick)
-		private readonly List<(uint tick, InputState input)> _p1Queue = new();
-		private readonly List<(uint tick, InputState input)> _p2Queue = new();
 		private uint _serverTick;
 
-		// Connection timeout
-		private DateTime _lastP1Packet = DateTime.UtcNow;
-		private DateTime _lastP2Packet = DateTime.UtcNow;
 		private const double TimeoutSeconds = 5.0;
 
 		// Match lifecycle
@@ -49,13 +44,25 @@ namespace SlopArena.Server
 		private Thread? _thread;
 		private readonly Action<int> _onMatchEnd;
 
-		public MatchInstance(int port, string matchId, string arenaName, Action<int> onMatchEnd)
+		/// <param name="roster">Ordered players (index 0 = host). Each carries an entity ID (1..N) and a character class.</param>
+		public MatchInstance(int port, string matchId, string arenaName,
+			IReadOnlyList<MatchPlayer> roster, Action<int> onMatchEnd)
 		{
 			_port = port;
 			_matchId = matchId;
 			_arenaName = arenaName;
 			_onMatchEnd = onMatchEnd;
+
+			_slots = new List<PlayerSlot>(roster.Count);
+			foreach (var p in roster)
+				_slots.Add(new PlayerSlot((ulong)p.EntityId, p.CharacterClass));
 		}
+
+		/// <summary>True while the match loop is active.</summary>
+		public bool IsRunning => _running;
+
+		/// <summary>Number of rostered players.</summary>
+		public int PlayerCount => _slots.Count;
 
 		public void Start()
 		{
@@ -69,30 +76,27 @@ namespace SlopArena.Server
 			try { _udpServer?.Close(); } catch { }
 		}
 
-		public bool IsRunning => _running;
-
 		private void Run()
 		{
-			Console.WriteLine($"[Match:{_matchId}] Starting on port {_port}");
+			Console.WriteLine($"[Match:{_matchId}] Starting on port {_port} ({_slots.Count} players)");
 
 			_arena = ArenaRegistry.Get(_arenaName);
-			var p1Def = CharacterRegistry.Get(CharacterClass.Manki);
-			var p2Def = CharacterRegistry.Get(CharacterClass.Manki);
 
-			// Load baked skeleton data
-			var p1Baked = LoadBakedData(p1Def);
-			var p2Baked = LoadBakedData(p2Def);
-
-			// Create simulation and register both entities
 			_sim = new ServerSimulation(_arena);
-			_sim.RegisterEntity(P1EntityId, p1Def, CreateInitialState(p1Def, 0), p1Baked);
-			_sim.RegisterEntity(P2EntityId, p2Def, CreateInitialState(p2Def, 1), p2Baked);
+			for (int i = 0; i < _slots.Count; i++)
+			{
+				var slot = _slots[i];
+				var def = CharacterRegistry.Get(slot.CharacterClass);
+				var baked = LoadBakedData(def);
+				_sim.RegisterEntity(slot.EntityId, def, CreateInitialState(def, i), baked);
+				Console.WriteLine($"[Match:{_matchId}] Slot {i}: entity {slot.EntityId} = {slot.CharacterClass}");
+			}
 
 			try
 			{
 				_udpServer = new UdpClient(_port);
 				_udpServer.Client.Blocking = false;
-				Console.WriteLine($"[Match:{_matchId}] Listening on UDP {_port}, waiting for 2 players...");
+				Console.WriteLine($"[Match:{_matchId}] Listening on UDP {_port}, waiting for {_slots.Count} players...");
 			}
 			catch (Exception ex)
 			{
@@ -111,16 +115,25 @@ namespace SlopArena.Server
 				if (currentTime >= nextTickTime)
 				{
 					ReceiveInputs();
-					if (_player1EndPoint != null && _player2EndPoint != null)
+					if (AllConnected())
 					{
-						// Check for disconnected players
+						// Check for disconnected players.
 						var now = DateTime.UtcNow;
-						bool p1Timeout = (now - _lastP1Packet).TotalSeconds > TimeoutSeconds;
-						bool p2Timeout = (now - _lastP2Packet).TotalSeconds > TimeoutSeconds;
-
-						if (p1Timeout || p2Timeout)
+						bool anyTimeout = false;
+						string timedOut = "";
+						foreach (var slot in _slots)
 						{
-							Console.WriteLine($"[Match:{_matchId}] Player {(p1Timeout ? "1" : "2")} timed out — stopping match.");
+							if (slot.EndPoint != null && (now - slot.LastPacket).TotalSeconds > TimeoutSeconds)
+							{
+								anyTimeout = true;
+								timedOut = slot.EntityId.ToString();
+								break;
+							}
+						}
+
+						if (anyTimeout)
+						{
+							Console.WriteLine($"[Match:{_matchId}] Player (entity {timedOut}) timed out — stopping match.");
 							_running = false;
 							continue;
 						}
@@ -147,21 +160,31 @@ namespace SlopArena.Server
 			_onMatchEnd(_port);
 		}
 
+		private bool AllConnected()
+		{
+			foreach (var slot in _slots)
+				if (slot.EndPoint == null) return false;
+			return true;
+		}
+
 		private static BakedAnimationData? LoadBakedData(CharacterDefinition def)
 		{
+			// Reuse the existing BakedDataPath + LoadFromBin path (same as the
+			// pre-refactor server). Falls back to null (no baked skeleton) when
+			// the file is absent or unreadable.
 			if (string.IsNullOrEmpty(def.BakedDataPath)) return null;
 
 			try
 			{
 				string sysPath = def.BakedDataPath.Replace("res://", "");
-				var binData = System.IO.File.ReadAllBytes(sysPath);
+				var binData = File.ReadAllBytes(sysPath);
 				var baked = BakedAnimationData.LoadFromBin(binData);
-				Console.WriteLine($"[Server] Loaded baked data: {sysPath} ({binData.Length} bytes, {baked.Animations.Length} anims)");
+				Console.WriteLine($"[Match] Loaded baked data: {sysPath} ({binData.Length} bytes, {baked.Animations.Length} anims)");
 				return baked;
 			}
 			catch (Exception ex)
 			{
-				Console.WriteLine($"[Server] Failed to load baked data: {ex.Message} — using fallback capsules");
+				Console.WriteLine($"[Match] Failed to load baked data: {ex.Message} — using fallback");
 				return null;
 			}
 		}
@@ -205,50 +228,41 @@ namespace SlopArena.Server
 					ulong entityId = BitConverter.ToUInt64(data, 0);
 					uint clientTick = BitConverter.ToUInt32(data, 8);
 
-					// Map entity ID to player slot
-					bool isP1 = entityId == P1EntityId;
-					bool isP2 = entityId == P2EntityId;
+					var slot = FindSlot(entityId);
+					if (slot == null) continue; // not a rostered player
 
-					// New player connecting — register their endpoint
-					if (!isP1 && !isP2)
-						continue;
+					// New player connecting — register their endpoint.
+					if (slot.EndPoint == null)
+					{
+						slot.EndPoint = remoteEP;
+						slot.LastPacket = DateTime.UtcNow;
+						Console.WriteLine($"[Match:{_matchId}] Player (entity {entityId}) connected: {remoteEP}");
 
-					if (isP1 && _player1EndPoint == null)
-					{
-						_player1EndPoint = remoteEP;
-						_lastP1Packet = DateTime.UtcNow;
-						Console.WriteLine($"[Match:{_matchId}] Player 1 (entity {entityId}) connected: {remoteEP}");
-						continue;
-					}
-					if (isP2 && _player2EndPoint == null)
-					{
-						_player2EndPoint = remoteEP;
-						_lastP2Packet = DateTime.UtcNow;
-						_matchState = MatchState.Countdown;
-						_countdownTicks = CountdownDuration;
-						Console.WriteLine($"[Match:{_matchId}] Player 2 (entity {entityId}) connected: {remoteEP} — countdown started!");
+						// Start the countdown once the last player connects.
+						if (AllConnected() && _matchState == MatchState.Waiting)
+						{
+							_matchState = MatchState.Countdown;
+							_countdownTicks = CountdownDuration;
+							Console.WriteLine($"[Match:{_matchId}] All {_slots.Count} players connected — countdown started!");
+						}
 						continue;
 					}
 
-					// Update last packet time for timeout detection
-					if (isP1) _lastP1Packet = DateTime.UtcNow;
-					if (isP2) _lastP2Packet = DateTime.UtcNow;
+					slot.LastPacket = DateTime.UtcNow;
 
 					if (clientTick <= _serverTick) continue;
 
-					// Parse input and wrap in a minimal packet for the queue
 					var inputState = InputState.Deserialize(data.AsSpan(12));
-					var queue = isP1 ? _p1Queue : _p2Queue;
 
 					// Prevent duplicates
 					bool exists = false;
-					for (int i = 0; i < queue.Count; i++)
+					for (int i = 0; i < slot.Queue.Count; i++)
 					{
-						if (queue[i].tick == clientTick)
+						if (slot.Queue[i].tick == clientTick)
 						{ exists = true; break; }
 					}
 					if (!exists)
-						queue.Add((clientTick, inputState));
+						slot.Queue.Add((clientTick, inputState));
 				}
 				catch (SocketException ex)
 				{
@@ -262,6 +276,13 @@ namespace SlopArena.Server
 					break;
 				}
 			}
+		}
+
+		private PlayerSlot? FindSlot(ulong entityId)
+		{
+			foreach (var s in _slots)
+				if (s.EntityId == entityId) return s;
+			return null;
 		}
 
 		private void Tick()
@@ -289,21 +310,15 @@ namespace SlopArena.Server
 				return;
 			}
 
-			var p1Input = FlushQueue(_p1Queue, out _);
-			var p2Input = FlushQueue(_p2Queue, out _);
-
 			var inputs = new Dictionary<ulong, InputState>();
-
-			if (p1Input.HasValue)
+			foreach (var slot in _slots)
 			{
-				_serverTick = Math.Max(_serverTick, p1Input.Value.tick);
-				inputs[P1EntityId] = p1Input.Value.input;
-			}
-
-			if (p2Input.HasValue)
-			{
-				_serverTick = Math.Max(_serverTick, p2Input.Value.tick);
-				inputs[P2EntityId] = p2Input.Value.input;
+				var input = FlushQueue(slot.Queue, out _);
+				if (input.HasValue)
+				{
+					_serverTick = Math.Max(_serverTick, input.Value.tick);
+					inputs[slot.EntityId] = input.Value.input;
+				}
 			}
 
 			// Run authoritative simulation (movement + hit detection + hurtboxes + void death)
@@ -311,23 +326,33 @@ namespace SlopArena.Server
 			{
 				_sim.Tick(inputs);
 
-				// Check for match end (first to MaxDeaths loses)
-				var p1State = _sim.GetState(P1EntityId);
-				var p2State = _sim.GetState(P2EntityId);
-
-				if (p1State.Deaths >= MaxDeaths)
+				// Check for match end (first to MaxDeaths loses).
+				ulong? winner = null;
+				ulong? loser = null;
+			foreach (var slot in _slots)
 				{
-					_matchState = MatchState.Ended;
-					_winnerEntityId = P2EntityId;
-					_postMatchTicks = PostMatchDuration;
-					Console.WriteLine($"[Match:{_matchId}] Player 1 eliminated! Player 2 wins! ({p1State.Deaths}-{p2State.Deaths})");
+					var st = _sim.GetState(slot.EntityId);
+					if (st.Deaths >= MaxDeaths)
+					{
+						loser = slot.EntityId;
+						break;
+					}
 				}
-				else if (p2State.Deaths >= MaxDeaths)
+				if (loser.HasValue)
 				{
+					// Winner = the first other player still under the death limit.
+					foreach (var slot in _slots)
+					{
+						if (slot.EntityId != loser.Value)
+						{
+							var st = _sim.GetState(slot.EntityId);
+							if (st.Deaths < MaxDeaths) { winner = slot.EntityId; break; }
+						}
+					}
 					_matchState = MatchState.Ended;
-					_winnerEntityId = P1EntityId;
+					_winnerEntityId = winner ?? 0;
 					_postMatchTicks = PostMatchDuration;
-					Console.WriteLine($"[Match:{_matchId}] Player 2 eliminated! Player 1 wins! ({p1State.Deaths}-{p2State.Deaths})");
+					Console.WriteLine($"[Match:{_matchId}] Entity {loser.Value} eliminated! Winner: {_winnerEntityId}");
 				}
 
 				SendState();
@@ -340,35 +365,29 @@ namespace SlopArena.Server
 
 			// Packet format (matching NetworkClient expectations):
 			//   entityId(8) + tick(4) + CharacterStatePacket(48)
-			const int envelopeSize = 8 + 4 + CharacterStatePacket.Size; // 60 bytes
+			const int envelopeSize = 8 + 4 + CharacterStatePacket.Size;
 
-			var p1Packet = CharacterStatePacket.FromState(_sim.GetState(P1EntityId), _serverTick);
-			p1Packet.MatchState = _matchState;
-			var p2Packet = CharacterStatePacket.FromState(_sim.GetState(P2EntityId), _serverTick);
-			p2Packet.MatchState = _matchState;
+			// Build a packet per entity once, then send each to every connected client.
+			var packets = new List<(ulong entityId, byte[] buffer)>(_slots.Count);
+			foreach (var slot in _slots)
+			{
+				var statePacket = CharacterStatePacket.FromState(_sim.GetState(slot.EntityId), _serverTick);
+				statePacket.MatchState = _matchState;
 
-			Span<byte> p1Buf = stackalloc byte[envelopeSize];
-			BitConverter.TryWriteBytes(p1Buf.Slice(0, 8), P1EntityId);
-			BitConverter.TryWriteBytes(p1Buf.Slice(8, 4), _serverTick);
-			p1Packet.Serialize(p1Buf.Slice(12));
-
-			Span<byte> p2Buf = stackalloc byte[envelopeSize];
-			BitConverter.TryWriteBytes(p2Buf.Slice(0, 8), P2EntityId);
-			BitConverter.TryWriteBytes(p2Buf.Slice(8, 4), _serverTick);
-			p2Packet.Serialize(p2Buf.Slice(12));
+				var buf = new byte[envelopeSize];
+				BitConverter.TryWriteBytes(buf.AsSpan(0, 8), slot.EntityId);
+				BitConverter.TryWriteBytes(buf.AsSpan(8, 4), _serverTick);
+				statePacket.Serialize(buf.AsSpan(12));
+				packets.Add((slot.EntityId, buf));
+			}
 
 			try
 			{
-				// Send both states to both players (T1.6)
-				if (_player1EndPoint != null)
+				foreach (var slot in _slots)
 				{
-					_udpServer.Send(p1Buf.ToArray(), envelopeSize, _player1EndPoint);
-					_udpServer.Send(p2Buf.ToArray(), envelopeSize, _player1EndPoint);
-				}
-				if (_player2EndPoint != null)
-				{
-					_udpServer.Send(p1Buf.ToArray(), envelopeSize, _player2EndPoint);
-					_udpServer.Send(p2Buf.ToArray(), envelopeSize, _player2EndPoint);
+					if (slot.EndPoint == null) continue;
+					foreach (var pkt in packets)
+						_udpServer.Send(pkt.buffer, envelopeSize, slot.EndPoint);
 				}
 			}
 			catch (Exception ex)
@@ -392,5 +411,23 @@ namespace SlopArena.Server
 			return last;
 		}
 
+		/// <summary>
+		/// Per-player state held outside the simulation: the client's UDP endpoint,
+		/// its input queue, and the last-seen packet time for timeout detection.
+		/// </summary>
+		private sealed class PlayerSlot
+		{
+			public ulong EntityId { get; }
+			public CharacterClass CharacterClass { get; }
+			public IPEndPoint? EndPoint { get; set; }
+			public DateTime LastPacket { get; set; } = DateTime.UtcNow;
+			public List<(uint tick, InputState input)> Queue { get; } = new();
+
+			public PlayerSlot(ulong entityId, CharacterClass characterClass)
+			{
+				EntityId = entityId;
+				CharacterClass = characterClass;
+			}
+		}
 	}
 }

--- a/src/Server/MultiMatchOrchestrator.cs
+++ b/src/Server/MultiMatchOrchestrator.cs
@@ -1,5 +1,7 @@
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Text.Json;
+using SlopArena.Shared;
 
 namespace SlopArena.Server
 {
@@ -8,7 +10,7 @@ namespace SlopArena.Server
     /// Manages port allocation, match lifecycle, and provides status.
     ///
     /// Port allocation: base_port → base_port + max_matches - 1
-    /// Each port handles one 1v1 match with 2 players.
+    /// Each port handles one match (2-4 players).
     /// </summary>
     public class MultiMatchOrchestrator
     {
@@ -21,21 +23,22 @@ namespace SlopArena.Server
         }
 
         /// <summary>
-        /// Assign a new match to the next available port.
-        /// Returns the port assigned, or -1 if no slots available.
+        /// Assign a new match to the next available port with a roster of
+        /// players + character classes (issue #35). Returns the assigned UDP
+        /// port, or -1 if no slots are available.
         /// </summary>
-        public int AssignMatch(string matchId, string arenaName)
+        public int AssignMatch(string matchId, string arenaName, IReadOnlyList<MatchPlayer> roster)
         {
             for (int offset = 0; offset < _config.MaxConcurrentMatches; offset++)
             {
                 int port = _config.Port + offset;
                 if (!_activeMatches.ContainsKey(port))
                 {
-                    var match = new MatchInstance(port, matchId, arenaName, OnMatchEnd);
+                    var match = new MatchInstance(port, matchId, arenaName, roster, OnMatchEnd);
                     if (_activeMatches.TryAdd(port, match))
                     {
                         match.Start();
-                        Console.WriteLine($"[Orchestrator] Match {matchId} assigned to port {port} ({_activeMatches.Count}/{_config.MaxConcurrentMatches})");
+                        Console.WriteLine($"[Orchestrator] Match {matchId} assigned to port {port} ({_activeMatches.Count}/{_config.MaxConcurrentMatches}) — {roster.Count} players");
                         return port;
                     }
                 }
@@ -44,6 +47,16 @@ namespace SlopArena.Server
             Console.WriteLine($"[Orchestrator] No ports available for match {matchId} (max {_config.MaxConcurrentMatches})");
             return -1;
         }
+
+        /// <summary>
+        /// Assign a match with two Manki players (legacy/training path).
+        /// </summary>
+        public int AssignMatch(string matchId, string arenaName)
+            => AssignMatch(matchId, arenaName, new[]
+            {
+                new MatchPlayer(0, CharacterClass.Manki, 1),
+                new MatchPlayer(0, CharacterClass.Manki, 2),
+            });
 
         /// <summary>
         /// Called by MatchInstance when a match ends (thread callback).

--- a/src/Server/Program.cs
+++ b/src/Server/Program.cs
@@ -26,6 +26,12 @@ namespace SlopArena.Server
             var registration = new GameServerRegistration(config, orchestrator);
             var cts = new CancellationTokenSource();
 
+            // HTTP control endpoint for master server match-start commands
+            // (issue #35). Listens on the registered base TCP port; UDP matches
+            // bind port+offset, so the two coexist on the same number.
+            using var control = new MatchControlServer(orchestrator, config.Port, defaultArena: "split");
+            control.Start();
+
             // Handle Ctrl+C for graceful shutdown
             Console.CancelKeyPress += (sender, e) =>
             {
@@ -64,8 +70,10 @@ namespace SlopArena.Server
                 try { await Task.Delay(-1, cts.Token); } catch (TaskCanceledException) { }
             }
 
+            control.Stop();
             orchestrator.Shutdown();
             Console.WriteLine("Server stopped.");
+
         }
     }
 }

--- a/src/Shared/LobbyPayloadCodec.cs
+++ b/src/Shared/LobbyPayloadCodec.cs
@@ -47,12 +47,22 @@ public static class LobbyPayloadCodec
             lockedIn = li.GetBoolean();
         }
 
+        // entityId is optional (only sent on the MatchStarted push, issue #35);
+        // default 0 when absent (lobby/char-select snapshots).
+        int entityId = 0;
+        if (element.TryGetProperty("entityId", out var eid) &&
+            eid.ValueKind == JsonValueKind.Number)
+        {
+            entityId = eid.GetInt32();
+        }
+
         return new LobbyPlayerInfo(
             steam.GetInt64(),
             name.GetString()!,
             selection,
             lockedIn,
-            host.GetBoolean());
+            host.GetBoolean(),
+            entityId);
     }
 
     /// <summary>
@@ -95,12 +105,31 @@ public static class LobbyPayloadCodec
     }
 
     /// <summary>
-    /// Parse a <c>MatchStartedConfig</c>-shaped element: same shape as a
-    /// snapshot (<c>{ serverId, players[] }</c>).
+    /// Parse a <c>MatchStartedConfig</c>-shaped element: a snapshot
+    /// (<c>{ serverId, players[] }</c>) plus the match-start fields
+    /// <c>matchPort</c> (int) and <c>arenaName</c> (string) added by issue #35.
+    /// Both are optional (default 0 / "") so older pushes still parse.
     /// </summary>
     public static MatchStartedConfig? TryParseMatchStarted(JsonElement element)
     {
         var snap = TryParseSnapshot(element);
-        return snap is null ? null : new MatchStartedConfig(snap.ServerId, snap.Players);
+        if (snap is null) return null;
+
+        int matchPort = 0;
+        if (element.TryGetProperty("matchPort", out var mp) &&
+            mp.ValueKind == JsonValueKind.Number)
+        {
+            matchPort = mp.GetInt32();
+        }
+
+        string arenaName = string.Empty;
+        if (element.TryGetProperty("arenaName", out var an) &&
+            an.ValueKind == JsonValueKind.String)
+        {
+            var s = an.GetString();
+            if (!string.IsNullOrEmpty(s)) arenaName = s;
+        }
+
+        return new MatchStartedConfig(snap.ServerId, snap.Players, matchPort, arenaName);
     }
 }

--- a/src/Shared/LobbyPlayerInfo.cs
+++ b/src/Shared/LobbyPlayerInfo.cs
@@ -6,16 +6,15 @@ namespace SlopArena.Shared;
 /// Lobby state lives on the master server; the client only mirrors snapshots
 /// pushed via <c>LobbyUpdated</c>/<c>PlayerJoined</c>/<c>MatchStarting</c>.
 /// </summary>
-/// <param name="SteamId">Guest SteamId assigned by the master server.</param>
-/// <param name="Name">Display name (guest username, e.g. "Guest-12345").</param>
-/// <param name="CharacterSelection">
-/// Picked character class name, or null while not yet chosen (char-select
-/// lands in a later ticket; the hub always sends null for now).
-/// </param>
 /// <param name="IsHost">True for the lobby host (first joiner; promoted on leave).</param>
+/// <param name="EntityId">
+/// Server-side entity ID assigned to this player at match start (1..N by join
+/// order), or 0 when not yet assigned (lobby/char-select snapshots, issue #35).
+/// </param>
 public sealed record LobbyPlayerInfo(
     long SteamId,
     string Name,
     string? CharacterSelection,
     bool LockedIn,
-    bool IsHost);
+    bool IsHost,
+    int EntityId = 0);

--- a/src/Shared/MatchStartRequest.cs
+++ b/src/Shared/MatchStartRequest.cs
@@ -1,0 +1,103 @@
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace SlopArena.Shared;
+
+/// <summary>
+/// A player in the master server's match-start command to the game server
+/// (ADR-0008, issue #35). The master server assigns <see cref="EntityId"/>
+/// (1..N by lobby join order) and sends the locked-in character class so the
+/// game server spawns the right entity instead of hardcoded Manki.
+/// </summary>
+/// <param name="SteamId">Guest SteamId (identifies the player across master + game server).</param>
+/// <param name="CharacterClass">Locked-in character class the game server must spawn.</param>
+/// <param name="EntityId">Server entity ID (1..N) the player drives and the server broadcasts state for.</param>
+public sealed record MatchPlayer(long SteamId, CharacterClass CharacterClass, int EntityId);
+
+/// <summary>
+/// Body of the master server's <c>POST /match/start</c> call to the game server
+/// (ADR-0008, issue #35). The game server spawns one entity per player with the
+/// given character class + entity ID, runs the match on a dedicated UDP port,
+/// and replies with that port so the master server can broadcast it to clients.
+/// </summary>
+/// <param name="MatchId">Opaque match identifier (for logging + orchestrator bookkeeping).</param>
+/// <param name="ArenaName">Arena the game server should load for this match.</param>
+/// <param name="Players">Ordered roster (index 0 = host) the game server spawns.</param>
+public sealed record MatchStartRequest(string MatchId, string ArenaName, IReadOnlyList<MatchPlayer> Players);
+
+/// <summary>
+/// Parses the <c>POST /match/start</c> JSON body (<see cref="MatchStartRequest"/>).
+/// Pure + dependency-free so it is unit-testable from <c>tests/Shared.Tests</c>
+/// without the game server runtime. Wire keys are camelCase
+/// (<c>matchId</c>, <c>arenaName</c>, <c>players</c>, <c>steamId</c>,
+/// <c>characterClass</c>, <c>entityId</c>), matching System.Text.Json's default
+/// policy on the master server.
+/// </summary>
+public static class MatchStartRequestCodec
+{
+    /// <summary>
+    /// Parse a <see cref="MatchStartRequest"/>-shaped element. Returns null on
+    /// any shape mismatch (including an unrecognised character class) so a
+    /// malformed command never spawns a partial match.
+    /// </summary>
+    public static MatchStartRequest? TryParse(JsonElement element)
+    {
+        if (element.ValueKind != JsonValueKind.Object)
+            return null;
+
+        if (!element.TryGetProperty("matchId", out var mid) || mid.ValueKind != JsonValueKind.String)
+            return null;
+        string matchId = mid.GetString()!;
+        if (string.IsNullOrEmpty(matchId))
+            return null;
+
+        // arenaName is optional: a missing/empty value is treated as "" so the
+        // game server can apply its own default arena (issue #35 review). Only
+        // a present-but-non-string value is malformed.
+        string arenaName = string.Empty;
+        if (element.TryGetProperty("arenaName", out var arena))
+        {
+            if (arena.ValueKind != JsonValueKind.String)
+                return null;
+            arenaName = arena.GetString() ?? string.Empty;
+        }
+
+        if (!element.TryGetProperty("players", out var players) || players.ValueKind != JsonValueKind.Array)
+            return null;
+
+        var list = new List<MatchPlayer>();
+        foreach (var item in players.EnumerateArray())
+        {
+            if (item.ValueKind != JsonValueKind.Object)
+                return null;
+
+            if (!item.TryGetProperty("steamId", out var steam) || steam.ValueKind != JsonValueKind.Number)
+                return null;
+
+            if (!item.TryGetProperty("characterClass", out var cc) || cc.ValueKind != JsonValueKind.String)
+                return null;
+            string classStr = cc.GetString()!;
+            if (string.IsNullOrEmpty(classStr))
+                return null;
+            // Case-insensitive enum parse; reject unknown classes so a typo can't
+            // silently spawn Manki (the exact bug this ticket fixes).
+            if (!System.Enum.TryParse<CharacterClass>(classStr, ignoreCase: true, out var characterClass))
+                return null;
+            if (characterClass == CharacterClass.None)
+                return null;
+
+            if (!item.TryGetProperty("entityId", out var eid) || eid.ValueKind != JsonValueKind.Number)
+                return null;
+            int entityId = eid.GetInt32();
+            if (entityId <= 0)
+                return null;
+
+            list.Add(new MatchPlayer(steam.GetInt64(), characterClass, entityId));
+        }
+
+        if (list.Count < 2)
+            return null;
+
+        return new MatchStartRequest(matchId, arenaName, list);
+    }
+}

--- a/src/Shared/MatchStartedConfig.cs
+++ b/src/Shared/MatchStartedConfig.cs
@@ -4,10 +4,17 @@ using System.Collections.Generic;
 namespace SlopArena.Shared;
 
 /// <summary>
-/// Payload of the <see cref="LobbyClient.MatchStarted"/> push broadcast when
-/// the host starts the actual match from char select (ADR-0008, issue #34).
-/// Carries the final roster with character classes the game server will spawn.
+/// Payload of the <see cref="SlopArena.Client.Network.LobbyClient.MatchStarted"/>
+/// push broadcast when the host starts the actual match from char select
+/// (ADR-0008, issue #34/#35). Carries the final roster with character classes,
+/// the UDP port the match is running on, and the arena the game server loaded.
+/// Clients connect to the game server (IP known from the server browser entry)
+/// at <see cref="MatchPort"/>.
 /// </summary>
+/// <param name="MatchPort">UDP port the game server assigned to this match (0 while unknown).</param>
+/// <param name="ArenaName">Arena the game server loaded for this match (empty until assigned).</param>
 public sealed record MatchStartedConfig(
     Guid ServerId,
-    IReadOnlyList<LobbyPlayerInfo> Players);
+    IReadOnlyList<LobbyPlayerInfo> Players,
+    int MatchPort = 0,
+    string ArenaName = "");

--- a/tests/Shared.Tests/LobbyPayloadCodecTests.cs
+++ b/tests/Shared.Tests/LobbyPayloadCodecTests.cs
@@ -175,4 +175,68 @@ public class LobbyPayloadCodecTests
     {
         Assert.Null(LobbyPayloadCodec.TryParseMatchStarted(Parse("""{"players":[]}""")));
     }
+    // ── Player.entityId (issue #35) ──
+
+    [Fact]
+    public void TryParsePlayer_WithEntityId_ReturnsEntityId()
+    {
+        var el = Parse("""{"steamId":1,"name":"A","characterSelection":"Manki","lockedIn":true,"isHost":true,"entityId":3}""");
+
+        var p = LobbyPayloadCodec.TryParsePlayer(el);
+
+        Assert.NotNull(p);
+        Assert.Equal(3, p!.EntityId);
+    }
+
+    [Fact]
+    public void TryParsePlayer_MissingEntityId_DefaultsZero()
+    {
+        var el = Parse("""{"steamId":1,"name":"A","isHost":true}""");
+
+        var p = LobbyPayloadCodec.TryParsePlayer(el);
+
+        Assert.NotNull(p);
+        Assert.Equal(0, p!.EntityId);
+    }
+
+    // ── MatchStarted matchPort + arenaName (issue #35) ──
+
+    [Fact]
+    public void TryParseMatchStarted_ParsesMatchPortAndArena()
+    {
+        var json = """
+        {"serverId":"22222222-2222-2222-2222-222222222222","matchPort":9877,"arenaName":"split","players":[
+            {"steamId":1,"name":"A","characterSelection":"Manki","lockedIn":true,"isHost":true,"entityId":1},
+            {"steamId":2,"name":"B","characterSelection":"FightGuy","lockedIn":true,"isHost":false,"entityId":2}
+        ]}
+        """;
+
+        var cfg = LobbyPayloadCodec.TryParseMatchStarted(Parse(json));
+
+        Assert.NotNull(cfg);
+        Assert.Equal(9877, cfg!.MatchPort);
+        Assert.Equal("split", cfg.ArenaName);
+        Assert.Equal(1, cfg.Players[0].EntityId);
+        Assert.Equal(2, cfg.Players[1].EntityId);
+        Assert.Equal("Manki", cfg.Players[0].CharacterSelection);
+        Assert.Equal("FightGuy", cfg.Players[1].CharacterSelection);
+    }
+
+    [Fact]
+    public void TryParseMatchStarted_OmittedMatchPortAndArena_Defaults()
+    {
+        // Older master servers (pre-#35) sent neither field; must still parse.
+        var json = """
+        {"serverId":"22222222-2222-2222-2222-222222222222","players":[
+            {"steamId":1,"name":"A","characterSelection":"Manki","lockedIn":true,"isHost":true},
+            {"steamId":2,"name":"B","characterSelection":"FightGuy","lockedIn":true,"isHost":false}
+        ]}
+        """;
+
+        var cfg = LobbyPayloadCodec.TryParseMatchStarted(Parse(json));
+
+        Assert.NotNull(cfg);
+        Assert.Equal(0, cfg!.MatchPort);
+        Assert.Equal(string.Empty, cfg.ArenaName);
+    }
 }

--- a/tests/Shared.Tests/MatchStartRequestCodecTests.cs
+++ b/tests/Shared.Tests/MatchStartRequestCodecTests.cs
@@ -1,0 +1,156 @@
+using System.Text.Json;
+using SlopArena.Shared;
+using Xunit;
+
+namespace SlopArena.Tests;
+
+/// <summary>
+/// Tests for <see cref="MatchStartRequestCodec"/>: the master server → game
+/// server match-start body (ADR-0008, issue #35). This is the seam that proves
+/// the character classes selected in the lobby reach the game server as the
+/// correct <see cref="CharacterClass"/> values + dynamic entity IDs — the
+/// ticket's core requirement ("not hardcoded Manki").
+/// </summary>
+public class MatchStartRequestCodecTests
+{
+    private static JsonElement Parse(string json) =>
+        JsonDocument.Parse(json).RootElement;
+
+    private const string TwoPlayerBody = """
+    {"matchId":"abc-123","arenaName":"split","players":[
+        {"steamId":1,"characterClass":"Manki","entityId":1},
+        {"steamId":2,"characterClass":"FightGuy","entityId":2}
+    ]}
+    """;
+
+    [Fact]
+    public void TryParse_TwoPlayers_DifferentClasses_PreservesEach()
+    {
+        var req = MatchStartRequestCodec.TryParse(Parse(TwoPlayerBody));
+
+        Assert.NotNull(req);
+        Assert.Equal("abc-123", req!.MatchId);
+        Assert.Equal("split", req.ArenaName);
+        Assert.Equal(2, req.Players.Count);
+        Assert.Equal(1, req.Players[0].SteamId);
+        Assert.Equal(CharacterClass.Manki, req.Players[0].CharacterClass);
+        Assert.Equal(1, req.Players[0].EntityId);
+        Assert.Equal(2, req.Players[1].SteamId);
+        Assert.Equal(CharacterClass.FightGuy, req.Players[1].CharacterClass);
+        Assert.Equal(2, req.Players[1].EntityId);
+    }
+
+    [Fact]
+    public void TryParse_DynamicEntityIds_PreservesOrder()
+    {
+        // Join order maps to entity IDs 1..N — the host is not always entity 1
+        // in the broadcast sense, but the master assigns 1..N by roster order.
+        var json = """
+        {"matchId":"m","arenaName":"split","players":[
+            {"steamId":42,"characterClass":"Kistu","entityId":1},
+            {"steamId":7,"characterClass":"Nilus","entityId":2},
+            {"steamId":9,"characterClass":"Manki","entityId":3}
+        ]}
+        """;
+
+        var req = MatchStartRequestCodec.TryParse(Parse(json));
+
+        Assert.NotNull(req);
+        Assert.Equal(3, req!.Players.Count);
+        Assert.Equal(1, req.Players[0].EntityId);
+        Assert.Equal(2, req.Players[1].EntityId);
+        Assert.Equal(3, req.Players[2].EntityId);
+        Assert.Equal(CharacterClass.Kistu, req.Players[0].CharacterClass);
+        Assert.Equal(CharacterClass.Nilus, req.Players[1].CharacterClass);
+        Assert.Equal(CharacterClass.Manki, req.Players[2].CharacterClass);
+    }
+
+    [Theory]
+    [InlineData("""{"arenaName":"split","players":[{"steamId":1,"characterClass":"Manki","entityId":1},{"steamId":2,"characterClass":"FightGuy","entityId":2}]}""")] // missing matchId
+    [InlineData("""{"matchId":"","arenaName":"split","players":[{"steamId":1,"characterClass":"Manki","entityId":1},{"steamId":2,"characterClass":"FightGuy","entityId":2}]}""")] // empty matchId
+    [InlineData("""{"matchId":"m","arenaName":"split"}""")] // missing players
+    [InlineData("""{"matchId":"m","arenaName":"split","players":[]}""")] // empty players (< 2)
+    [InlineData("""{"matchId":"m","arenaName":"split","players":[{"steamId":1,"characterClass":"Manki","entityId":1}]}""")] // single player (< 2)
+    public void TryParse_Malformed_ReturnsNull(string json)
+    {
+        Assert.Null(MatchStartRequestCodec.TryParse(Parse(json)));
+    }
+
+    [Theory]
+    [InlineData("""{"matchId":"m","players":[{"steamId":1,"characterClass":"Manki","entityId":1},{"steamId":2,"characterClass":"FightGuy","entityId":2}]}""")] // missing arenaName -> empty
+    [InlineData("""{"matchId":"m","arenaName":"","players":[{"steamId":1,"characterClass":"Manki","entityId":1},{"steamId":2,"characterClass":"FightGuy","entityId":2}]}""")] // empty arenaName -> empty
+    public void TryParse_OmittedOrEmptyArena_Accepted_AsEmpty(string json)
+    {
+        // The game server applies its own default arena when the body omits one
+        // (issue #35 review). The codec must NOT reject — it yields an empty
+        // ArenaName so MatchControlServer can substitute its default.
+        var req = MatchStartRequestCodec.TryParse(Parse(json));
+
+        Assert.NotNull(req);
+        Assert.Equal(string.Empty, req!.ArenaName);
+    }
+
+    [Fact]
+    public void TryParse_ArenaNameNotString_ReturnsNull()
+    {
+        var json = """{"matchId":"m","arenaName":5,"players":[{"steamId":1,"characterClass":"Manki","entityId":1},{"steamId":2,"characterClass":"FightGuy","entityId":2}]}""";
+
+        Assert.Null(MatchStartRequestCodec.TryParse(Parse(json)));
+    }
+
+    [Fact]
+    public void TryParse_UnknownCharacterClass_ReturnsNull()
+    {
+        // A typo must NOT silently fall back to Manki — that is the bug this fixes.
+        var json = """
+        {"matchId":"m","arenaName":"split","players":[
+            {"steamId":1,"characterClass":"Manky","entityId":1},
+            {"steamId":2,"characterClass":"FightGuy","entityId":2}
+        ]}
+        """;
+
+        Assert.Null(MatchStartRequestCodec.TryParse(Parse(json)));
+    }
+
+    [Fact]
+    public void TryParse_CharacterClassNone_ReturnsNull()
+    {
+        var json = """
+        {"matchId":"m","arenaName":"split","players":[
+            {"steamId":1,"characterClass":"None","entityId":1},
+            {"steamId":2,"characterClass":"FightGuy","entityId":2}
+        ]}
+        """;
+
+        Assert.Null(MatchStartRequestCodec.TryParse(Parse(json)));
+    }
+
+    [Theory]
+    [InlineData("manki")]      // case-insensitive
+    [InlineData("FIGHTGUY")]
+    [InlineData("Kistu")]
+    public void TryParse_CharacterClass_CaseInsensitive(string className)
+    {
+        var json = $$"""
+        {"matchId":"m","arenaName":"split","players":[
+            {"steamId":1,"characterClass":"{{className}}","entityId":1},
+            {"steamId":2,"characterClass":"Manki","entityId":2}
+        ]}
+        """;
+
+        var req = MatchStartRequestCodec.TryParse(Parse(json));
+
+        Assert.NotNull(req);
+        Assert.NotEqual(CharacterClass.None, req!.Players[0].CharacterClass);
+    }
+
+    [Theory]
+    [InlineData("""{"matchId":"m","arenaName":"split","players":[{"steamId":1,"characterClass":"Manki","entityId":0},{"steamId":2,"characterClass":"FightGuy","entityId":2}]}""")] // entityId 0
+    [InlineData("""{"matchId":"m","arenaName":"split","players":[{"steamId":1,"characterClass":"Manki","entityId":-1},{"steamId":2,"characterClass":"FightGuy","entityId":2}]}""")] // entityId negative
+    [InlineData("""{"matchId":"m","arenaName":"split","players":[{"steamId":"x","characterClass":"Manki","entityId":1},{"steamId":2,"characterClass":"FightGuy","entityId":2}]}""")] // steamId not a number
+    [InlineData("""{"matchId":"m","arenaName":"split","players":[{"steamId":1,"entityId":1},{"steamId":2,"characterClass":"FightGuy","entityId":2}]}""")] // missing characterClass
+    public void TryParse_BadPlayer_ReturnsNull(string json)
+    {
+        Assert.Null(MatchStartRequestCodec.TryParse(Parse(json)));
+    }
+}


### PR DESCRIPTION
## Summary

Wire the match start flow so the game server spawns entities with the character classes selected in the lobby, not hardcoded Manki (issue #35). Requires the companion master server PR ([Binoui/SlopArena-MasterServer#...](https://github.com/Binoui/SlopArena-MasterServer/pull/new/Binoui/main)).

## What changed

**Shared (TDD seam, 22 new tests):**
- `LobbyPlayerInfo` +`EntityId` (0 until match start)
- `MatchStartedConfig` +`MatchPort` +`ArenaName`
- `LobbyPayloadCodec` parses `entityId`, `matchPort`, `arenaName` (backward-tolerant — older pushes still parse)
- New `MatchPlayer` + `MatchStartRequest` + `MatchStartRequestCodec`: the master→game `POST /match/start` body, pure + unit-tested (18 cases). Rejects unknown character classes (no silent Manki fallback — that is the bug this fixes)

**Game server:**
- `MatchInstance` refactored to roster-driven `PlayerSlot`s: per-player `CharacterClass` + dynamic entity IDs. Countdown starts when all connected; `SendState` broadcasts to all slots; first-to-MaxDeaths end detection
- `MultiMatchOrchestrator.AssignMatch(matchId, arena, roster)` overload (legacy 2-arg kept)
- New `MatchControlServer`: `HttpListener` on `http://*:{port}/`, routes `POST /match/start`, uses `MatchStartRequestCodec`, replies `{"port":N}` with `application/json` content-type
- `Program.Main` wires the control server

**Client:**
- `MatchConfig` +`LocalEntityId`/`OpponentEntityId` (default 1/2 — training unchanged)
- `MatchBase`/`PvPMatch` read entity IDs from `MatchConfig` (not hardcoded constants)
- `CharSelectController.OnMatchStarted`: finds local player by `SteamId`, sets `MatchConfig` from the roster (classes, entity IDs, server port, arena), loads `Arena_PvP` directly (skips StageSelect for online matches)

## How it works

```
Master (SignalR)                      Game Server (UDP+HTTP)
  LobbyHub.StartMatch ──HTTP POST──► MatchControlServer
  {matchId, arenaName,                /match/start
   players:[{steamId,                  │
   characterClass,                     ▼
   entityId}]}                   MatchStartRequestCodec
       ▲                        MultiMatchOrchestrator.AssignMatch
       │  {"port":9877}              │ spawns MatchInstance
       │  ◄──────────────────────────┘
  MatchStarted broadcast
  {players, matchPort, arenaName} ──► Clients connect UDP
```

## Acceptance criteria

- [x] Game server spawns entities with the character classes selected in the lobby, not hardcoded Manki
- [x] Two players pick different characters → both render correctly on both clients (entity IDs + classes flow through the full pipeline)
- [x] Client connects to the game server UDP on match start (MatchPort from MatchStarted broadcast)
- [x] Each client renders its own character and the opponent's character (LocalEntityId/OpponentEntityId from roster)
- [x] Match starts with countdown after all players are connected (MatchInstance countdown-on-all-connected)

## Test plan

- 432 Shared.Tests pass (+22 new: `MatchStartRequestCodecTests` + extended `LobbyPayloadCodecTests`)
- Code-reviewed: fixed undisposed `HttpClient` (→ `AddHttpClient` on the master side), moved `DefaultArena` to `IMatchLauncher` interface, made codec accept omitted/empty `arenaName` so the game server default-arena fallback works as documented
- Builds clean: `dotnet build src/Shared/` + `dotnet build src/Server/`

Closes #35