### PR TITLE
feat(client): HUD panels for 2-4 players (issue #38)

### DIFF
--- a/.omp/AGENTS.md
+++ b/.omp/AGENTS.md
@@ -40,7 +40,7 @@ Master Server (SignalR/REST)          Game Server (src/Server, .NET console)
 - All tick durations use `ushort` (max 65535 ticks = ~18 minutes).
 - Packet serialization uses `System.Buffers.Binary.BinaryPrimitives` (little-endian).
 - Client → Server: `entityId(8) + tick(4) + InputState(19)` = 31 bytes, 60Hz.
-- Server → Client: `entityId(8) + tick(4) + CharacterStatePacket(49)` = 61 bytes per entity.
+- Server → Client: `entityId(8) + tick(4) + CharacterStatePacket(63)` = 75 bytes per entity.
 - Match flow: Server Browser → Lobby Room → Character Select → Countdown → Fight → Results → Lobby Room (ADR-0008). Master server (SignalR) manages lobby/char-select/results; game server (UDP) manages countdown/fight only.
 
 ## Key Conventions

--- a/.omp/skills/sloparena-netcode/SKILL.md
+++ b/.omp/skills/sloparena-netcode/SKILL.md
@@ -25,8 +25,8 @@ Verified against `src/Shared/` and `src/Server/MatchInstance.cs`:
 
 - `InputState.Size = 19` (`src/Shared/InputState.cs`)
 - **Client → server: `entityId(8) + tick(4) + InputState(19)` = 31 bytes** (`MatchInstance.ReceiveInputs` comment)
-- `CharacterStatePacket.Size = 49` (`src/Shared/CharacterStatePacket.cs`)
-- **Server → client, per entity: `entityId(8) + tick(4) + CharacterStatePacket(49)` = 61 bytes** (`MatchInstance.SendState` comment)
+- `CharacterStatePacket.Size = 63` (`src/Shared/CharacterStatePacket.cs`)
+- **Server → client, per entity: `entityId(8) + tick(4) + CharacterStatePacket(63)` = 75 bytes** (`MatchInstance.SendState` comment)
 
 InputState layout (19 bytes): MoveX(4) + MoveY(4) + flags(1) + ActiveSlot(1) + FacingYaw(2) + AimYaw(2) + AimPitch(2) + AimDistance(2) + TargetEntityId(1).
 
@@ -42,7 +42,7 @@ InputState layout (19 bytes): MoveX(4) + MoveY(4) + flags(1) + ActiveSlot(1) + F
 | 16-17  | ushort | AimDistance    | cm (0-6500 = 0-65m)                    |
 | 18     | byte   | TargetEntityId | Client-selected target (0 = none)      |
 
-CharacterStatePacket layout (49 bytes): TickNumber(4) + Position(12) + Velocity(12) + CurrentActionState(1) + IsGrounded(1) + StateDurationFrames(2) + AttackSlot(1) + ComboStage(1) + AnimIndex(1) + FacingYaw(4) + MatchState(1) + BuffRemainingTicks(2) + BuffActiveFlags(1) + HitstunLevel(1) + AimPitch(4) + Deaths(1).
+CharacterStatePacket layout (63 bytes): TickNumber(4) + Position(12) + Velocity(12) + CurrentActionState(1) + IsGrounded(1) + StateDurationFrames(2) + AttackSlot(1) + ComboStage(1) + AnimIndex(1) + FacingYaw(4) + MatchState(1) + BuffRemainingTicks(2) + BuffActiveFlags(1) + HitstunLevel(1) + AimPitch(4) + Deaths(1) + DamagePercent(2) + Cooldown0..5(12).
 
 The server sends ALL entity states to every client; each client filters by entityId. The tick field echoes the client's tick (informational in Phase 1). When adding a packet field, update the `Size` constant AND all four serialization methods (`FromState`/`ToState`/`Serialize`/`Deserialize`).
 

--- a/client/Unity/Assets/Scripts/Runtime/UI/CharSelectController.cs
+++ b/client/Unity/Assets/Scripts/Runtime/UI/CharSelectController.cs
@@ -235,6 +235,9 @@ namespace SlopArena.Client.UI
             // ServerIP is already set (host: localhost, joiner: server browser IP).
             MatchConfig.PlayerClass = ParseClass(local.CharacterSelection, _selected);
             MatchConfig.LocalEntityId = (ulong)(local.EntityId > 0 ? local.EntityId : 1);
+            // Codec guarantees [1,99] (default 3); assign directly so a stale value
+            // from a previous match can never leak through (issue #38).
+            MatchConfig.MaxStocks = config.MaxStocks;
             // Every non-local rostered player is an opponent (issue #36).
             // entityId <= 0 means the master never assigned it, so the game
             // server never spawned the entity — skip it.

--- a/client/Unity/Assets/Scripts/Runtime/UI/HUDManager.cs
+++ b/client/Unity/Assets/Scripts/Runtime/UI/HUDManager.cs
@@ -1,32 +1,73 @@
 using System;
+using System.Collections.Generic;
 using SlopArena.Shared;
 using UnityEngine;
 using UnityEngine.UIElements;
 
 namespace SlopArena.Client.UI
 {
+    /// <summary>
+    /// HUD for stock matches (ADR-0007, issue #38): one panel per player showing
+    /// name, damage % and stock count, with the local player highlighted. The
+    /// local player's ability cooldown slots stay visible below the panels.
+    /// Panels are built at runtime from the roster so the layout adapts to
+    /// 2, 3 or 4 players with no per-count UXML variants.
+    /// </summary>
     public class HUDManager : MonoBehaviour
     {
         [SerializeField] private UIDocument _uiDocument;
 
-        private Func<CharacterState> _getState;
-        // Queried elements
-        private Label _damagePercentLabel;
+        /// <summary>One HUD panel's backing data: entity id, label, local flag.</summary>
+        public readonly struct HudPlayer
+        {
+            public readonly ulong EntityId;
+            public readonly string Label;
+            public readonly bool IsLocal;
+
+            public HudPlayer(ulong entityId, string label, bool isLocal)
+            {
+                EntityId = entityId;
+                Label = label;
+                IsLocal = isLocal;
+            }
+        }
+
+        private sealed class Panel
+        {
+            public VisualElement Root = null!;
+            public Label DamageLabel = null!;
+            public VisualElement[] StockIcons = Array.Empty<VisualElement>();
+            public Label StockCountLabel = null!;
+        }
+
+        // Stock icons beyond this many become a "×N" count label instead (MaxStocks ≤ 99).
+        private const int MaxStockIcons = 8;
+
+        private Func<ulong, CharacterState> _getState;
+        private ulong _localEntityId;
+        private int _maxStocks;
+        private readonly Dictionary<ulong, Panel> _panels = new();
+
+        // Local player's cooldown slots (unchanged from the single-player HUD)
         private VisualElement[] _slotIcons = new VisualElement[6];
         private VisualElement[] _slotCooldownFills = new VisualElement[6];
         private ushort[] _slotMaxCooldowns = new ushort[6];
         private CharacterDefinition? _charDef;
 
-        private static readonly string[] SlotKeys = { "LMB", "RMB", "Q", "E", "R", "F" };
-
         /// <summary>
         /// Initialize the HUD.
-        /// <paramref name="getState"/> is called each Refresh() — pass a lambda over whatever
-        /// simulation source owns the player state (local sim, network client, replay reader).
+        /// <paramref name="getState"/> is called each Refresh() per panel entity id —
+        /// pass a method over whatever simulation source owns the states (local sim,
+        /// network client, replay reader).
         /// </summary>
-        public void Initialize(Func<CharacterState> getState)
+        /// <param name="players">Roster, one panel per entry. Local player must be marked.</param>
+        /// <param name="maxStocks">Stocks per player; &lt;= 0 hides stock display (training).</param>
+        public void Initialize(Func<ulong, CharacterState> getState, IReadOnlyList<HudPlayer> players, int maxStocks)
         {
             _getState = getState;
+            _maxStocks = Mathf.Max(0, maxStocks);
+            _localEntityId = 0;
+
             if (_uiDocument == null)
             {
                 Debug.LogWarning("[HUD] No UIDocument assigned");
@@ -34,13 +75,70 @@ namespace SlopArena.Client.UI
             }
 
             var root = _uiDocument.rootVisualElement;
-            _damagePercentLabel = root.Q<Label>("damage-percent");
+
+            // Rebuild player panels from the roster.
+            var panelsContainer = root.Q<VisualElement>("player-panels");
+            panelsContainer.Clear();
+            _panels.Clear();
+            foreach (var p in players)
+            {
+                var panel = BuildPanel(p);
+                _panels[p.EntityId] = panel;
+                panelsContainer.Add(panel.Root);
+                if (p.IsLocal) _localEntityId = p.EntityId;
+            }
 
             for (int i = 0; i < 6; i++)
             {
                 _slotIcons[i] = root.Q<VisualElement>($"slot-{i}");
                 _slotCooldownFills[i] = root.Q<VisualElement>($"slot-{i}-cooldown");
             }
+        }
+
+        private Panel BuildPanel(HudPlayer p)
+        {
+            var root = new VisualElement();
+            root.name = $"player-panel-{p.EntityId}";
+            root.AddToClassList("player-panel");
+            if (p.IsLocal) root.AddToClassList("local");
+
+            var nameLabel = new Label(p.Label);
+            nameLabel.AddToClassList("player-name");
+            root.Add(nameLabel);
+
+            var damageLabel = new Label("0%");
+            damageLabel.AddToClassList("player-damage");
+            root.Add(damageLabel);
+
+            var panel = new Panel { Root = root, DamageLabel = damageLabel };
+
+            if (_maxStocks > 0)
+            {
+                var stockRow = new VisualElement();
+                stockRow.AddToClassList("stock-row");
+                root.Add(stockRow);
+
+                if (_maxStocks <= MaxStockIcons)
+                {
+                    panel.StockIcons = new VisualElement[_maxStocks];
+                    for (int i = 0; i < _maxStocks; i++)
+                    {
+                        var icon = new VisualElement();
+                        icon.AddToClassList("stock-icon");
+                        stockRow.Add(icon);
+                        panel.StockIcons[i] = icon;
+                    }
+                }
+                else
+                {
+                    var count = new Label($"×{_maxStocks}");
+                    count.AddToClassList("stock-count");
+                    stockRow.Add(count);
+                    panel.StockCountLabel = count;
+                }
+            }
+
+            return panel;
         }
 
         public void SetSlotMaxCooldown(int slot, ushort ticks)
@@ -76,36 +174,62 @@ namespace SlopArena.Client.UI
         {
             if (_getState == null || _uiDocument == null) return;
 
-            var state = _getState();
-
-            // Damage %
-            if (_damagePercentLabel != null)
-                _damagePercentLabel.text = $"{state.DamagePercent}%";
-
-            // Slot cooldowns
-            ushort[] cooldowns = {
-                state.Cooldown0, state.Cooldown1, state.Cooldown2,
-                state.Cooldown3, state.Cooldown4, state.Cooldown5
-            };
-
-            for (int i = 0; i < 6; i++)
+            // Player panels: damage % + stocks for everyone.
+            foreach (var kv in _panels)
             {
-                ushort cd = cooldowns[i];
-                bool onCooldown = cd > 0;
+                var state = _getState(kv.Key);
+                var panel = kv.Value;
 
-                if (_slotCooldownFills[i] != null)
+                panel.DamageLabel.text = $"{(int)state.DamagePercent}%";
+
+                if (_maxStocks > 0)
                 {
-                    _slotCooldownFills[i].style.display = onCooldown
-                        ? DisplayStyle.Flex
-                        : DisplayStyle.None;
+                    int stocksLeft = _maxStocks - state.Deaths;
+                    if (stocksLeft < 0) stocksLeft = 0;
 
-                    if (onCooldown)
+                    if (panel.StockIcons.Length > 0)
                     {
-                        float fraction = _slotMaxCooldowns[i] > 0
-                            ? Mathf.Clamp01(cd / (float)_slotMaxCooldowns[i])
-                            : 1f;
-                        // Scale Y from bottom (1 = full height = just started)
-                        _slotCooldownFills[i].style.scale = new Scale(new Vector2(1f, fraction));
+                        for (int i = 0; i < panel.StockIcons.Length; i++)
+                            panel.StockIcons[i].EnableInClassList("lost", i >= stocksLeft);
+                    }
+                    else if (panel.StockCountLabel != null)
+                    {
+                        panel.StockCountLabel.text = $"×{stocksLeft}";
+                    }
+
+                    // Eliminated (0 stocks) → dim the panel (spectator).
+                    panel.Root.EnableInClassList("eliminated", stocksLeft <= 0);
+                }
+            }
+
+            // Cooldown slots — local player only.
+            if (_localEntityId != 0)
+            {
+                var state = _getState(_localEntityId);
+                ushort[] cooldowns = {
+                    state.Cooldown0, state.Cooldown1, state.Cooldown2,
+                    state.Cooldown3, state.Cooldown4, state.Cooldown5
+                };
+
+                for (int i = 0; i < 6; i++)
+                {
+                    ushort cd = cooldowns[i];
+                    bool onCooldown = cd > 0;
+
+                    if (_slotCooldownFills[i] != null)
+                    {
+                        _slotCooldownFills[i].style.display = onCooldown
+                            ? DisplayStyle.Flex
+                            : DisplayStyle.None;
+
+                        if (onCooldown)
+                        {
+                            float fraction = _slotMaxCooldowns[i] > 0
+                                ? Mathf.Clamp01(cd / (float)_slotMaxCooldowns[i])
+                                : 1f;
+                            // Scale Y from bottom (1 = full height = just started)
+                            _slotCooldownFills[i].style.scale = new Scale(new Vector2(1f, fraction));
+                        }
                     }
                 }
             }

--- a/client/Unity/Assets/Scripts/Runtime/UI/MatchConfig.cs
+++ b/client/Unity/Assets/Scripts/Runtime/UI/MatchConfig.cs
@@ -36,6 +36,10 @@ namespace SlopArena.Client.UI
         /// <summary>All non-local players, in master-server roster order.</summary>
         public static List<OpponentInfo> Opponents = new();
 
+        /// <summary>Stocks per player (ADR-0007, issue #38). Must match the game
+        /// server's rule; the master server push carries it when present, else 3.</summary>
+        public static int MaxStocks = SlopArena.Shared.MatchDefaults.DefaultMaxStocks;
+
         public static void Reset()
         {
             Mode = GameMode.Training;
@@ -46,6 +50,7 @@ namespace SlopArena.Client.UI
             ServerPort = 9876;
             LocalEntityId = 1;
             Opponents.Clear();
+            MaxStocks = SlopArena.Shared.MatchDefaults.DefaultMaxStocks;
         }
     }
 }

--- a/client/Unity/Assets/Scripts/Runtime/World/MatchBase.cs
+++ b/client/Unity/Assets/Scripts/Runtime/World/MatchBase.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using Unity.Cinemachine;
 using UnityEngine;
@@ -85,7 +86,20 @@ namespace SlopArena.Client.World
 
         protected void SetupHUD(CharacterDefinition def)
         {
-            _hudManager?.Initialize(() => Bridge.GetState(PlayerEntityId));
+            // One panel per player (local + opponents), sorted by entity ID so
+            // panels read P1..PN left to right regardless of who is local (issue #38).
+            var players = new List<HUDManager.HudPlayer>(MatchConfig.Opponents.Count + 1)
+            {
+                new(PlayerEntityId, $"P{PlayerEntityId}", isLocal: true)
+            };
+            foreach (var opp in MatchConfig.Opponents)
+                players.Add(new HUDManager.HudPlayer(opp.EntityId, $"P{opp.EntityId}", isLocal: false));
+            players.Sort((a, b) => a.EntityId.CompareTo(b.EntityId));
+
+            // Stocks only in PvP (the game server's StockMatchRule); training has
+            // no win condition, so stock display is hidden (maxStocks <= 0).
+            int maxStocks = MatchConfig.Mode == GameMode.PvP ? MatchConfig.MaxStocks : 0;
+            _hudManager?.Initialize(Bridge.GetState, players, maxStocks);
             _hudManager?.SetCharacterDefinition(def);
             for (int slot = 0; slot < 6; slot++)
             {

--- a/client/Unity/Assets/UI/HUD.uss
+++ b/client/Unity/Assets/UI/HUD.uss
@@ -1,9 +1,75 @@
-.damage-percent {
-    font-size: 48px;
+.hud-root {
+    flex-grow: 1;
+    justify-content: flex-end;
+    align-items: center;
+    padding-bottom: 40px;
+}
+
+.player-panels {
+    flex-direction: row;
+    justify-content: center;
+    margin-bottom: 12px;
+}
+
+.player-panel {
+    min-width: 140px;
+    margin: 4px;
+    padding: 8px 12px;
+    border-radius: 8px;
+    border-width: 2px;
+    border-color: rgba(255, 255, 255, 0.35);
+    background-color: rgba(0, 0, 0, 0.5);
+    align-items: center;
+}
+
+/* Local player's panel is highlighted (issue #38) */
+.player-panel.local {
+    border-color: #ffd700;
+    background-color: rgba(40, 35, 0, 0.55);
+}
+
+/* Eliminated (0 stocks) — dimmed spectator */
+.player-panel.eliminated {
+    opacity: 0.45;
+}
+
+.player-name {
+    font-size: 16px;
+    color: rgba(255, 255, 255, 0.85);
+    -unity-font-style: bold;
+}
+
+.player-panel.local .player-name {
+    color: #ffd700;
+}
+
+.player-damage {
+    font-size: 40px;
     color: white;
     -unity-font-style: bold;
-    text-align: center;
-    margin-bottom: 20px;
+}
+
+.stock-row {
+    flex-direction: row;
+    margin-top: 6px;
+}
+
+.stock-icon {
+    width: 14px;
+    height: 14px;
+    margin: 2px;
+    border-radius: 7px;
+    background-color: white;
+}
+
+.stock-icon.lost {
+    background-color: rgba(255, 255, 255, 0.15);
+}
+
+.stock-count {
+    font-size: 18px;
+    color: white;
+    -unity-font-style: bold;
 }
 
 .slot-row {

--- a/client/Unity/Assets/UI/HUD.uxml
+++ b/client/Unity/Assets/UI/HUD.uxml
@@ -1,10 +1,10 @@
 <ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements">
     <ui:Style src="HUD.uss" />
-    <ui:VisualElement style="flex-grow: 1; justify-content: flex-end; padding-bottom: 40px;">
-        <!-- Damage % -->
-        <ui:Label name="damage-percent" text="0%" class="damage-percent" />
+    <ui:VisualElement name="hud-root" class="hud-root">
+        <!-- Player panels — one per player, built at runtime by HUDManager (issue #38) -->
+        <ui:VisualElement name="player-panels" class="player-panels" />
 
-        <!-- Slot row -->
+        <!-- Slot row (local player only) -->
         <ui:VisualElement name="slot-row" class="slot-row">
             <ui:VisualElement name="slot-0" class="slot-icon">
                 <ui:VisualElement name="slot-0-cooldown" class="slot-cooldown" />

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -23,7 +23,7 @@ SlopArena/
 │   ├── Simulation.cs        ← SimulateTick(): one tick of movement + combat
 │   ├── SpellResolver.cs     ← hitbox collision math
 │   ├── CharacterState.cs    ← per-tick entity state
-│   ├── CharacterStatePacket.cs ← UDP packet (49 bytes, +13B envelope)
+│   ├── CharacterStatePacket.cs ← UDP packet (63 bytes, +13B envelope)
 │   ├── ClientInputPacket.cs ← legacy — the wire uses InputState; kept for compat
 │   ├── InputState.cs        ← normalized input (MoveX/Y, flags, ActiveSlot), 19 bytes
 │   ├── AttackData.cs        ← HitboxEvent, AttackStage, AbilityData structs

--- a/docs/systems/hitstun-di.md
+++ b/docs/systems/hitstun-di.md
@@ -234,7 +234,7 @@ Hitstun has 3 animation tiers based on the damage of the attack that hits, provi
                                finalDamage < 15f ? (byte)1 : (byte)2;
    ```
 2. **Set once:** The level is set at hit time, not re-derived from `DamagePercent`. This prevents flicker if another hit lands during hitstun.
-3. **Serialized:** Packed into `CharacterStatePacket` at byte offset 43 (Size = 49). The client receives it every tick during hitstun.
+3. **Serialized:** Packed into `CharacterStatePacket` at byte offset 43 (Size = 63). The client receives it every tick during hitstun.
 4. **Client renderer:** `PlayerRenderer` maps `HitstunLevel` to a clip name (0→`hit_light`/HitSmall, 1→`hit_medium`/HitMedium, 2→`hit_hard`/HitHard) resolved through `CharacterAnimationConfig`, played via `_animancer.Play(clip)` with `Speed = GetAnimSpeedFromDuration(name, HitstunTicks)`
 5. **Server bone resolution:** Both bone-animation spots in `ServerSimulation` use the same switch to pick the clip name for hurtbox alignment.
 
@@ -268,6 +268,6 @@ See `tests/Shared.Tests/HitstunAnimationTierTests.cs` for:
 - **CharacterState.cs:** Line 47-48 (HitstunTicks, DIX, DIY), Line 102 (HitstunLevel)
 - **ActionState.cs:** Line 7 (Hitstun enum)
 - **Simulation.cs:** Line 61-67 (ProcessHitstun call), Line 141-176 (ProcessHitstun function), Line 462-495 (ApplyKnockback with hitstun)
-- **CharacterStatePacket.cs:** Offset 43 (HitstunLevel), Size 49
+- **CharacterStatePacket.cs:** Offset 43 (HitstunLevel), Size 63
 - **PlayerRenderer.cs:** (hitstun clip play + speed)
 - **HitstunAnimationTierTests.cs:** Full unit + integration coverage

--- a/docs/systems/netcode-architecture.md
+++ b/docs/systems/netcode-architecture.md
@@ -94,7 +94,7 @@ PvPMatch.FixedUpdate() / TrainingMatch.OnMatchFixedUpdate():
   1. Receive server states (non-blocking)
      → NetworkClient.ReceiveStates()
      → Returns: Dictionary<entityId, (tick, CharacterState)>
-     → Packet per entity: entityId(8) + tick(4) + CharacterStatePacket(49) = 61B
+     → Packet per entity: entityId(8) + tick(4) + CharacterStatePacket(63) = 75B
 
   2. Store into the bridge
      → NetworkSimulationBridge._latestStates[kv.Key] = kv.Value
@@ -134,7 +134,7 @@ Tick():
   6. SendState() — broadcast to all connected clients
      → For each client:
        → For each entity (all rostered players):
-       → Packet: entityId(8) + tick(4) + CharacterStatePacket(49) = 61B
+       → Packet: entityId(8) + tick(4) + CharacterStatePacket(63) = 75B
          → tick = _serverTick (echoed back)
        → Client filters by entityId
 ```
@@ -171,14 +171,14 @@ Total: 31 bytes (8 + 4 + 19)
 ### 4b. Server → Client (per entity)
 
 ```
-Receive packet per entity: entityId(8) + tick(4) + CharacterStatePacket(49) = 61 bytes
+Receive packet per entity: entityId(8) + tick(4) + CharacterStatePacket(63) = 75 bytes
 
 [0..7]   entityId          (ulong)
 [8..11]  tick              (uint)       ← echoes client's tick number
-[12..60] CharacterStatePacket (49 bytes)
+[12..74] CharacterStatePacket (63 bytes)
 ```
 
-**CharacterStatePacket layout (49 bytes):**
+**CharacterStatePacket layout (63 bytes):**
 | Offset | Type    | Field               | Notes                              |
 |--------|---------|---------------------|------------------------------------|
 | 0-3    | uint    | TickNumber          | Echoed client tick (for matching)  |
@@ -201,8 +201,10 @@ Receive packet per entity: entityId(8) + tick(4) + CharacterStatePacket(49) = 61
 | 43     | byte    | HitstunLevel        | 0=small, 1=medium, 2=hard          |
 | 44-47  | float   | AimPitch            | Server-authoritative aim pitch (radians) |
 | 48     | byte    | Deaths              | Stock counter: stocks left = maxStocks - Deaths (issue #37) |
+| 49-50  | ushort  | DamagePercent       | Smash-style damage %, HUD display (issue #38) |
+| 51-62  | ushort×6| Cooldown0..5        | Per-slot cooldown ticks, local HUD fills (issue #38) |
 
-Total: 61 bytes per entity (8 + 4 + 49)
+Total: 75 bytes per entity (8 + 4 + 63)
 
 **The server sends ALL states to every client.** Clients ignore the ones that don't concern them. No routing overhead.
 
@@ -212,7 +214,7 @@ Total: 61 bytes per entity (8 + 4 + 49)
 
 ## 5. CharacterState internals (Shared)
 
-`CharacterState` (144 bytes in memory, 49 serialized) is the full per-tick state of one entity:
+`CharacterState` (144 bytes in memory, 63 serialized) is the full per-tick state of one entity:
 
 | Field               | Type    | Notes                                |
 |---------------------|---------|--------------------------------------|

--- a/src/Server/MatchInstance.cs
+++ b/src/Server/MatchInstance.cs
@@ -47,7 +47,7 @@ namespace SlopArena.Server
 		/// <param name="roster">Ordered players (index 0 = host). Each carries an entity ID (1..N) and a character class.</param>
 		/// <param name="maxStocks">Stocks per player (default 3, issue #37).</param>
 		public MatchInstance(int port, string matchId, string arenaName,
-			IReadOnlyList<MatchPlayer> roster, Action<int> onMatchEnd, byte maxStocks = 3)
+			IReadOnlyList<MatchPlayer> roster, Action<int> onMatchEnd, byte maxStocks = MatchDefaults.DefaultMaxStocks)
 		{
 			_port = port;
 			_matchId = matchId;
@@ -362,7 +362,7 @@ namespace SlopArena.Server
 			if (_udpServer == null) return;
 
 			// Packet format (matching NetworkClient expectations):
-			//   entityId(8) + tick(4) + CharacterStatePacket(49)
+			//   entityId(8) + tick(4) + CharacterStatePacket(63)
 			const int envelopeSize = 8 + 4 + CharacterStatePacket.Size;
 
 			// Build a packet per entity once, then send each to every connected client.

--- a/src/Shared/CharacterStatePacket.cs
+++ b/src/Shared/CharacterStatePacket.cs
@@ -45,8 +45,12 @@ namespace SlopArena.Shared
         public float AimPitch;
         /// <summary>Match death counter (stock counter: stocks = maxStocks - Deaths). Issue #37.</summary>
         public byte Deaths;
-        /// <summary>49 bytes</summary>
-        public const int Size = 4 + 4 + 4 + 4 + 4 + 4 + 4 + 1 + 1 + 2 + 1 + 1 + 1 + 4 + 1 + 2 + 1 + 1 + 4 + 1;
+        /// <summary>Smash-style damage percent 0-999, sent so the client HUD can show every player's %. Issue #38.</summary>
+        public ushort DamagePercent;
+        /// <summary>Per-slot cooldown ticks (0-5), sent so the local player's HUD cooldown fills work in PvP. Issue #38.</summary>
+        public ushort Cooldown0, Cooldown1, Cooldown2, Cooldown3, Cooldown4, Cooldown5;
+        /// <summary>63 bytes</summary>
+        public const int Size = 4 + 4 + 4 + 4 + 4 + 4 + 4 + 1 + 1 + 2 + 1 + 1 + 1 + 4 + 1 + 2 + 1 + 1 + 4 + 1 + 2 + 2 + 2 + 2 + 2 + 2 + 2;
 
         /// <summary>Convert from CharacterState to serializable packet.</summary>
         public static CharacterStatePacket FromState(CharacterState s, uint tick = 0)
@@ -73,6 +77,13 @@ namespace SlopArena.Shared
                 HitstunLevel = s.HitstunLevel,
                 AimPitch = s.AimPitch,
                 Deaths = s.Deaths,
+                DamagePercent = s.DamagePercent,
+                Cooldown0 = s.Cooldown0,
+                Cooldown1 = s.Cooldown1,
+                Cooldown2 = s.Cooldown2,
+                Cooldown3 = s.Cooldown3,
+                Cooldown4 = s.Cooldown4,
+                Cooldown5 = s.Cooldown5,
             };
         }
 
@@ -99,6 +110,13 @@ namespace SlopArena.Shared
                 HitstunLevel = HitstunLevel,
                 AimPitch = AimPitch,
                 Deaths = Deaths,
+                DamagePercent = DamagePercent,
+                Cooldown0 = Cooldown0,
+                Cooldown1 = Cooldown1,
+                Cooldown2 = Cooldown2,
+                Cooldown3 = Cooldown3,
+                Cooldown4 = Cooldown4,
+                Cooldown5 = Cooldown5,
             };
         }
 
@@ -127,6 +145,13 @@ namespace SlopArena.Shared
             buffer[43] = HitstunLevel;
             BinaryPrimitives.WriteInt32LittleEndian(buffer.Slice(44, 4), BitConverter.SingleToInt32Bits(AimPitch));
             buffer[48] = Deaths;
+            BinaryPrimitives.WriteUInt16LittleEndian(buffer.Slice(49, 2), DamagePercent);
+            BinaryPrimitives.WriteUInt16LittleEndian(buffer.Slice(51, 2), Cooldown0);
+            BinaryPrimitives.WriteUInt16LittleEndian(buffer.Slice(53, 2), Cooldown1);
+            BinaryPrimitives.WriteUInt16LittleEndian(buffer.Slice(55, 2), Cooldown2);
+            BinaryPrimitives.WriteUInt16LittleEndian(buffer.Slice(57, 2), Cooldown3);
+            BinaryPrimitives.WriteUInt16LittleEndian(buffer.Slice(59, 2), Cooldown4);
+            BinaryPrimitives.WriteUInt16LittleEndian(buffer.Slice(61, 2), Cooldown5);
         }
 
         public static CharacterStatePacket Deserialize(ReadOnlySpan<byte> buffer)
@@ -155,6 +180,13 @@ namespace SlopArena.Shared
             packet.HitstunLevel = buffer[43];
             packet.AimPitch = BitConverter.Int32BitsToSingle(BinaryPrimitives.ReadInt32LittleEndian(buffer.Slice(44, 4)));
             packet.Deaths = buffer[48];
+            packet.DamagePercent = BinaryPrimitives.ReadUInt16LittleEndian(buffer.Slice(49, 2));
+            packet.Cooldown0 = BinaryPrimitives.ReadUInt16LittleEndian(buffer.Slice(51, 2));
+            packet.Cooldown1 = BinaryPrimitives.ReadUInt16LittleEndian(buffer.Slice(53, 2));
+            packet.Cooldown2 = BinaryPrimitives.ReadUInt16LittleEndian(buffer.Slice(55, 2));
+            packet.Cooldown3 = BinaryPrimitives.ReadUInt16LittleEndian(buffer.Slice(57, 2));
+            packet.Cooldown4 = BinaryPrimitives.ReadUInt16LittleEndian(buffer.Slice(59, 2));
+            packet.Cooldown5 = BinaryPrimitives.ReadUInt16LittleEndian(buffer.Slice(61, 2));
             return packet;
         }
     }

--- a/src/Shared/LobbyPayloadCodec.cs
+++ b/src/Shared/LobbyPayloadCodec.cs
@@ -130,6 +130,19 @@ public static class LobbyPayloadCodec
             if (!string.IsNullOrEmpty(s)) arenaName = s;
         }
 
-        return new MatchStartedConfig(snap.ServerId, snap.Players, matchPort, arenaName);
+        // maxStocks is optional (absent → default 3, matching MatchStartRequest and
+        // the game server's StockMatchRule). Present-but-malformed also falls back
+        // to the default, mirroring how matchPort/arenaName treat bad input — a
+        // malformed optional field must never abort the whole match-start push.
+        int maxStocks = MatchDefaults.DefaultMaxStocks;
+        if (element.TryGetProperty("maxStocks", out var ms) &&
+            ms.ValueKind == JsonValueKind.Number &&
+            ms.TryGetInt32(out int parsed) &&
+            parsed >= 1 && parsed <= 99)
+        {
+            maxStocks = parsed;
+        }
+
+        return new MatchStartedConfig(snap.ServerId, snap.Players, matchPort, arenaName, maxStocks);
     }
 }

--- a/src/Shared/MatchDefaults.cs
+++ b/src/Shared/MatchDefaults.cs
@@ -1,0 +1,12 @@
+namespace SlopArena.Shared;
+
+/// <summary>
+/// Shared match defaults so the lobby codec, match-start request, game server
+/// rule and client HUD agree on one value instead of duplicated literals
+/// (issue #38). Wire DTO defaults must stay compile-time constants.
+/// </summary>
+public static class MatchDefaults
+{
+    /// <summary>Stocks per player when the producer omits maxStocks (ADR-0007).</summary>
+    public const int DefaultMaxStocks = 3;
+}

--- a/src/Shared/MatchStartRequest.cs
+++ b/src/Shared/MatchStartRequest.cs
@@ -24,7 +24,7 @@ public sealed record MatchPlayer(long SteamId, CharacterClass CharacterClass, in
 /// <param name="ArenaName">Arena the game server should load for this match.</param>
 /// <param name="Players">Ordered roster (index 0 = host) the game server spawns.</param>
 /// <param name="MaxStocks">Stocks per player (default 3, issue #37).</param>
-public sealed record MatchStartRequest(string MatchId, string ArenaName, IReadOnlyList<MatchPlayer> Players, int MaxStocks = 3);
+public sealed record MatchStartRequest(string MatchId, string ArenaName, IReadOnlyList<MatchPlayer> Players, int MaxStocks = MatchDefaults.DefaultMaxStocks);
 
 /// <summary>
 /// Parses the <c>POST /match/start</c> JSON body (<see cref="MatchStartRequest"/>).

--- a/src/Shared/MatchStartedConfig.cs
+++ b/src/Shared/MatchStartedConfig.cs
@@ -17,4 +17,5 @@ public sealed record MatchStartedConfig(
     Guid ServerId,
     IReadOnlyList<LobbyPlayerInfo> Players,
     int MatchPort = 0,
-    string ArenaName = "");
+    string ArenaName = "",
+    int MaxStocks = MatchDefaults.DefaultMaxStocks);

--- a/tests/Shared.Tests/CharacterStatePacketTests.cs
+++ b/tests/Shared.Tests/CharacterStatePacketTests.cs
@@ -29,6 +29,13 @@ public class CharacterStatePacketTests
             HitstunLevel = 2,
             AimPitch = -0.5f,
             Deaths = 2,
+            DamagePercent = 87,
+            Cooldown0 = 1,
+            Cooldown1 = 12,
+            Cooldown2 = 33,
+            Cooldown3 = 44,
+            Cooldown4 = 55,
+            Cooldown5 = 66,
         };
 
         // Act: FromState → Serialize → Deserialize → ToState
@@ -59,14 +66,22 @@ public class CharacterStatePacketTests
         Assert.Equal(original.HitstunLevel, restored.HitstunLevel);
         Assert.Equal(original.AimPitch, restored.AimPitch);
         Assert.Equal(original.Deaths, restored.Deaths);
+        Assert.Equal(original.DamagePercent, restored.DamagePercent);
+        Assert.Equal(original.Cooldown0, restored.Cooldown0);
+        Assert.Equal(original.Cooldown1, restored.Cooldown1);
+        Assert.Equal(original.Cooldown2, restored.Cooldown2);
+        Assert.Equal(original.Cooldown3, restored.Cooldown3);
+        Assert.Equal(original.Cooldown4, restored.Cooldown4);
+        Assert.Equal(original.Cooldown5, restored.Cooldown5);
     }
 
     [Fact]
     public void Size_MatchesActualSerializedLayout()
     {
-        // AimPitch (float at offset 44) ends at byte 47, Deaths at byte 48 → 49 bytes.
+        // AimPitch (float at offset 44) ends at byte 47, Deaths at 48, then
+        // DamagePercent (49-50) and six cooldowns (51-62) → 63 bytes.
         // Lock the constant: a silent Size change would break every packet on the wire.
-        Assert.Equal(49, CharacterStatePacket.Size);
+        Assert.Equal(63, CharacterStatePacket.Size);
 
         // Prove it: serialize into an exactly-Size buffer must not throw
         var packet = CharacterStatePacket.FromState(new CharacterState { AimPitch = 1f });

--- a/tests/Shared.Tests/HitstunAnimationTierTests.cs
+++ b/tests/Shared.Tests/HitstunAnimationTierTests.cs
@@ -107,8 +107,8 @@ public class HitstunAnimationTierTests
     [Fact]
     public void CharacterStatePacket_Size_IncludesHitstunLevel()
     {
-        // Size should be 49 for the current packet layout (Deaths added, issue #37)
-        Assert.Equal(49, CharacterStatePacket.Size);
+        // Size should be 63 for the current packet layout (Deaths #37, damage + cooldowns #38)
+        Assert.Equal(63, CharacterStatePacket.Size);
     }
 
     // ═══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Multi-player HUD for stock matches: one panel per player (damage %, stock icons, P1-P4 label), local panel highlighted, eliminated players dimmed, cooldown slots local-only. The wire now carries DamagePercent + per-slot cooldowns (packet 49->63B) so the PvP HUD shows real damage; maxStocks flows from the master push with a shared default.

Closes #38.

## Changes
- feat(client): HUD panels for 2-4 players (issue #38)
  - HUDManager: runtime-built panels from roster, stock icons/count, local highlight + eliminated dim, cooldown fills local-only
  - HUD.uxml/.uss: player-panels container + styles; layout adapts to 2-4 players
  - MatchBase.SetupHUD: passes roster + maxStocks (hidden in training)
  - CharacterStatePacket: +DamagePercent, +Cooldown0..5 (63B); FromState/ToState/Serialize/Deserialize updated
  - LobbyPayloadCodec/MatchStartedConfig: optional maxStocks (default 3), lenient on malformed input
  - MatchDefaults.DefaultMaxStocks shared const (codec, request, server rule, client HUD)
  - Docs: packet layout + sizes synced (netcode-architecture, architecture-overview, hitstun-di, AGENTS.md, netcode skill)

## Verification
- dotnet test tests/Shared.Tests/: 450/450 passed (packet round-trip extended, Size=63 locked)
- Unity editor compile clean (temp-synced to the running editor's checkout, restored after): HUDManager.HudPlayer, MatchConfig.MaxStocks, MatchDefaults, packet Size=63 confirmed via runtime reflection
- Note: visual smoke test pending a live 2-4 player match (master server + game server + clients not running)

## Diffstat
```text
 .omp/AGENTS.md                                     |   2 +-
 .omp/skills/sloparena-netcode/SKILL.md             |   6 +-
 .../Scripts/Runtime/UI/CharSelectController.cs     |   3 +
 .../Unity/Assets/Scripts/Runtime/UI/HUDManager.cs  | 186 +++++++++++++++++----
 .../Unity/Assets/Scripts/Runtime/UI/MatchConfig.cs |   5 +
 .../Assets/Scripts/Runtime/World/MatchBase.cs      |  16 +-
 client/Unity/Assets/UI/HUD.uss                     |  74 +++++++-
 client/Unity/Assets/UI/HUD.uxml                    |   8 +-
 docs/architecture-overview.md                      |   2 +-
 docs/systems/hitstun-di.md                         |   4 +-
 docs/systems/netcode-architecture.md               |  16 +-
 src/Server/MatchInstance.cs                        |   4 +-
 src/Shared/CharacterStatePacket.cs                 |  36 +++-
 src/Shared/LobbyPayloadCodec.cs                    |  15 +-
 src/Shared/MatchDefaults.cs                        |  12 ++
 src/Shared/MatchStartRequest.cs                    |   2 +-
 src/Shared/MatchStartedConfig.cs                   |   3 +-
 tests/Shared.Tests/CharacterStatePacketTests.cs    |  19 ++-
 tests/Shared.Tests/HitstunAnimationTierTests.cs    |   4 +-
 19 files changed, 352 insertions(+), 65 deletions(-)
```