### PR TITLE
feat(match): results screen + return to lobby (issue #40)

### DIFF
--- a/client/Unity/Assets/Scenes/Results.unity
+++ b/client/Unity/Assets/Scenes/Results.unity
@@ -1,0 +1,328 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 10
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 13
+  m_BakeOnSceneLoad: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 1
+    m_PVRFilteringGaussRadiusAO: 1
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 20201, guid: 0000000000000000f000000000000000, type: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &1100000000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1100000003}
+  - component: {fileID: 1100000002}
+  - component: {fileID: 1100000001}
+  m_Layer: 5
+  m_Name: Results
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1100000001
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1100000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f9d2a7c1e4b4d8f9a6c3b2e1d0f4a8b, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  _uiDocument: {fileID: 1100000002}
+--- !u!114 &1100000002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1100000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 19102, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name:
+  m_EditorClassIdentifier:
+  m_PanelSettings: {fileID: 11400000, guid: 375219e0f9be73791af68905fab77544, type: 2}
+  m_ParentUI: {fileID: 0}
+  sourceAsset: {fileID: 9197481963319205126, guid: 7b3d8e2f4a5c6d7e8f9a0b1c2d3e4f5a, type: 3}
+  m_SortingOrder: 0
+  m_WorldSpaceSizeMode: 1
+  m_WorldSpaceWidth: 1920
+  m_WorldSpaceHeight: 1080
+--- !u!4 &1100000003
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1100000000}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1100000004
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1100000009}
+  - component: {fileID: 1100000008}
+  - component: {fileID: 1100000007}
+  - component: {fileID: 1100000006}
+  m_Layer: 0
+  m_Name: Camera
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1100000006
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1100000004}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_AllowHDROutput: 1
+  m_UseScreenCoordOverride: 0
+  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_Version: 2
+  m_TaaSettings:
+    m_Quality: 3
+    m_FrameInfluence: 0.1
+    m_JitterScale: 1
+    m_MipBias: 0
+    m_VarianceClampScale: 0.9
+    m_ContrastAdaptiveSharpening: 0
+--- !u!81 &1100000007
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1100000004}
+  m_Enabled: 1
+--- !u!20 &1100000008
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1100000004}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &1100000009
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1100000004}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 1100000003}
+  - {fileID: 1100000009}

--- a/client/Unity/Assets/Scenes/Results.unity.meta
+++ b/client/Unity/Assets/Scenes/Results.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a1b2c3d4e5f60718293a4b5c6d7e8f9a
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/client/Unity/Assets/Scripts/Runtime/ClientSession.cs
+++ b/client/Unity/Assets/Scripts/Runtime/ClientSession.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System;
+using System.Collections.Generic;
 
 namespace SlopArena.Client
 {
@@ -45,6 +46,30 @@ namespace SlopArena.Client
         /// </summary>
         public static Shared.LobbySnapshot? LobbyRoster;
 
+        /// <summary>Roster stashed at match start (entityId → name/class) for the results screen (issue #40).</summary>
+        public static IReadOnlyList<Shared.LobbyPlayerInfo>? MatchRoster;
+
+        /// <summary>Final standings, set by PvPMatch when the match ends; consumed by ResultsUI.</summary>
+        public static MatchResultsData? CurrentMatchResults;
+
+        /// <summary>One player's final standing line on the results screen.</summary>
+        public sealed class ResultEntry
+        {
+            public ulong EntityId;
+            public string Name = "";
+            public string ClassName = "";
+            public int StocksRemaining;
+            public int DamagePercent;
+            public bool IsWinner;
+        }
+
+        /// <summary>Final standings snapshot for the results screen.</summary>
+        public sealed class MatchResultsData
+        {
+            public bool SharedVictory;
+            public List<ResultEntry> Entries = new();
+        }
+
         public static void Reset()
         {
             MasterServerUrl = "http://localhost:5000";
@@ -55,6 +80,8 @@ namespace SlopArena.Client
             SelectedServerName = string.Empty;
             ActiveLobby = null;
             LobbyRoster = null;
+            MatchRoster = null;
+            CurrentMatchResults = null;
         }
     }
 }

--- a/client/Unity/Assets/Scripts/Runtime/UI/CharSelectController.cs
+++ b/client/Unity/Assets/Scripts/Runtime/UI/CharSelectController.cs
@@ -204,7 +204,7 @@ namespace SlopArena.Client.UI
             UpdateStartMatchButton();
         }
 
-        private async void OnMatchStarted(MatchStartedConfig config)
+        private void OnMatchStarted(MatchStartedConfig config)
         {
             Debug.Log($"[CharSelect] Match started: {config.Players.Count} players, port={config.MatchPort}, arena={config.ArenaName}.");
 
@@ -251,20 +251,19 @@ namespace SlopArena.Client.UI
                     ParseClass(p.CharacterSelection, CharacterClass.Manki)));
             }
 
-            // Tear down the lobby connection — the match is now handed off to
-            // the game server (UDP). Leaving the SignalR lobby connected would
-            // keep server-side lobby membership alive past match start.
+            // Keep the lobby connection alive through the match (issue #40): the
+            // results screen + lobby return rely on it. Just unsubscribe the
+            // event handlers so nothing fires while in Arena_PvP.
             if (_lobby != null)
             {
                 _lobby.LobbyUpdated    -= OnLobbyUpdated;
                 _lobby.CharacterSelected -= OnCharacterSelected;
                 _lobby.MatchStarted     -= OnMatchStarted;
                 _lobby.Error            -= OnPvPError;
-                try { await _lobby.LeaveLobbyAsync(); } catch { /* best effort */ }
-                await _lobby.DisconnectAsync();
             }
-            ClientSession.ActiveLobby = null;
-            ClientSession.LobbyRoster = null;
+
+            // Stash the roster so the results screen can render names/classes.
+            ClientSession.MatchRoster = config.Players;
 
             // Go straight to the PvP arena — the master server already picked
             // the arena and assigned the port, so StageSelect is skipped for

--- a/client/Unity/Assets/Scripts/Runtime/UI/ResultsUI.cs
+++ b/client/Unity/Assets/Scripts/Runtime/UI/ResultsUI.cs
@@ -1,0 +1,89 @@
+#nullable enable
+using UnityEngine;
+using UnityEngine.UIElements;
+using UnityEngine.SceneManagement;
+using SlopArena.Client;
+
+namespace SlopArena.Client.UI
+{
+    /// <summary>
+    /// Results screen shown after a PvP match ends (issue #40). Reads the final
+    /// standings stashed by <c>PvPMatch.BuildAndShowResults</c>, renders winner +
+    /// standings, then auto-returns to the lobby room after a 6s countdown. The
+    /// SignalR lobby connection stayed alive through the match (decision 1), so
+    /// landing back in LobbyRoom re-joins the same lobby — host role intact.
+    /// </summary>
+    public class ResultsUI : MonoBehaviour
+    {
+        private const float ReturnCountdownSeconds = 6f;
+
+        [SerializeField] private UIDocument _uiDocument;
+
+        private VisualElement _standings;
+        private Label _lblWinner;
+        private Label _lblCountdown;
+        private float _remaining = ReturnCountdownSeconds;
+
+        private void OnEnable()
+        {
+            var root = _uiDocument.rootVisualElement;
+            _lblWinner = root.Q<Label>("lbl-winner");
+            _standings = root.Q<VisualElement>("standings-list");
+            _lblCountdown = root.Q<Label>("lbl-countdown");
+            _remaining = ReturnCountdownSeconds;
+
+            RenderResults();
+            UpdateCountdownLabel();
+        }
+
+        private void Update()
+        {
+            // Drain queued lobby events while we wait — the connection is still
+            // alive (decision 1) and LobbyRoomUI will pump after we load it too.
+            ClientSession.ActiveLobby?.Pump();
+
+            _remaining -= Time.deltaTime;
+            UpdateCountdownLabel();
+            if (_remaining <= 0f)
+                SceneManager.LoadScene("LobbyRoom");
+        }
+
+        private void RenderResults()
+        {
+            var results = ClientSession.CurrentMatchResults;
+            if (results == null)
+            {
+                // Defensive: unreachable in practice (PvPMatch always stashes
+                // results before loading this scene).
+                _lblWinner.text = "MATCH OVER";
+                return;
+            }
+
+            if (results.SharedVictory)
+            {
+                _lblWinner.text = "SHARED VICTORY";
+            }
+            else
+            {
+                var winner = results.Entries.Find(e => e.IsWinner);
+                _lblWinner.text = winner != null
+                    ? $"{winner.Name} WINS!"
+                    : "WINNER: P?";
+            }
+
+            for (int i = 0; i < results.Entries.Count; i++)
+            {
+                var e = results.Entries[i];
+                var row = new Label($"{i + 1}. {e.Name} — {e.ClassName} — {e.StocksRemaining} STOCKS");
+                row.AddToClassList("player-slot");
+                row.AddToClassList("slot-name");
+                _standings.Add(row);
+            }
+        }
+
+        private void UpdateCountdownLabel()
+        {
+            _lblCountdown.text = $"Returning to lobby in {Mathf.CeilToInt(Mathf.Max(0f, _remaining))}s";
+        }
+    }
+}

--- a/client/Unity/Assets/Scripts/Runtime/UI/ResultsUI.cs.meta
+++ b/client/Unity/Assets/Scripts/Runtime/UI/ResultsUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5f9d2a7c1e4b4d8f9a6c3b2e1d0f4a8b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/client/Unity/Assets/Scripts/Runtime/World/PvPMatch.cs
+++ b/client/Unity/Assets/Scripts/Runtime/World/PvPMatch.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.IO;
 using System;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 using SlopArena.Shared;
 using SlopArena.Client.Entities;
 using SlopArena.Client.Input;
@@ -197,6 +198,11 @@ namespace SlopArena.Client.World
             {
                 Debug.Log($"[PvP] MatchState transition: {_lastMatchState} → {matchState}");
                 _lastMatchState = matchState;
+
+                if (matchState == MatchState.Ended)
+                {
+                    BuildAndShowResults();
+                }
             }
 
             _tick++;
@@ -206,6 +212,83 @@ namespace SlopArena.Client.World
                 Debug.Log($"[PvP] tick={_tick} connected={_networkClient.IsServerConnected} " +
                           $"pos=({ps.PX:F1},{ps.PY:F2},{ps.PZ:F1}) serverTick={_networkClient.LastServerTick}");
             }
+        }
+
+        /// <summary>
+        /// Build the final standings from the last server states and schedule the
+        /// return to the results screen (issue #40). Runs once on the Ended transition.
+        /// </summary>
+        private void BuildAndShowResults()
+        {
+            var states = new Dictionary<ulong, CharacterState>
+            {
+                { PlayerEntityId, _bridge.GetState(PlayerEntityId) }
+            };
+            foreach (var id in _opponentRenderers.Keys)
+                states[id] = _bridge.GetState(id);
+
+            // Winner via the shared rule — same decision the game server made.
+            var outcome = new StockMatchRule((byte)MatchConfig.MaxStocks).Evaluate(states);
+
+            var data = new ClientSession.MatchResultsData
+            {
+                SharedVictory = outcome.IsSharedVictory,
+            };
+
+            if (ClientSession.MatchRoster != null)
+            {
+                foreach (var roster in ClientSession.MatchRoster)
+                {
+                    if (roster.EntityId <= 0) continue;
+                    var id = (ulong)roster.EntityId;
+                    if (!states.TryGetValue(id, out var st)) continue;
+
+                    var className = roster.CharacterSelection;
+                    if (string.IsNullOrEmpty(className))
+                    {
+                        className = id == PlayerEntityId
+                            ? MatchConfig.PlayerClass.ToString()
+                            : OpponentClass(id);
+                    }
+
+                    data.Entries.Add(new ClientSession.ResultEntry
+                    {
+                        EntityId = id,
+                        Name = string.IsNullOrEmpty(roster.Name) ? $"P{id}" : roster.Name,
+                        ClassName = className,
+                        StocksRemaining = MatchConfig.MaxStocks - st.Deaths,
+                        DamagePercent = st.DamagePercent,
+                        IsWinner = !outcome.IsSharedVictory && id == outcome.WinnerEntityId,
+                    });
+                }
+            }
+
+            // Rank: most stocks first, then least damage (tie-break).
+            data.Entries.Sort((a, b) =>
+            {
+                int byStocks = b.StocksRemaining.CompareTo(a.StocksRemaining);
+                return byStocks != 0 ? byStocks : a.DamagePercent.CompareTo(b.DamagePercent);
+            });
+
+            ClientSession.CurrentMatchResults = data;
+            Debug.Log($"[PvP] Match ended — {data.Entries.Count} entries, shared={outcome.IsSharedVictory}");
+
+            // 2s beat so the KO moment renders; the server keeps broadcasting the
+            // Ended state for its 3s post-match window, then we cut to Results.
+            StartCoroutine(ReturnToLobbyAfterDelay());
+        }
+
+        private string OpponentClass(ulong entityId)
+        {
+            foreach (var opp in MatchConfig.Opponents)
+                if (opp.EntityId == entityId) return opp.Class.ToString();
+            return $"P{entityId}";
+        }
+
+        private System.Collections.IEnumerator ReturnToLobbyAfterDelay()
+        {
+            yield return new WaitForSeconds(2f);
+            SceneManager.LoadScene("Results");
         }
     }
 }

--- a/client/Unity/Assets/UI/Results.uxml
+++ b/client/Unity/Assets/UI/Results.uxml
@@ -1,0 +1,9 @@
+<ui:UXML xmlns:ui="UnityEngine.UIElements">
+    <ui:Style src="SlopArena.uss" />
+    <ui:VisualElement name="root" class="screen">
+        <ui:Label name="title" text="RESULTS" class="title" />
+        <ui:Label name="lbl-winner" text="" class="subtitle" />
+        <ui:VisualElement name="standings-list" class="player-list lobby-list" />
+        <ui:Label name="lbl-countdown" text="" class="subtitle" />
+    </ui:VisualElement>
+</ui:UXML>

--- a/client/Unity/Assets/UI/Results.uxml.meta
+++ b/client/Unity/Assets/UI/Results.uxml.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 7b3d8e2f4a5c6d7e8f9a0b1c2d3e4f5a
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+  script: {fileID: 13804, guid: 0000000000000000e000000000000000, type: 0}

--- a/client/Unity/ProjectSettings/EditorBuildSettings.asset
+++ b/client/Unity/ProjectSettings/EditorBuildSettings.asset
@@ -29,6 +29,9 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Scenes/LobbyRoom.unity
     guid: 84d2952d59214d19b4032edd770b2ad9
+  - enabled: 1
+    path: Assets/Scenes/Results.unity
+    guid: a1b2c3d4e5f60718293a4b5c6d7e8f9a
   m_configObjects:
     com.unity.dt.app-ui: {fileID: 11400000, guid: 1b1c20d82303e4b5781c3ef50ac1449f, type: 2}
   m_UseUCBPForAssetBundles: 0

--- a/src/Server/MatchInstance.cs
+++ b/src/Server/MatchInstance.cs
@@ -43,21 +43,25 @@ namespace SlopArena.Server
 
 		private Thread? _thread;
 		private readonly Action<int> _onMatchEnd;
+		private readonly Action<Guid, long>? _onMatchResult;
 
 		/// <param name="roster">Ordered players (index 0 = host). Each carries an entity ID (1..N) and a character class.</param>
 		/// <param name="maxStocks">Stocks per player (default 3, issue #37).</param>
+		/// <param name="onMatchResult">Optional callback invoked once when the match ends (match guid, winner steam id).</param>
 		public MatchInstance(int port, string matchId, string arenaName,
-			IReadOnlyList<MatchPlayer> roster, Action<int> onMatchEnd, byte maxStocks = MatchDefaults.DefaultMaxStocks)
+			IReadOnlyList<MatchPlayer> roster, Action<int> onMatchEnd, byte maxStocks = MatchDefaults.DefaultMaxStocks,
+			Action<Guid, long>? onMatchResult = null)
 		{
 			_port = port;
 			_matchId = matchId;
 			_arenaName = arenaName;
 			_onMatchEnd = onMatchEnd;
+			_onMatchResult = onMatchResult;
 			_rule = new StockMatchRule(maxStocks);
 
 			_slots = new List<PlayerSlot>(roster.Count);
 			foreach (var p in roster)
-				_slots.Add(new PlayerSlot((ulong)p.EntityId, p.CharacterClass));
+				_slots.Add(new PlayerSlot((ulong)p.EntityId, p.CharacterClass, p.SteamId));
 		}
 
 		/// <summary>True while the match loop is active.</summary>
@@ -351,6 +355,18 @@ namespace SlopArena.Server
 					Console.WriteLine(outcome.IsSharedVictory
 						? $"[Match:{_matchId}] Shared victory — all players eliminated simultaneously."
 						: $"[Match:{_matchId}] Winner: {_winnerEntityId}");
+
+					// Report the result to the master server (issue #40). Fire-and-forget:
+					// ReportMatchResultAsync swallows errors. Shared victory (_winnerEntityId == 0)
+					// reports winnerSteamId = 0, which the master stores as NULL. Runs exactly once
+					// because subsequent ticks take the Ended branch above.
+					if (_onMatchResult != null && Guid.TryParse(_matchId, out var matchGuid))
+					{
+						long winnerSteamId = 0;
+						var winnerSlot = FindSlot(_winnerEntityId);
+						if (winnerSlot != null) winnerSteamId = winnerSlot.SteamId;
+						_onMatchResult(matchGuid, winnerSteamId); // fire-and-forget; ReportMatchResultAsync swallows errors
+					}
 				}
 
 				SendState();
@@ -417,15 +433,17 @@ namespace SlopArena.Server
 		{
 			public ulong EntityId { get; }
 			public CharacterClass CharacterClass { get; }
+			public long SteamId { get; }
 			public IPEndPoint? EndPoint { get; set; }
 			public DateTime LastPacket { get; set; } = DateTime.UtcNow;
 			public bool Disconnected { get; set; }
 			public List<(uint tick, InputState input)> Queue { get; } = new();
 
-			public PlayerSlot(ulong entityId, CharacterClass characterClass)
+			public PlayerSlot(ulong entityId, CharacterClass characterClass, long steamId)
 			{
 				EntityId = entityId;
 				CharacterClass = characterClass;
+				SteamId = steamId;
 			}
 		}
 	}

--- a/src/Server/MultiMatchOrchestrator.cs
+++ b/src/Server/MultiMatchOrchestrator.cs
@@ -22,6 +22,9 @@ namespace SlopArena.Server
             _config = config;
         }
 
+        /// <summary>Optional callback invoked with (match guid, winner steam id) when a match ends (issue #40).</summary>
+        public Action<Guid, long>? ReportMatchResult { get; set; }
+
         /// <summary>
         /// Assign a new match to the next available port with a roster of
         /// players + character classes (issue #35). Returns the assigned UDP
@@ -34,7 +37,7 @@ namespace SlopArena.Server
                 int port = _config.Port + offset;
                 if (!_activeMatches.ContainsKey(port))
                 {
-                    var match = new MatchInstance(port, matchId, arenaName, roster, OnMatchEnd, maxStocks);
+                    var match = new MatchInstance(port, matchId, arenaName, roster, OnMatchEnd, maxStocks, ReportMatchResult);
                     if (_activeMatches.TryAdd(port, match))
                     {
                         match.Start();

--- a/src/Server/Program.cs
+++ b/src/Server/Program.cs
@@ -26,6 +26,11 @@ namespace SlopArena.Server
             var registration = new GameServerRegistration(config, orchestrator);
             var cts = new CancellationTokenSource();
 
+            // Report finished-match results (winner steam id) to the master server (issue #40).
+            // Fire-and-forget: ReportMatchResultAsync swallows errors; shared victory reports 0.
+            orchestrator.ReportMatchResult = (matchId, winner) =>
+                _ = registration.ReportMatchResultAsync(matchId, winner);
+
             // HTTP control endpoint for master server match-start commands
             // (issue #35). Listens on the registered base TCP port; UDP matches
             // bind port+offset, so the two coexist on the same number.


### PR DESCRIPTION
Closes the match loop: when a match ends, every client sees a results screen (winner + final standings), then auto-returns to the lobby room where the host can start another match. The game server now reports the result (winner SteamId) to the master server, which records the Match row + winner; ELO/MMR math stays disabled. The client keeps its SignalR lobby connection alive through the match so the lobby and host role survive (no re-join host rotation).
Closes #40.

## Changes
- feat(match): game server reports match result to master server via fire-and-forget callback (winner SteamId; shared victory reports 0 → NULL)
- feat(match): client results screen (Results scene + ResultsUI + Results.uxml) driven by the UDP MatchState.Ended broadcast, winner derived via shared StockMatchRule
- feat(match): 2s arena beat then 6s countdown → auto-return to LobbyRoom; lobby connection kept alive (decision 1)
- feat(match): PvPMatch stashes final standings (roster name/class, stocks, damage) sorted stocks desc / damage asc

## Verification
- dotnet build src/Shared/ + src/Server/: 0 errors
- dotnet test tests/Shared.Tests/: 450/450 pass
- Client scripts static-compiled against Unity reference assemblies: 0 errors
- Master server: 52/52 tests pass, migration AddPlayer3And4ToMatches applied (Player3SteamId/Player4SteamId columns verified)
- Manual E2E (fight → results → same lobby → match 2) pending in-editor; Unity Editor currently on main checkout + MCP approval revoked

## Diffstat
```text
 client/Unity/Assets/Scenes/Results.unity           | 328 +++++++++++++++++++++
 client/Unity/Assets/Scenes/Results.unity.meta      |   7 +
 .../Unity/Assets/Scripts/Runtime/ClientSession.cs  |  27 ++
 .../Scripts/Runtime/UI/CharSelectController.cs     |  15 +-
 .../Unity/Assets/Scripts/Runtime/UI/ResultsUI.cs   |  89 ++++++
 .../Assets/Scripts/Runtime/UI/ResultsUI.cs.meta    |  11 +
 .../Unity/Assets/Scripts/Runtime/World/PvPMatch.cs |  83 ++++++
 client/Unity/Assets/UI/Results.uxml                |   9 +
 client/Unity/Assets/UI/Results.uxml.meta           |  10 +
 .../ProjectSettings/EditorBuildSettings.asset      |   3 +
 src/Server/MatchInstance.cs                        |  24 +-
 src/Server/MultiMatchOrchestrator.cs               |   5 +-
 src/Server/Program.cs                              |   5 +
 13 files changed, 604 insertions(+), 12 deletions(-)
```