### PR TITLE
build: add release pipeline, player identity, and StreamingAssets ignore (issue #63)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -208,3 +208,6 @@ client/Unity/Assets/BOXOPHOBIC/
 
 # Handoff playtest checklist (worktree agents → PR body, never committed)
 TESTING-UNITY.md
+
+# Staged by scripts/build-release.sh (bundled server + arenas for player build)
+/client/Unity/Assets/StreamingAssets/

--- a/client/Unity/ProjectSettings/ProjectSettings.asset
+++ b/client/Unity/ProjectSettings/ProjectSettings.asset
@@ -12,8 +12,8 @@ PlayerSettings:
   targetDevice: 2
   useOnDemandResources: 0
   accelerometerFrequency: 60
-  companyName: DefaultCompany
-  productName: Unity
+  companyName: SlopArena
+  productName: SlopArena
   defaultCursor: {fileID: 0}
   cursorHotspot: {x: 0, y: 0}
   m_SplashScreenBackgroundColor: {r: 0.12156863, g: 0.12156863, b: 0.1254902, a: 1}
@@ -142,7 +142,7 @@ PlayerSettings:
   loadStoreDebugModeEnabled: 0
   visionOSBundleVersion: 1.0
   tvOSBundleVersion: 1.0
-  bundleVersion: 1.0
+  bundleVersion: 0.1.0
   preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Build a Windows demo release: SlopArena-<version>.zip in build/release/.
+# Usage: scripts/build-release.sh <version>   e.g. scripts/build-release.sh 0.2.0-demo.1
+set -euo pipefail
+
+VERSION="${1:?usage: build-release.sh <version>}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+UNITY="${UNITY_EDITOR:-/home/binoui/Unity/Hub/Editor/6000.0.78f1/Editor/Unity}"
+PROJ="$ROOT/client/Unity"
+REL="$ROOT/build/release/SlopArena-$VERSION"
+SA="$PROJ/Assets/StreamingAssets"
+
+echo "== Shared build =="
+dotnet build "$ROOT/src/Shared/" --nologo
+
+echo "== Tests =="
+dotnet test "$ROOT/tests/Shared.Tests/" --nologo
+
+echo "== Self-contained Windows server (embedded host-and-play) =="
+dotnet publish "$ROOT/src/Server/SlopArena.Server.csproj" -c Release -r win-x64 --self-contained true -o "$SA/Server"
+
+echo "== linux-x64 server for the mini PC =="
+dotnet publish "$ROOT/src/Server/SlopArena.Server.csproj" -c Release -r linux-x64 --self-contained false -o "$ROOT/build/minipc"
+
+echo "== Stage arenas =="
+mkdir -p "$SA/arenas"
+cp "$ROOT"/data/arenas/*.arena "$SA/arenas/"
+
+echo "== Version stamp =="
+# The stamp is reverted below with a hard checkout of the committed file; refuse
+# to run if ProjectSettings.asset has uncommitted edits (they would be lost).
+git -C "$ROOT" diff --quiet -- client/Unity/ProjectSettings/ProjectSettings.asset \
+  || { echo "error: ProjectSettings.asset has uncommitted changes -- commit or stash them first (the version stamp is reverted via git checkout)" >&2; exit 1; }
+sed -i "s/^  bundleVersion: .*/  bundleVersion: $VERSION/" "$PROJ/ProjectSettings/ProjectSettings.asset"
+
+echo "== Unity Windows player build =="
+mkdir -p "$REL"
+"$UNITY" -batchmode -quit -projectPath "$PROJ" -buildWindows64Player "$REL/SlopArena.exe"
+
+echo "== Restore committed bundleVersion =="
+git -C "$ROOT" checkout -- client/Unity/ProjectSettings/ProjectSettings.asset
+
+echo "== Unstage build-only artifacts =="
+rm -rf "$SA/Server" "$SA/arenas"
+
+echo "== Ship docs + zip =="
+cp "$ROOT/docs/release/PLAY_GUIDE.md" "$REL/README.txt"
+cp "$ROOT/docs/release/HOST_GUIDE.md" "$REL/HOSTING.txt"
+(cd "$REL/.." && zip -r "SlopArena-$VERSION.zip" "SlopArena-$VERSION")
+echo "DONE: build/release/SlopArena-$VERSION.zip"


### PR DESCRIPTION
Implements issue #63 (EXE release epic, plan Tasks 5.1-5.3): player identity in the Unity project, gitignore for staged build artifacts, and the `scripts/build-release.sh` release pipeline that produces `build/release/SlopArena-<version>.zip`.
Closes #63.

## Changes
- Set `productName`/`companyName` to `SlopArena` and `bundleVersion` to `0.1.0` in `client/Unity/ProjectSettings/ProjectSettings.asset` (window title no longer reads "Unity").
- `.gitignore`: ignore `/client/Unity/Assets/StreamingAssets/` (bundled server + arenas staged by the release script).
- `scripts/build-release.sh <version>` (executable): Shared build -> 451-test suite -> self-contained win-x64 server publish into `StreamingAssets/Server` -> linux-x64 publish to `build/minipc` -> stage `data/arenas/*.arena` -> sed `bundleVersion` -> Unity `-buildWindows64Player` -> restore committed ProjectSettings (guarded against uncommitted edits) -> unstage -> zip with README.txt + HOSTING.txt.
- Two correctness fixes vs the plan's verbatim script: sed anchors the two-space-indented `bundleVersion` YAML key (plan's `^bundleVersion:` would silently no-op); a pre-stamp guard refuses to run when `ProjectSettings.asset` is dirty (the restore step is a hard checkout that would discard uncommitted edits).

## Verification
- `dotnet test tests/Shared.Tests/`: 451 passed, 0 failed.
- Full pipeline dry-run with `UNITY_EDITOR=/bin/true` and fake version `0.0.0-dryrun`, twice (pre- and post-commit): Shared build, tests, both publishes, arenas staging, version stamp, restore, unstage, and zip all green; bundleVersion restored to committed `0.1.0`; tree clean after cleanup.
- Dry-run caught and fixed the uncommitted-ProjectSettings wipe (now guarded).
- No Shared files changed (script + settings + gitignore only).

**Test in Unity:**
# Test in Unity (issue #63 — build-release.sh + player identity)

Worktree slice. All headless verification passed; these need the Unity editor
(main repo only).

## Player identity (Task 5.1)
- Open the project in the Unity editor (regenerates dependent metadata).
- Window title must read "SlopArena" (was "Unity").
- Player Settings > Product Name "SlopArena", Company "SlopArena",
  Version "0.1.0".

## Release pipeline (Task 5.3) — run in the MAIN checkout
`scripts/build-release.sh 0.2.0-demo.1`
- Player build lands in `build/release/SlopArena-0.2.0-demo.1/SlopArena.exe`
  and the zip contains README.txt + HOSTING.txt.
- Bundle version in the built player = `0.2.0-demo.1`.
- Known ordering dependency: the script's final `cp` fails until
  `docs/release/PLAY_GUIDE.md` + `HOST_GUIDE.md` exist (plan Tasks 6.1/6.2).
- Host flow: hosting a match spawns the bundled
  `StreamingAssets/Server/SlopArena.Server.exe`, not `dotnet` (Task 3.3).
- Clean machine rehearsal (Task 7.2): no `localhost:5000` anywhere in the zip.

## Diffstat
```text
 .gitignore                                         |  3 ++
 client/Unity/ProjectSettings/ProjectSettings.asset |  6 +--
 scripts/build-release.sh                           | 50 ++++++++++++++++++++++
 3 files changed, 56 insertions(+), 3 deletions(-)
```
