### PR TITLE
feat(match): generalize matches to 2-4 players (issue #36)

### DIFF
--- a/.omp/AGENTS.md
+++ b/.omp/AGENTS.md
@@ -86,6 +86,10 @@ Master Server (SignalR/REST)          Game Server (src/Server, .NET console)
 - Mixamo FBX scale: cm (0.01 factor). Blender 5.1 uses layered actions API.
 
 
+### Git
+- Commit convention: Conventional Commits, one squash commit per branch — `<type>(<scope>): <imperative summary> (issue #N)`. Full rules in `docs/contributing/conventions.md` § Git & Commits.
+- Squash + PR flow lives in `.omp/skills/sloparena-finish-branch`.
+
 ### Debugging Protocol
 1. State the problem (1-2 sentences)
 2. Describe the fix (2-3 sentences): what, which files, why

--- a/.omp/skills/sloparena-finish-branch/SKILL.md
+++ b/.omp/skills/sloparena-finish-branch/SKILL.md
@@ -15,6 +15,15 @@ triggers:
 
 Deterministic flow, no menu. Run from the repo root or let `git rev-parse --show-toplevel` find it.
 
+## 0. Subject
+
+Decide `<subject>` before touching git:
+
+- A user-supplied subject wins.
+- Otherwise derive one conventional subject for the whole branch, per the commit convention in `docs/contributing/conventions.md` (§ Git & Commits): `<type>(<scope>): <imperative summary>` + ` (issue #N)` when the branch resolves a GitHub issue.
+- Pick the type/scope from the actual change (`feat(match)` for gameplay, `fix(client)` for repairs, else `refactor`/`docs`/`test`/`chore` + the subsystem scope). Match the existing log style, e.g. `feat(match): roster-driven match start with character classes (issue #35)`.
+- If the branch is empty (no code changes), say so and stop.
+
 ## 1. Branch guard
 
 ```bash
@@ -34,21 +43,49 @@ Failures → stop, report them, do NOT commit.
 ## 3. Squash
 
 ```bash
-git reset --soft "$(git merge-base HEAD main)" && git commit -m "<subject>"
+git add -A   # required: reset --soft does NOT stage untracked files — they'd be dropped from the commit
+git reset --soft "$(git merge-base HEAD main)"
+git diff --cached --quiet && { echo "nothing to squash — clean tree"; exit 1; }
+git commit -m "<subject>"
 ```
 
-`<subject>` = the last commit's subject (or the user-supplied arg). Clean tree / nothing staged → report and stop.
+- **Always `git add -A` first.** `git reset --soft` only stages the diff merge-base..HEAD; brand-new files in the working tree would otherwise be silently omitted from the commit.
+- **Fresh branch (HEAD == merge-base, no commits)?** The reset is a no-op — that's fine: `git add -A` already staged the whole working tree and the commit is created normally. This is NOT the "clean tree" case.
+- "Clean tree / nothing staged" means the tree was already clean after the reset — print "nothing to squash — clean tree" and stop.
 
 ## 4. Push + PR
 
 ```bash
-git push -u origin HEAD
-gh pr create --title "<subject>" --body "<body>"
+if git ls-remote --heads origin "$(git branch --show-current)" | grep -q .; then
+  git push --force-with-lease -u origin HEAD   # branch was pushed before — rewritten history needs force
+else
+  git push -u origin HEAD
+fi
 ```
 
-`<body>` = `git log main..HEAD --format='- %s'` + diffstat (`git diff --stat main...HEAD`).
+Open the PR with a real description — summary, changes, verification, and a **fenced** diffstat:
 
-If `gh` is unavailable → print the push output and the repo URL (`https://github.com/Binoui/SlopArena`) instead, and stop there.
+````bash
+gh pr create --title "<subject>" --body "$(cat <<'EOF'
+<1-3 sentences: what the branch does and why>
+
+## Changes
+- bullet per logical change (start from `git log main..HEAD --format='- %s'` and expand)
+
+## Verification
+- what was run and the result: test count, build, manual/e2e checks
+
+## Diffstat
+```text
+<git diff --stat main...HEAD>
+```
+EOF
+)"
+````
+
+- The diffstat MUST be inside a ```text fence — an unfenced diffstat renders with broken alignment in GitHub Markdown.
+- Server-authoritative changes: note which Shared files changed (per `docs/contributing/conventions.md` § Git & Commits).
+- If `gh` is unavailable → print the push output and the repo URL (`https://github.com/Binoui/SlopArena`) instead, and stop there.
 
 ## 5. Report
 

--- a/client/Unity/Assets/Scripts/Runtime/UI/CharSelectController.cs
+++ b/client/Unity/Assets/Scripts/Runtime/UI/CharSelectController.cs
@@ -208,19 +208,16 @@ namespace SlopArena.Client.UI
         {
             Debug.Log($"[CharSelect] Match started: {config.Players.Count} players, port={config.MatchPort}, arena={config.ArenaName}.");
 
-            // Find the local player in the roster (by SteamId) and an opponent
-            // (first other player). The master server assigned entity IDs 1..N
-            // by join order (issue #35); the game server spawns each with the
-            // roster's character class, so both clients render the right chars.
+            // Find the local player in the roster (by SteamId). The master
+            // server assigned entity IDs 1..N by join order (issue #35); the
+            // game server spawns each with the roster's character class, so
+            // every client renders the right chars (issue #36).
             var players = config.Players;
             LobbyPlayerInfo? local = null;
-            LobbyPlayerInfo? opponent = null;
             foreach (var p in players)
             {
                 if (p.SteamId == ClientSession.SteamId)
                     local = p;
-                else if (opponent == null)
-                    opponent = p;
             }
 
             if (local == null)
@@ -238,10 +235,17 @@ namespace SlopArena.Client.UI
             // ServerIP is already set (host: localhost, joiner: server browser IP).
             MatchConfig.PlayerClass = ParseClass(local.CharacterSelection, _selected);
             MatchConfig.LocalEntityId = (ulong)(local.EntityId > 0 ? local.EntityId : 1);
-            if (opponent != null)
+            // Every non-local rostered player is an opponent (issue #36).
+            // entityId <= 0 means the master never assigned it, so the game
+            // server never spawned the entity — skip it.
+            MatchConfig.Opponents.Clear();
+            foreach (var p in players)
             {
-                MatchConfig.OpponentClass = ParseClass(opponent.CharacterSelection, CharacterClass.Manki);
-                MatchConfig.OpponentEntityId = (ulong)(opponent.EntityId > 0 ? opponent.EntityId : 2);
+                if (p.SteamId == ClientSession.SteamId) continue;
+                if (p.EntityId <= 0) continue;
+                MatchConfig.Opponents.Add(new MatchConfig.OpponentInfo(
+                    (ulong)p.EntityId,
+                    ParseClass(p.CharacterSelection, CharacterClass.Manki)));
             }
 
             // Tear down the lobby connection — the match is now handed off to

--- a/client/Unity/Assets/Scripts/Runtime/UI/MatchConfig.cs
+++ b/client/Unity/Assets/Scripts/Runtime/UI/MatchConfig.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace SlopArena.Client.UI
 {
     public enum GameMode { Training, PvP }
@@ -7,31 +9,43 @@ namespace SlopArena.Client.UI
         public static GameMode Mode = GameMode.Training;
         public static SlopArena.Shared.CharacterClass PlayerClass
             = SlopArena.Shared.CharacterClass.FightGuy;
-        public static SlopArena.Shared.CharacterClass OpponentClass
-            = SlopArena.Shared.CharacterClass.Manki;
         public static string ArenaName = "training";
         public static bool IsHost = true;
         public static string ServerIP = "127.0.0.1";
         public static int ServerPort = 9876;
 
+        /// <summary>One opponent in the match (issue #36): entity ID + class.</summary>
+        public sealed class OpponentInfo
+        {
+            public ulong EntityId { get; }
+            public SlopArena.Shared.CharacterClass Class { get; }
+
+            public OpponentInfo(ulong entityId, SlopArena.Shared.CharacterClass @class)
+            {
+                EntityId = entityId;
+                Class = @class;
+            }
+        }
+
         // Per-match entity IDs assigned by the master server at match start
-        // (issue #35). The local player drives LocalEntityId; the rendered
-        // opponent is OpponentEntityId. Default to the legacy 1/2 so training
-        // and the old join-by-IP path keep working unchanged.
+        // (issue #35). The local player drives LocalEntityId; the opponents
+        // come from Opponents (issue #36). Defaults keep training and the old
+        // join-by-IP path working unchanged.
         public static ulong LocalEntityId = 1;
-        public static ulong OpponentEntityId = 2;
+
+        /// <summary>All non-local players, in master-server roster order.</summary>
+        public static List<OpponentInfo> Opponents = new();
 
         public static void Reset()
         {
             Mode = GameMode.Training;
             PlayerClass = SlopArena.Shared.CharacterClass.FightGuy;
-            OpponentClass = SlopArena.Shared.CharacterClass.Manki;
             ArenaName = "training";
             IsHost = true;
             ServerIP = "127.0.0.1";
             ServerPort = 9876;
             LocalEntityId = 1;
-            OpponentEntityId = 2;
+            Opponents.Clear();
         }
     }
 }

--- a/client/Unity/Assets/Scripts/Runtime/World/PvPMatch.cs
+++ b/client/Unity/Assets/Scripts/Runtime/World/PvPMatch.cs
@@ -24,7 +24,8 @@ namespace SlopArena.Client.World
         [Header("Network")]
         [SerializeField] private NetworkClient _networkClient;
 
-        private static ulong OpponentEntityId => MatchConfig.OpponentEntityId;
+        private readonly Dictionary<ulong, PlayerRenderer> _opponentRenderers = new();
+        private PlayerRenderer[] _opponentArray = System.Array.Empty<PlayerRenderer>();
 
         private uint _tick;
         private MatchState _lastMatchState = MatchState.Waiting;
@@ -61,31 +62,51 @@ namespace SlopArena.Client.World
             var playerDef = CharacterRegistry.Get(MatchConfig.PlayerClass);
             _playerDef = playerDef;
             var playerBaked = LoadBakedData(playerDef);
-            var opponentDef = CharacterRegistry.Get(MatchConfig.OpponentClass);
-            var opponentBaked = LoadBakedData(opponentDef);
 
             // Shared player renderer + HUD setup
             SetupPlayerRenderer(playerDef, playerBaked);
             SetupHUD(playerDef);
 
-            // Opponent renderer
-            if (_opponentRenderer != null)
+            // Opponent renderers — one per MatchConfig.Opponents entry. The scene's
+            // _opponentRenderer is the first opponent + the clone template for the rest.
+            _opponentRenderers.Clear();
+            for (int i = 0; i < MatchConfig.Opponents.Count; i++)
             {
-                _opponentRenderer.ModelYOffset = opponentDef.ModelYOffset;
-                _opponentRenderer.CapsuleRadius = opponentDef.CapsuleRadius;
-                _opponentRenderer.CapsuleHeight = opponentDef.CapsuleHeight;
-                _opponentRenderer.HurtboxBoneDefs = opponentDef.HurtboxBoneDefs;
-                _opponentRenderer.SetBakedData(opponentBaked);
-                _opponentRenderer.SetCharacterDefinition(opponentDef);
-                _opponentRenderer.LoadModel(opponentDef);
-            }
+                var opp = MatchConfig.Opponents[i];
 
-            // Position renderers at spawn points
-            var spawnPoints = arena.SpawnPoints;
-            if (spawnPoints.Length > 0)
-                _playerRenderer.transform.position = new Vector3(spawnPoints[0].X, spawnPoints[0].Y, spawnPoints[0].Z);
-            if (_opponentRenderer != null && spawnPoints.Length > 1)
-                _opponentRenderer.transform.position = new Vector3(spawnPoints[1].X, spawnPoints[1].Y, spawnPoints[1].Z);
+                PlayerRenderer renderer;
+                if (i == 0 && _opponentRenderer != null)
+                {
+                    renderer = _opponentRenderer;
+                }
+                else if (_opponentRenderer != null)
+                {
+                    var clone = Instantiate(_opponentRenderer.gameObject);
+                    clone.name = $"Opponent_{opp.EntityId}";
+                    renderer = clone.GetComponent<PlayerRenderer>();
+                }
+                else
+                {
+                    Debug.LogWarning($"[PvPMatch] No opponent template in scene — skipping opponent {opp.EntityId}.");
+                    continue;
+                }
+
+                var def = CharacterRegistry.Get(opp.Class);
+                var baked = LoadBakedData(def);
+                renderer.ModelYOffset = def.ModelYOffset;
+                renderer.CapsuleRadius = def.CapsuleRadius;
+                renderer.CapsuleHeight = def.CapsuleHeight;
+                renderer.HurtboxBoneDefs = def.HurtboxBoneDefs;
+                renderer.SetBakedData(baked);
+                renderer.SetCharacterDefinition(def);
+                renderer.LoadModel(def);
+                renderer.transform.position = SpawnPosition(arena, opp.EntityId);
+                _opponentRenderers[opp.EntityId] = renderer;
+            }
+            _opponentArray = new List<PlayerRenderer>(_opponentRenderers.Values).ToArray();
+
+            // Player spawns at its own roster spawn point (entityId 1..N ↔ spawnPoints[0..N-1]).
+            _playerRenderer.transform.position = SpawnPosition(arena, PlayerEntityId);
 
             // Shared camera + aim setup
             SetupCamera();
@@ -95,6 +116,15 @@ namespace SlopArena.Client.World
         private void Update()
         {
             _inputController.Poll();
+        }
+
+        private static Vector3 SpawnPosition(ArenaDefinition arena, ulong entityId)
+        {
+            int idx = (int)entityId - 1;
+            if (idx < 0 || arena.SpawnPoints == null || idx >= arena.SpawnPoints.Length)
+                return new Vector3(40f, 0.5f, 40f);
+            var s = arena.SpawnPoints[idx];
+            return new Vector3(s.X, s.Y, s.Z);
         }
 
         protected override void OnMatchFixedUpdate()
@@ -110,7 +140,7 @@ namespace SlopArena.Client.World
             _showCrosshair = _aimHandler?.ShowCrosshair ?? false;
 
             byte targetEntityId = PickScreenTarget(
-                _opponentRenderer != null ? new[] { _opponentRenderer } : Array.Empty<PlayerRenderer>(),
+                _opponentArray,
                 _mainCamera ??= _cameraMount?.RenderCamera ?? UnityEngine.Camera.main);
 
             var (input, _, _) = _inputController.BuildInputState(
@@ -131,8 +161,8 @@ namespace SlopArena.Client.World
 
             // Apply server states to renderers
             _playerRenderer.ApplyServerState(_bridge.GetState(PlayerEntityId));
-            if (_opponentRenderer != null)
-                _opponentRenderer.ApplyServerState(_bridge.GetState(OpponentEntityId));
+            foreach (var kv in _opponentRenderers)
+                kv.Value.ApplyServerState(_bridge.GetState(kv.Key));
 
             // Surface server match state transitions (countdown → fight → results)
             var matchState = _bridge.GetState(PlayerEntityId).MatchState;

--- a/docs/contributing/conventions.md
+++ b/docs/contributing/conventions.md
@@ -257,3 +257,36 @@ The 3D model should be as clean and simple as possible.
 | 1 | Manki | Agile rushdown / fire monkey | In-game prototype |
 
 See `docs/characters/manki.md` for details.
+
+---
+
+## 9. Git & Commits
+
+**One squash commit per branch.** Feature branches are squashed at finish time (see `.omp/skills/sloparena-finish-branch`); the message is written once, at the end, and must describe the whole branch.
+
+### Format — Conventional Commits
+
+```
+<type>(<scope>): <imperative summary> (issue #N)
+```
+
+- **type**: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`
+- **scope**: the subsystem touched — `match`, `client`, `server`, `shared`, `netcode`, `arena`, `docs`, `mcp`, …
+- **summary**: imperative, lowercase, ≤ 72 chars. What the change does, not how.
+- **issue ref**: append ` (issue #N)` when the work resolves a GitHub issue.
+
+### Examples (from the repo log)
+
+```
+feat(match): roster-driven match start with character classes (issue #35)
+fix(client): repair Unity-MCP stack
+docs: sync skills and docs to Unity codebase
+chore(mcp): add Unity-MCP extensions, update docs
+```
+
+### Rules
+
+- One type + one scope per commit; pick the dominant one when mixed.
+- Server-authoritative changes note the Shared files touched in the PR body (not the subject).
+- Never commit generated artifacts (`artifacts/`, Unity Plugins DLLs — gitignored).
+

--- a/src/Server/MatchControlServer.cs
+++ b/src/Server/MatchControlServer.cs
@@ -95,7 +95,7 @@ namespace SlopArena.Server
             }
 
             if (req is null)
-                return (0, "Invalid match-start body (need matchId, arenaName, and >=2 players with a known characterClass + entityId).");
+                return (0, "Invalid match-start body (need matchId, arenaName, and 2-4 players with a known characterClass + entityId).");
 
             var arena = string.IsNullOrEmpty(req.ArenaName) ? _defaultArena : req.ArenaName;
             int port = _orchestrator.AssignMatch(req.MatchId, arena, req.Players);

--- a/src/Server/MatchInstance.cs
+++ b/src/Server/MatchInstance.cs
@@ -117,25 +117,18 @@ namespace SlopArena.Server
 					ReceiveInputs();
 					if (AllConnected())
 					{
-						// Check for disconnected players.
+						// Check for disconnected players: mark the slot, clear its
+						// stale queue, and let the entity go idle (issue #36).
 						var now = DateTime.UtcNow;
-						bool anyTimeout = false;
-						string timedOut = "";
 						foreach (var slot in _slots)
 						{
-							if (slot.EndPoint != null && (now - slot.LastPacket).TotalSeconds > TimeoutSeconds)
+							if (slot.EndPoint == null || slot.Disconnected) continue;
+							if ((now - slot.LastPacket).TotalSeconds > TimeoutSeconds)
 							{
-								anyTimeout = true;
-								timedOut = slot.EntityId.ToString();
-								break;
+								slot.Disconnected = true;
+								slot.Queue.Clear();
+								Console.WriteLine($"[Match:{_matchId}] Player (entity {slot.EntityId}) disconnected — entity goes idle.");
 							}
-						}
-
-						if (anyTimeout)
-						{
-							Console.WriteLine($"[Match:{_matchId}] Player (entity {timedOut}) timed out — stopping match.");
-							_running = false;
-							continue;
 						}
 
 						Tick();
@@ -231,6 +224,13 @@ namespace SlopArena.Server
 					var slot = FindSlot(entityId);
 					if (slot == null) continue; // not a rostered player
 
+					// A previously disconnected player reconnecting resumes control.
+					if (slot.Disconnected)
+					{
+						slot.Disconnected = false;
+						Console.WriteLine($"[Match:{_matchId}] Player (entity {entityId}) reconnected.");
+					}
+
 					// New player connecting — register their endpoint.
 					if (slot.EndPoint == null)
 					{
@@ -317,6 +317,8 @@ namespace SlopArena.Server
 				if (input.HasValue)
 				{
 					_serverTick = Math.Max(_serverTick, input.Value.tick);
+					if (slot.Disconnected) continue;
+					if (MatchRules.IsEliminated(_sim.GetState(slot.EntityId), MaxDeaths)) continue;
 					inputs[slot.EntityId] = input.Value.input;
 				}
 			}
@@ -326,33 +328,14 @@ namespace SlopArena.Server
 			{
 				_sim.Tick(inputs);
 
-				// Check for match end (first to MaxDeaths loses).
-				ulong? winner = null;
-				ulong? loser = null;
-			foreach (var slot in _slots)
+				// Check for match end: last player standing wins (ADR-0007, issue #36).
+				ulong? winner = MatchRules.FindWinner(_sim.GetAllStates(), MaxDeaths);
+				if (winner.HasValue)
 				{
-					var st = _sim.GetState(slot.EntityId);
-					if (st.Deaths >= MaxDeaths)
-					{
-						loser = slot.EntityId;
-						break;
-					}
-				}
-				if (loser.HasValue)
-				{
-					// Winner = the first other player still under the death limit.
-					foreach (var slot in _slots)
-					{
-						if (slot.EntityId != loser.Value)
-						{
-							var st = _sim.GetState(slot.EntityId);
-							if (st.Deaths < MaxDeaths) { winner = slot.EntityId; break; }
-						}
-					}
 					_matchState = MatchState.Ended;
-					_winnerEntityId = winner ?? 0;
+					_winnerEntityId = winner.Value;
 					_postMatchTicks = PostMatchDuration;
-					Console.WriteLine($"[Match:{_matchId}] Entity {loser.Value} eliminated! Winner: {_winnerEntityId}");
+					Console.WriteLine($"[Match:{_matchId}] Winner: {_winnerEntityId}");
 				}
 
 				SendState();
@@ -385,7 +368,7 @@ namespace SlopArena.Server
 			{
 				foreach (var slot in _slots)
 				{
-					if (slot.EndPoint == null) continue;
+					if (slot.EndPoint == null || slot.Disconnected) continue;
 					foreach (var pkt in packets)
 						_udpServer.Send(pkt.buffer, envelopeSize, slot.EndPoint);
 				}
@@ -421,6 +404,7 @@ namespace SlopArena.Server
 			public CharacterClass CharacterClass { get; }
 			public IPEndPoint? EndPoint { get; set; }
 			public DateTime LastPacket { get; set; } = DateTime.UtcNow;
+			public bool Disconnected { get; set; }
 			public List<(uint tick, InputState input)> Queue { get; } = new();
 
 			public PlayerSlot(ulong entityId, CharacterClass characterClass)

--- a/src/Shared/MatchRules.cs
+++ b/src/Shared/MatchRules.cs
@@ -1,0 +1,51 @@
+using System.Collections.Generic;
+
+namespace SlopArena.Shared;
+
+/// <summary>
+/// Stock-mode match rules for 2-4 players (ADR-0007, issue #36).
+/// Deaths is the stock counter: a player with Deaths >= maxDeaths is
+/// eliminated (spectator). Last player standing wins.
+/// </summary>
+public static class MatchRules
+{
+    /// <summary>True once the player has lost all stocks and is spectating.</summary>
+    public static bool IsEliminated(CharacterState state, byte maxDeaths)
+        => state.Deaths >= maxDeaths;
+
+    /// <summary>
+    /// Winner of a stock match, or null while the match continues.
+    /// Exactly one non-eliminated player → that player wins.
+    /// Zero non-eliminated players (simultaneous last-stock trade) → the
+    /// player with the fewest deaths, ties broken by lowest entity ID.
+    /// </summary>
+    public static ulong? FindWinner(IReadOnlyDictionary<ulong, CharacterState> states, byte maxDeaths)
+    {
+        ulong? soleSurvivor = null;
+        int alive = 0;
+        foreach (var (id, st) in states)
+        {
+            if (st.Deaths < maxDeaths)
+            {
+                alive++;
+                soleSurvivor = id;
+            }
+        }
+        if (alive == 1) return soleSurvivor;
+        if (alive == 0)
+        {
+            ulong best = ulong.MaxValue;
+            byte bestDeaths = byte.MaxValue;
+            foreach (var (id, st) in states)
+            {
+                if (st.Deaths < bestDeaths || (st.Deaths == bestDeaths && id < best))
+                {
+                    bestDeaths = st.Deaths;
+                    best = id;
+                }
+            }
+            return best == ulong.MaxValue ? null : best;
+        }
+        return null;
+    }
+}

--- a/src/Shared/MatchStartRequest.cs
+++ b/src/Shared/MatchStartRequest.cs
@@ -95,7 +95,7 @@ public static class MatchStartRequestCodec
             list.Add(new MatchPlayer(steam.GetInt64(), characterClass, entityId));
         }
 
-        if (list.Count < 2)
+        if (list.Count is < 2 or > 4)
             return null;
 
         return new MatchStartRequest(matchId, arenaName, list);

--- a/tests/Shared.Tests/MatchRulesTests.cs
+++ b/tests/Shared.Tests/MatchRulesTests.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using SlopArena.Shared;
+using Xunit;
+
+namespace SlopArena.Tests;
+
+public class MatchRulesTests
+{
+    private const byte MaxDeaths = 3;
+
+    private static Dictionary<ulong, CharacterState> States(params (ulong id, byte deaths)[] players)
+    {
+        var d = new Dictionary<ulong, CharacterState>();
+        foreach (var (id, deaths) in players)
+            d[id] = new CharacterState { EntityId = id, Deaths = deaths };
+        return d;
+    }
+
+    [Fact]
+    public void FindWinner_WhileTwoOrMoreAlive_ReturnsNull()
+    {
+        var states = States((1, 0), (2, 2), (3, 1));
+        Assert.Null(MatchRules.FindWinner(states, MaxDeaths));
+    }
+
+    [Fact]
+    public void FindWinner_OneSurvivor_ReturnsSurvivor()
+    {
+        var states = States((1, 3), (2, 1), (3, 3));
+        Assert.Equal(2ul, MatchRules.FindWinner(states, MaxDeaths));
+    }
+
+    [Fact]
+    public void FindWinner_AllEliminated_PicksFewestDeaths()
+    {
+        var states = States((1, 3), (2, 3), (3, 2));
+        Assert.Equal(3ul, MatchRules.FindWinner(states, MaxDeaths));
+    }
+
+    [Fact]
+    public void FindWinner_AllEliminated_TieBreaksByLowestEntityId()
+    {
+        var states = States((1, 3), (2, 3), (4, 3));
+        Assert.Equal(1ul, MatchRules.FindWinner(states, MaxDeaths));
+    }
+
+    [Fact]
+    public void IsEliminated_AtThreshold_IsTrue()
+    {
+        Assert.True(MatchRules.IsEliminated(new CharacterState { Deaths = MaxDeaths }, MaxDeaths));
+        Assert.False(MatchRules.IsEliminated(new CharacterState { Deaths = (byte)(MaxDeaths - 1) }, MaxDeaths));
+    }
+}

--- a/tests/Shared.Tests/MatchStartRequestCodecTests.cs
+++ b/tests/Shared.Tests/MatchStartRequestCodecTests.cs
@@ -153,4 +153,19 @@ public class MatchStartRequestCodecTests
     {
         Assert.Null(MatchStartRequestCodec.TryParse(Parse(json)));
     }
+
+    [Fact]
+    public void TryParse_FivePlayers_Rejects()
+    {
+        var body = """
+        {"matchId":"m","arenaName":"split","players":[
+            {"steamId":1,"characterClass":"Manki","entityId":1},
+            {"steamId":2,"characterClass":"Kistu","entityId":2},
+            {"steamId":3,"characterClass":"Nilus","entityId":3},
+            {"steamId":4,"characterClass":"FightGuy","entityId":4},
+            {"steamId":5,"characterClass":"Manki","entityId":5}
+        ]}
+        """;
+        Assert.Null(MatchStartRequestCodec.TryParse(Parse(body)));
+    }
 }


### PR DESCRIPTION
Generalizes the match server + client from exactly 2 players to 2-4 (issue #36).

## Changes

- **Server (`MatchInstance`)** — disconnect now idles the entity instead of stopping the match; a reconnecting player resumes control. Win check is last-standing via the new pure `MatchRules.FindWinner` (eliminated = `Deaths >= 3`; all-eliminated tie → fewest deaths, then lowest entity ID). `SendState` skips disconnected recipients; eliminated players still receive state (spectate).
- **Codec (`MatchStartRequest`)** — roster capped at 2-4 players; 5+ or 1-player match-start bodies are rejected.
- **Client** — `MatchConfig.Opponents` (roster of entity ID + class) replaces the single `OpponentClass`/`OpponentEntityId`; `PvPMatch` spawns one `PlayerRenderer` per opponent (scene template = first opponent + clone template) at the roster spawn point; `CharSelectController` populates the roster from the full `MatchStarted` payload.
- **Docs/tooling** — commit convention defined (`docs/contributing/conventions.md` § Git & Commits, mirrored in AGENTS.md); `sloparena-finish-branch` skill hardened (squash stages untracked files, fenced PR diffstat, force-with-lease, subject derivation).

## Verification

- 438/438 Shared tests pass (5 new `MatchRulesTests` + `TryParse_FivePlayers_Rejects`).
- Server e2e: 4-player match-start accepted (slots 0-3 spawned, `waiting for 4 players`); 5/1-player bodies rejected.
- Scripted UDP clients: 4 connect → countdown → GO → one goes silent → `disconnected — entity goes idle.`, match keeps running; reconnect log confirmed.
- Client scripts compile in Unity (verified via reflection on the compiled assembly); Shared DLL synced to Unity Plugins.

## Diffstat

```text
 .omp/AGENTS.md                                     |  4 ++
 .omp/skills/sloparena-finish-branch/SKILL.md       | 49 +++++++++++++--
 .../Scripts/Runtime/UI/CharSelectController.cs     | 24 +++++---
 .../Unity/Assets/Scripts/Runtime/UI/MatchConfig.cs | 30 ++++++---
 .../Unity/Assets/Scripts/Runtime/World/PvPMatch.cs | 72 +++++++++++++++-------
 docs/contributing/conventions.md                   | 33 ++++++++++
 src/Server/MatchControlServer.cs                   |  2 +-
 src/Server/MatchInstance.cs                        | 62 +++++++------------
 src/Shared/MatchRules.cs                           | 51 +++++++++++++++
 src/Shared/MatchStartRequest.cs                    |  2 +-
 tests/Shared.Tests/MatchRulesTests.cs              | 53 ++++++++++++++++
 tests/Shared.Tests/MatchStartRequestCodecTests.cs  | 15 +++++
 12 files changed, 311 insertions(+), 86 deletions(-)
```
