### PR TITLE
docs: add ADR-0009 demo hosting model (issue #62)

### DIFF
--- a/docs/adr/0009-demo-hosting-model.md
+++ b/docs/adr/0009-demo-hosting-model.md
@@ -1,0 +1,32 @@
+# ADR-0009: Demo Hosting Model — OfficialServers + Technical Host-and-Play
+
+**Status:** Accepted — 2026-08-02
+**Deciders:** @Binoui
+**Amends:** ADR-0005 (embedded host-and-play demo posture)
+
+## Context
+
+ADR-0005 chose embedded host-and-play for the demo, noting "LAN/localhost is
+sufficient." The demo goal is friends over the internet. Player-hosted matches
+are unreachable from outside a LAN today: `GameServerRegistration` advertises
+the machine's LAN IP, and remote reachability requires per-host port
+forwarding — a non-starter for non-technical players.
+
+## Decision
+
+Two-tier hosting for the demo:
+1. **OfficialServers** — operator-run dedicated `GameServer` instances on the
+   home mini PC (always on, registered with a reachable public IP/domain).
+   Non-technical players only Join; no NAT work on their side.
+2. **HostAndPlay** — stays supported for technical players who port-forward.
+   The player sets their public IP/domain in the host UI; the bundled
+   self-contained server binary is spawned from StreamingAssets.
+
+## Consequences
+
+- Player-facing docs use "Join" (OfficialServers) as the primary path; "Host"
+  is documented separately for technical users.
+- The game server must accept a `publicIp` override (domain allowed) in
+  `server.json`; `ServerHost` must launch a bundled binary in release builds.
+- The master server URL in release builds points at `https://sloparena.barakaslurp.fr`.
+- Future migration to VPS hosting is infra-only (ADR-0005 consequence unchanged).


### PR DESCRIPTION
Adds ADR-0009, amending ADR-0005's LAN/localhost demo posture: two-tier demo hosting — operator-run OfficialServers on the home mini PC as the default online path for non-technical players, plus HostAndPlay kept for technical players who port-forward. ADR text is verbatim from the EXE release plan (Task 3.1) and consistent with the OfficialServer/HostAndPlay glossary terms already committed in CONTEXT.md.

Closes #62.

## Changes
- docs: add ADR-0009 demo hosting model (issue #62)

## Verification
- `dotnet test tests/Shared.Tests/` — 451 passed, 0 failed
- ADR file diffed byte-identical against the plan's Task 3.1 Step 1 block
- Docs-only change: no builds beyond the test suite applicable, no Unity-facing paths touched

## Diffstat
```text
 docs/adr/0009-demo-hosting-model.md | 32 ++++++++++++++++++++++++++++++++
 1 file changed, 32 insertions(+)
```