### PR TITLE
fix(client): stop embedded server when host backs out of lobby/char-select (issue #48)

### DIFF
--- a/client/Unity/Assets/Scripts/Runtime/UI/CharSelectController.cs
+++ b/client/Unity/Assets/Scripts/Runtime/UI/CharSelectController.cs
@@ -296,6 +296,13 @@ namespace SlopArena.Client.UI
                 _lobby.MatchStarted     -= OnMatchStarted;
                 _lobby.Error            -= OnPvPError;
             }
+            // The host owns the embedded server subprocess (ADR-0005): backing
+            // out of char-select must stop it, or the orphaned server keeps
+            // running and stays registered (issue #48). Non-hosts never touch
+            // it — MatchConfig.IsHost is the authoritative flag, not the roster.
+            if (MatchConfig.IsHost)
+                ServerHost.Instance?.Stop();
+
             // Return to lobby room (connection still alive)
             SceneManager.LoadScene("LobbyRoom");
         }

--- a/client/Unity/Assets/Scripts/Runtime/UI/LobbyRoomUI.cs
+++ b/client/Unity/Assets/Scripts/Runtime/UI/LobbyRoomUI.cs
@@ -219,6 +219,13 @@ namespace SlopArena.Client.UI
 
         private async void Leave()
         {
+            // The host owns the embedded server subprocess (ADR-0005): backing
+            // out of the lobby must stop it, or the orphaned server keeps
+            // running and stays registered (issue #48). Non-hosts never touch
+            // it — MatchConfig.IsHost is the authoritative flag, not the roster.
+            if (MatchConfig.IsHost)
+                ServerHost.Instance?.Stop();
+
             if (_lobby != null)
             {
                 try { await _lobby.LeaveLobbyAsync(); } catch { /* best effort */ }


### PR DESCRIPTION
When the host leaves the lobby or presses Back from char-select, the embedded host-and-play server subprocess (ServerHost, ADR-0005) kept running — letting the host re-join their own orphaned server and leaking the process until app quit. Both leave paths now stop the subprocess, gated on `MatchConfig.IsHost` so non-host clients (who don't own the subprocess) are unaffected.

Closes #48.

## Changes
- `LobbyRoomUI.Leave()` — host-only `ServerHost.Instance?.Stop()` before tearing down the lobby connection (covers both Leave and Back buttons).
- `CharSelectController.OnPvPBackClicked()` — same host-only guard before returning to LobbyRoom.
- Guard uses `MatchConfig.IsHost` (the authoritative flag set by `StartHostingFlow`), not the lobby roster. `ServerHost.Stop()` is idempotent, so repeated calls (Back then Leave) are safe no-ops; training mode has no `ServerHost` instance and is unaffected.

## Verification
- Full runtime script tree typechecked with Roslyn against Unity 6000.0.78f1 assemblies (editor MCP revoked): build succeeded, 0 errors.
- `dotnet test tests/Shared.Tests/`: 450 passed, 0 failed.
- No Shared/ files changed (client-only fix).
- Behavior not e2e-tested here: requires master server + game server + two clients.

## Diffstat
```text
 client/Unity/Assets/Scripts/Runtime/UI/CharSelectController.cs | 7 +++++++
 client/Unity/Assets/Scripts/Runtime/UI/LobbyRoomUI.cs          | 7 +++++++
 2 files changed, 14 insertions(+)
```