### PR TITLE
fix(server): camelCase server.json + publicIp override (issue #59)

### DIFF
--- a/docs/systems/master-server.md
+++ b/docs/systems/master-server.md
@@ -46,10 +46,10 @@ ASPNETCORE_ENVIRONMENT=Development dotnet run --no-build --urls http://localhost
 |---|---|---|
 | `appsettings.Development.json` | `ConnectionStrings:DefaultConnection` | `Host=localhost;Port=5432;Database=sloparena;Username=postgres;Password=password` |
 | `.env` (gitignored, overrides appsettings when sourced) | `ConnectionStrings__DefaultConnection`, `Jwt__Secret` | dev values; see `.env.example` |
-| **this repo** `src/Server/server.json` | `master_server_url` | `http://localhost:5000` |
+| **this repo** `src/Server/server.json` | `masterServerUrl` | `http://localhost:5000` |
 | **this repo** `src/Server/MultiMatchOrchestrator.cs` → `ServerConfig.MasterServerUrl` | default | `http://localhost:5000` |
 
-The game server (`src/Server`) points at the master server via `ServerConfig.MasterServerUrl`, loaded from `server.json`. Change `master_server_url` there to redirect registration/heartbeats (e.g. staging).
+The game server (`src/Server`) points at the master server via `ServerConfig.MasterServerUrl`, loaded from `server.json`. Change `masterServerUrl` there to redirect registration/heartbeats (e.g. staging).
 
 ---
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -39,7 +39,7 @@ dotnet test tests/Shared.Tests/ --nologo --filter "ServerSimulationTests"
  | `FightGuyAbilityTests.cs` | 38 | FightGuy LMB/Q/E/R/F activation, hitbox collision, mark system, homing, launcher |
  | `FightGuyKitRegressionTests.cs` | 5 | Golden kit regression for FightGuy |
  | `HitstunAnimationTierTests.cs` | 7 | 3-tier hitstun animation (damage → HitstunLevel, clip tiers) |
- | `HostedServerConfigTests.cs` | 3 | HostedServerConfig server.json builder (ADR-0005) |
+ | `HostedServerConfigTests.cs` | 4 | HostedServerConfig server.json builder (ADR-0005) |
  | `KistuAbilityTests.cs` | 13 | Kistu kit: RMB charge, E dash, R launcher + charge-stock, Q counter |
  | `LedgeSnapTests.cs` | 6 | Ledge snap auto-grab near stage edge |
  | `LobbyPayloadCodecTests.cs` | 16 | SignalR lobby JSON payload mapping (issue #33) |

--- a/src/Server/GameServerRegistration.cs
+++ b/src/Server/GameServerRegistration.cs
@@ -45,7 +45,7 @@ namespace SlopArena.Server
         {
             try
             {
-                var ip = GetPublicIpAddress();
+                var ip = _config.PublicIp ?? GetPublicIpAddress();
                 var payload = new
                 {
                     name = _config.ServerName,

--- a/src/Server/MultiMatchOrchestrator.cs
+++ b/src/Server/MultiMatchOrchestrator.cs
@@ -128,6 +128,12 @@ namespace SlopArena.Server
         public int Port { get; set; } = 9876;
         public int MaxConcurrentMatches { get; set; } = 15;
         public string MasterServerUrl { get; set; } = "http://localhost:5000";
+        /// <summary>
+        /// Public IP or DNS name advertised to the master server (clients connect
+        /// here over UDP). Null → auto-detect LAN IP (correct only for directly
+        /// routable machines). Set behind NAT (e.g. "slop.barakaslurp.fr").
+        /// </summary>
+        public string? PublicIp { get; set; }
         public bool IsOfficial { get; set; } = false;
         /// <summary>Directory containing .arena files. Relative to the server working directory.</summary>
         public string ArenaDataDir { get; set; } = "data/arenas";

--- a/src/Server/server.json
+++ b/src/Server/server.json
@@ -1,12 +1,9 @@
 {
-  "server_name": "SlopArena Local Dev",
+  "serverName": "SlopArena Local Dev",
   "region": "EU",
   "port": 7777,
-  "max_concurrent_matches": 15,
-  "master_server_url": "http://localhost:5000",
-  "is_official": false,
-  "custom_rules": {
-    "allowed_characters": ["Manki"],
-    "allowed_maps": ["pit"]
-  }
+  "maxConcurrentMatches": 15,
+  "masterServerUrl": "http://localhost:5000",
+  "isOfficial": false,
+  "arenaDataDir": "data/arenas"
 }

--- a/src/Shared/HostedServerConfig.cs
+++ b/src/Shared/HostedServerConfig.cs
@@ -33,6 +33,12 @@ public sealed record HostedServerConfig
     /// <summary>Master server base URL (e.g. http://localhost:5000).</summary>
     public string MasterServerUrl { get; init; } = "http://localhost:5000";
 
+    /// <summary>
+    /// Public IP/domain for the browser list when the host machine is behind NAT.
+    /// Null → the server advertises its LAN IP (LAN-only hosting).
+    /// </summary>
+    public string? PublicIp { get; init; }
+
     /// <summary>Hosted servers are never official.</summary>
     public bool IsOfficial { get; init; } = false;
 

--- a/tests/Shared.Tests/HostedServerConfigTests.cs
+++ b/tests/Shared.Tests/HostedServerConfigTests.cs
@@ -39,6 +39,15 @@ public class HostedServerConfigTests
     }
 
     [Fact]
+    public void ToJson_WithPublicIp_EmitsCamelCasePublicIp()
+    {
+        var cfg = new HostedServerConfig { PublicIp = "slop.barakaslurp.fr" };
+        var json = cfg.ToJson();
+
+        Assert.Contains("\"publicIp\": \"slop.barakaslurp.fr\"", json);
+    }
+
+    [Fact]
     public void ToJson_Defaults_AreDemoSafe()
     {
         var cfg = new HostedServerConfig { ArenaDataDir = "/x" };


### PR DESCRIPTION
Fixes server.json keys silently falling back to defaults (snake_case keys don't bind against case-insensitive-only deserialization) and lets hosted servers advertise a public IP / DNS name so remote players can reach home-hosted servers behind NAT.
Closes #59.

## Changes
- `src/Server/server.json`: rewrite snake_case keys (`master_server_url`, `custom_rules`, ...) to camelCase; `ServerConfig.Load` only uses `PropertyNameCaseInsensitive`, which handles case but not underscores, so the old keys silently fell back to defaults. `custom_rules` omitted per plan Task 3.2 (decorative, no server-side enforcement).
- `src/Server/MultiMatchOrchestrator.cs`: add nullable `ServerConfig.PublicIp` (JSON key `publicIp`; DNS name allowed).
- `src/Server/GameServerRegistration.cs`: advertise `_config.PublicIp ?? GetPublicIpAddress()` instead of always the auto-detected LAN IP.
- `src/Shared/HostedServerConfig.cs`: add `PublicIp` to the hosted server.json builder (camelCase `publicIp` emission).
- `tests/Shared.Tests/HostedServerConfigTests.cs`: new test asserting `"publicIp"` camelCase emission.
- `docs/systems/master-server.md`, `docs/testing.md`: fix doc references to the dead `master_server_url` key + refresh test inventory.

Shared files changed: `src/Shared/HostedServerConfig.cs` (rebuilt DLL auto-copied to Unity Plugins via post-build).

## Verification
- `dotnet build src/Shared/` — 0 errors
- `dotnet test tests/Shared.Tests/` — 451 passed, 0 failed (incl. new `ToJson_WithPublicIp_EmitsCamelCasePublicIp`)
- `dotnet build src/Server/` — 0 errors
- Smoke: ran server with `"publicIp": "1.2.3.4"` against a throwaway master listener; log shows `[Registration] Registered as 'smoke' (... IP: 1.2.3.4)` — override wins over LAN auto-detect

## Diffstat
```text
 docs/systems/master-server.md                 |  4 ++--
 docs/testing.md                               |  2 +-
 src/Server/GameServerRegistration.cs          |  2 +-
 src/Server/MultiMatchOrchestrator.cs          |  6 ++++++
 src/Server/server.json                        | 13 +++++--------
 src/Shared/HostedServerConfig.cs              |  6 ++++++
 tests/Shared.Tests/HostedServerConfigTests.cs |  9 +++++++++
 7 files changed, 30 insertions(+), 12 deletions(-)
```
