### PR TITLE
feat(release): self-hosted deploy pipeline, host-ip field, docs, ops skills (issue #64)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: ci
+on:
+  push:
+    branches: [main]
+  pull_request:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - run: dotnet build src/Shared/ --nologo
+      - run: dotnet test tests/Shared.Tests/ --nologo
+      - run: dotnet build src/Server/ --nologo

--- a/.omp/skills/sloparena-build-export/SKILL.md
+++ b/.omp/skills/sloparena-build-export/SKILL.md
@@ -1,16 +1,29 @@
 ---
 name: sloparena-build-export
-description: Build, export, and release SlopArena — Shared build, server publish, Unity player build, and CI/CD status.
+description: Build, export, and release SlopArena — Shared build, tests, server publish (mini PC deploy), Unity player build, GitHub release, CI status. The three flows: build-release.sh (exe zip), deploy-server.sh (alfred dedicated server), master deploy (manual).
 ---
 
-# SlopArena Build & Export (Unity)
+# SlopArena Build, Export & Release
 
 ## When to use
 
 - Building or testing the Shared library or the .NET server
-- Publishing the game server for release
+- Publishing the game server for release (zip bundled server, or alfred dedicated server)
 - Building the Unity player (Linux/Windows)
-- Checking what CI does (or doesn't) automate
+- Cutting a GitHub release, or checking CI status
+- Answering "how do I ship main to players / to alfred"
+
+## The three flows (mental model)
+
+```
+A. New exe zip (friends)      → scripts/build-release.sh <version>
+B. Dedicated server on alfred → scripts/deploy-server.sh [host]
+C. Master server on alfred    → manual (master repo, see below)
+
+Client-only change  → A only
+src/Server|Shared   → A (bundled server) + B (dedicated server)
+Master repo change  → C only
+```
 
 ## Build & Test Core
 
@@ -19,44 +32,129 @@ description: Build, export, and release SlopArena — Shared build, server publi
 # into client/Unity/Assets/Plugins/SlopArena.Shared/ automatically.
 dotnet build src/Shared/ --nologo
 
-# Test suite (33 suites, ~390 tests)
+# Test suite (~451 tests)
 dotnet test tests/Shared.Tests/ --nologo
 ```
 
 Always build `src/Shared/` after any Shared change so the Unity plugin DLL stays in sync.
 
-## Server
+## Flow A — Release zip (Windows exe)
 
 ```bash
-# Dev run
-dotnet run --project src/Server/
-
-# Release publish
-dotnet publish src/Server/SlopArena.Server.csproj -c Release -o build/server
+# Preconditions: Unity Editor CLOSED (locks the project; a second instance
+# aborts with "Another Unity instance is running with this project open").
+# ProjectSettings.asset must be CLEAN (the script stamps bundleVersion then
+# reverts via git checkout, and refuses to run otherwise).
+./scripts/build-release.sh 0.2.0-demo.1
+# → build/release/SlopArena-<version>.zip (90MB), contains:
+#   SlopArena.exe + SlopArena_Data/ + StreamingAssets/Server/ (self-contained
+#   win-x64 game server, embedded host-and-play) + arenas + README/HOSTING.txt
 ```
 
-Output: `build/server/SlopArena.Server.dll` plus the shared DLLs it depends on. Project layout: `src/Server/{Program.cs, MatchInstance.cs, MatchControlServer.cs, MultiMatchOrchestrator.cs, GameServerRegistration.cs, ServerSkeleton.cs, SlopArena.Server.csproj}`.
+What the script does: build Shared → run tests → publish win-x64 self-contained
+server to `StreamingAssets/Server` → publish linux-x64 to `build/minipc` →
+stage arenas → stamp `bundleVersion` → Unity `-buildWindows64Player` → restore
+stamp → unstage build artifacts → zip with docs.
 
-## Unity Player Build
+**Leak guard (Task 7.2):** the script deletes `server.json` from both publish
+outputs — the csproj copies dev defaults (`localhost:5000`) which must never
+ship or clobber the live config. Verify after building:
 
-No in-repo Editor build script exists (no `BuildPipeline`/`executeMethod` under `Assets/Scripts`, `scripts/`, or `.github/`) — the standalone player args need none:
+```bash
+unzip -l build/release/*.zip | grep -c server.json        # expect 0
+unzip -q build/release/*.zip -d /tmp/scan && grep -rl "localhost:5000" /tmp/scan
+```
+
+Publish (public — needs explicit operator go):
+
+```bash
+gh release create v0.2.0-demo.1 build/release/SlopArena-0.2.0-demo.1.zip \
+  --title "SlopArena 0.2.0-demo.1" \
+  --notes "$(sed 's/<version>/0.2.0-demo.1/' docs/release/RELEASE_NOTES.template.md)"
+```
+
+## Flow B — Dedicated server on alfred (one command)
+
+```bash
+scripts/deploy-server.sh            # ssh alias "alfred" by default
+# publish linux-x64 → rsync binaries + arenas → restart server-1 → verify
+# registration + heartbeat freshness in postgres
+```
+
+Why the restart: the game server registers with the master **once at startup
+and never retries** — after any deploy (or master redeploy) a restart is
+required or it stays unregistered.
+
+Safety: never uses rsync `--delete*` (would wipe live config); publish output
+has `server.json` deleted so `/srv/sloparena/server/server.json` (the live
+config: `masterServerUrl`, `publicIp`, `maxConcurrentMatches: 4`) is never
+clobbered.
+
+## Flow C — Master server deploy (manual, master repo)
+
+```bash
+cd ~/Documents/projects/SlopArena-MasterServer
+# /tmp, NOT build/: publishing inside the repo pulls MasterServer.Tests
+# bin/obj into the output and grows recursively on re-publish → MSB3030.
+dotnet publish -c Release -o /tmp/minipc-master
+rsync -avz --exclude 'appsettings.Production.json' /tmp/minipc-master/ \
+  alfred:/srv/sloparena/master/publish/
+# NEVER rsync --delete / --delete-excluded here (config lives inside publish/)
+ssh alfred 'cd /root/homelab/sloparena && docker compose restart master server-1'
+# server-1 too: it must re-register (registers once, never retries)
+```
+
+## Unity Player Build (manual, not scripted)
 
 ```bash
 "$UNITY_EDITOR" -batchmode -quit -projectPath client/Unity \
   -buildLinux64Player build/linux/SlopArena.x86_64
-# or
-"$UNITY_EDITOR" -batchmode -quit -projectPath client/Unity \
-  -buildWindows64Player build/windows/SlopArena.exe
+# or -buildWindows64Player build/windows/SlopArena.exe
 ```
 
-`$UNITY_EDITOR` = the Unity 6000.0.78f1 install path. On a headless/license-gated machine the first build may need manual activation — the command itself is standard.
+`$UNITY_EDITOR` = `/home/binoui/Unity/Hub/Editor/6000.0.78f1/Editor/Unity`.
+**Linux editors need the Windows Build Support (Mono) module** to build
+Windows players — install via
+`/opt/unityhub/unityhub-bin -- --headless install-modules --version 6000.0.78f1 -m windows-mono`.
+Player builds fail on editor-only API in runtime scripts
+(`UnityEditor.*` — grep `Assets/Scripts/Runtime/`); `dotnet build` does NOT
+compile Unity scripts, so validate with a Unity batchmode import
+(`-batchmode -quit -nographics`) before claiming compile-clean.
 
 ## CI Status (as of 2026-08)
 
-Only `.github/workflows/{nuget-publish, discord-push}.yml` exist. **There is no Unity build workflow.** If one is added, `game-ci/unity-builder` is the standard route [external knowledge — not yet verified in this repo].
+- `.github/workflows/ci.yml` (this repo): push to main + PR → build Shared, run
+  Shared.Tests (~451), build Server.
+- `.github/workflows/{nuget-publish, discord-push}.yml`: existing.
+- Master repo `.github/workflows/build.yml`: build + test on push/PR to main;
+  on `v*` tag push, publishes `dotnet publish -c Release` output as an Actions
+  artifact.
+- **No Unity build in CI** (exe is built locally by Flow A). Deploy is manual
+  (home infra is not CI-reliable).
 
-## Gotchas
+## Operations (alfred)
+
+```bash
+ssh alfred 'cd /root/homelab/sloparena && docker compose ps'   # 3 containers Up
+curl -s https://sloparena.barakaslurp.fr/health                # {"status":"ok",...}
+# registration + heartbeat freshness (age should be seconds):
+ssh alfred 'docker exec sloparena-postgres psql -U sloparena -d sloparena -c \
+  "SELECT \"Name\", \"IpAddress\", \"Port\", NOW() - \"LastHeartbeat\" AS age FROM \"GameServers\";"'
+# game ports MUST be open in UFW too (Bbox forward alone is not enough):
+ssh alfred 'sudo ufw status | grep 7777'   # 7777/tcp + 7777:7791/udp ALLOW
+```
+
+Backups: `/etc/cron.d/sloparena-backup` — weekly pg_dump Mondays 04:30, keep 90
+days. See `docs/systems/production-hosting.md` (runbook) and
+`docs/systems/troubleshooting.md` (failure playbook) for depth.
+
+## Gotchas (all hit for real 2026-08-02)
 
 - **Unity `.meta` files must be committed** — Unity regenerates GUIDs otherwise, breaking prefab/script references.
 - **`Library/` is gitignored** — never commit it; it's a local cache.
 - **Shared DLL drift** — if the Unity client shows stale behavior, rebuild `src/Shared/` (the plugin copy is post-build).
+- **UFW drops game ports** — "Join hangs" = client log shows the join line then silence; fix is `ufw allow 7777/tcp + 7777:7791/udp` on alfred.
+- **rsync `--delete-excluded` deletes excluded files** — it wiped `appsettings.Production.json` once. Never use `--delete*` on the master or server deploys.
+- **Version-stamp drift after failed build** — `build-release.sh` aborts leave `bundleVersion` stamped + `StreamingAssets/` staged + PipelineAsset/URP re-serialized. Restore: `git checkout -- client/Unity/ProjectSettings/ProjectSettings.asset client/Unity/Assets/Settings client/Unity/Assets/UniversalRenderPipelineGlobalSettings.asset`, `rm -rf client/Unity/Assets/StreamingAssets/... client/Unity/Assets/packages-merged-link*`.
+- **Editor lock** — a running Unity Editor on the project aborts batch builds; close it first.
+- **`data/arenas/` stubs** — 4 of 7 files (cross/pit/sanctum/split) are <500B placeholders that fail `[ArenaRegistry] Failed to load`; expected, not a deploy bug. Playable: training, colosseum, Island_arena.

--- a/.omp/skills/sloparena-ops/SKILL.md
+++ b/.omp/skills/sloparena-ops/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: sloparena-ops
+description: Operate and debug the SlopArena self-hosted backend on the mini PC (alfred) — status checks, log locations, connectivity tests, the diagnostic ladder, and every known failure mode with fixes. Use when the game can't connect, a service is down, registration is stale, or anyone asks "is the server up?".
+---
+
+# SlopArena Ops (alfred mini-PC backend)
+
+## When to use
+
+- Player reports "can't join / hangs / can't see servers"
+- Checking whether the master, game server, or tunnel is up
+- After any deploy/restart, verifying registration + heartbeat
+- Anything in `docs/systems/troubleshooting.md` (this skill is the compressed playbook)
+
+## Topology
+
+```
+Bbox router ──forwards TCP 7777, UDP 7777-7780──▶ alfred (<alfred-lan-ip>, ssh alias "alfred")
+                                                   ├─ sloparena-postgres (127.0.0.1:5432, host-only)
+                                                   ├─ sloparena-master   (127.0.0.1:5000, host net)
+                                                   ├─ sloparena-server-1 (TCP+UDP 7777, host net)
+                                                   └─ cloudflared (tunnel → sloparena.barakaslurp.fr → localhost:5000)
+```
+
+Compose stack: `/root/homelab/sloparena/docker-compose.yml` (on the box, NOT
+in the game repo). All commands run as `ssh alfred '...'`.
+
+## The diagnostic ladder (fastest → deepest)
+
+```bash
+# 1. Tunnel / master API reachable from anywhere
+curl -s https://sloparena.barakaslurp.fr/health          # {"status":"ok","version":"0.1.0"}
+
+# 2. All containers Up
+ssh alfred 'cd /root/homelab/sloparena && docker compose ps'
+
+# 3. Game server registered AND heartbeating (age = seconds = alive)
+ssh alfred 'docker exec sloparena-postgres psql -U sloparena -d sloparena -c \
+  "SELECT \"Name\", \"IpAddress\", \"Port\", \"IsOfficial\", NOW() - \"LastHeartbeat\" AS age FROM \"GameServers\";"'
+# age > 30s → heartbeat dead → server crashed, unregistered, or unreachable
+
+# 4. TCP reachability (0 = OK, 124 = dropped by firewall/forward)
+timeout 8 bash -c 'echo > /dev/tcp/<alfred-lan-ip>/7777' && echo "LAN OK"
+timeout 8 bash -c 'echo > /dev/tcp/<public-ip>/7777' && echo "public OK"   # hairpin via Bbox
+
+# 5. UDP round-trip (gameplay traffic; TCP 7777 is only match-control)
+ssh alfred 'python3 -c "import socket;s=socket.socket(socket.AF_INET,socket.SOCK_DGRAM);s.bind((\"0.0.0.0\",7777));s.settimeout(10);print(s.recvfrom(64))"' &
+sleep 1.5 && echo -n probe | timeout 8 bash -c 'cat > /dev/udp/<alfred-lan-ip>/7777' && wait
+
+# 6. Client log (the player's actual experience)
+# Windows exe:        %USERPROFILE%\AppData\LocalLow\SlopArena\SlopArena\Player.log
+# Steam Proton:       <steamapps>/compatdata/<appid>/pfx/drive_c/users/steamuser/AppData/LocalLow/SlopArena/SlopArena/Player.log
+# Unity Editor (lin): ~/.config/unity3d/Editor.log
+# look for: [ServerBrowser], [Registration], [LobbyClient], Exception, Error
+```
+
+## Failure catalog (each hit for real 2026-08-02)
+
+### Join hangs — UFW dropping game ports
+Symptom: client log ends at `[ServerBrowser] Joining server: ...` then silence;
+LAN TCP probe times out; loopback works.
+Fix: `ssh alfred 'sudo ufw allow 7777/tcp && sudo ufw allow 7777:7791/udp'` —
+alfred's UFW has `INPUT policy DROP`; the Bbox forward alone is NOT enough.
+Verify: `sudo ufw status | grep 7777`, re-run probes. Rule must match
+`server.json` port + `maxConcurrentMatches` (4 matches = 7777-7780; 15 = 7777-7791).
+
+### Registration fails `400 Invalid IP address: <domain>`
+Master's validator rejected DNS hostnames (fixed: `Uri.CheckHostName is IPv4 or
+Dns`). If it recurs, the deployed master is stale → redeploy (flow C in
+sloparena-build-export). Then `docker compose restart server-1` — the game
+server registers ONCE at startup and NEVER retries.
+
+### Heartbeat stale / server not in GameServers
+Server crashed, or was restarted before registering. Check
+`docker compose logs server-1` for the crash; restart: `docker compose restart
+server-1`. Verify age returns to seconds.
+
+### rsync wiped the master config
+`--delete` / `--delete-excluded` on the master publish dir deletes
+`appsettings.Production.json` (it lives inside `publish/`). Never use
+`--delete*` on that rsync. If gone: rebuild with the DB password from
+`/root/homelab/sloparena/.env` + fresh JWT (`openssl rand -base64 48`), chmod
+600. Old JWTs die — clients re-auth.
+
+### False 429s in master tests
+`RateLimitTracker` is a DI singleton now (per app instance); if it regresses to
+static, parallel test factories share one bucket → 429s. Check Program.cs
+registers it and the middleware uses `context.RequestServices`.
+
+### Unity player build fails
+- `build target was unsupported` → Windows Build Support module missing on
+  Linux: `/opt/unityhub/unityhub-bin -- --headless install-modules --version
+  6000.0.78f1 -m windows-mono`
+- `error CS0234: UnityEditor...` in a runtime script → editor-only API leaked
+  into player build; guard with `#if UNITY_EDITOR`.
+- `dotnet build` does NOT compile Unity scripts — validate with Unity
+  batchmode import (`-batchmode -quit -nographics`) or the player build.
+
+### Version stamp / PipelineAsset drift after a failed release build
+`build-release.sh` stamps `bundleVersion` pre-build, reverts post-build; a
+failure leaves the tree dirty. Restore:
+```bash
+git checkout -- client/Unity/ProjectSettings/ProjectSettings.asset \
+  client/Unity/Assets/Settings client/Unity/Assets/UniversalRenderPipelineGlobalSettings.asset
+rm -rf client/Unity/Assets/StreamingAssets/Server client/Unity/Assets/StreamingAssets/arenas \
+  client/Unity/Assets/StreamingAssets.meta client/Unity/Assets/packages-merged-link*
+```
+
+### Dev machine DNS broken (known)
+Resolver is misconfigured (systemd-resolved/NetworkManager). Use
+`dig @1.1.1.1` and `curl --resolve HOST:443:188.114.97.2` when verifying the
+tunnel. Not a server fault.
+
+## Arena note
+`data/arenas/` has 7 files; 4 are <500B stubs (cross/pit/sanctum/split) that
+fail `[ArenaRegistry] Failed to load` — expected. Playable: training,
+colosseum, Island_arena.
+
+## Deploying (cross-ref)
+- Dedicated server: `scripts/deploy-server.sh` (publish → rsync → restart → verify)
+- Exe zip: `scripts/build-release.sh <version>`
+- Master: manual, master repo (see sloparena-build-export skill, flow C)
+- Depth: `docs/systems/production-hosting.md`, `docs/systems/troubleshooting.md`

--- a/client/Unity/Assets/Scripts/Runtime/Entities/PlayerRenderer.cs
+++ b/client/Unity/Assets/Scripts/Runtime/Entities/PlayerRenderer.cs
@@ -683,7 +683,11 @@ namespace SlopArena.Client.Entities
             // ── Entity name label ──
             Gizmos.color = Color.white;
             Vector3 labelPos = transform.position + Vector3.up * 2.5f;
+#if UNITY_EDITOR
+            // UnityEditor.Handles is editor-only; the guard keeps the player
+            // build compiling (release blocker found 2026-08-02).
             UnityEditor.Handles.Label(labelPos, $"{_entityName} [{_lastState.State}]");
+#endif
 
             // ── State color indicator sphere (above label) ──
             Gizmos.color = stateColor;

--- a/client/Unity/Assets/Scripts/Runtime/Network/ServerHost.cs
+++ b/client/Unity/Assets/Scripts/Runtime/Network/ServerHost.cs
@@ -97,7 +97,9 @@ namespace SlopArena.Client.Network
         /// main thread. Safe to call once per host session.
         /// </summary>
         /// <param name="serverName">Browser display name for this server.</param>
-        public void StartHosting(string serverName)
+        /// <param name="publicIp">Optional public IP/domain advertised to the master server
+        /// (host behind NAT, see ADR-0009). Null/empty → server auto-detects its LAN IP.</param>
+        public void StartHosting(string serverName, string? publicIp = null)
         {
             if (IsRunning)
             {
@@ -134,7 +136,11 @@ namespace SlopArena.Client.Network
                 MaxConcurrentMatches = 1,
                 MasterServerUrl = _masterServerUrl,
                 IsOfficial = false,
-                ArenaDataDir = arenaDir
+                ArenaDataDir = arenaDir,
+                // Host-entered public IP/domain (ADR-0009 host-and-play tier);
+                // null → server auto-detects LAN IP (correct only for directly
+                // reachable hosts).
+                PublicIp = string.IsNullOrWhiteSpace(publicIp) ? null : publicIp
             };
 
             _configPath = Path.Combine(Path.GetTempPath(), $"sloparena-host-{_assignedPort}.json");

--- a/client/Unity/Assets/Scripts/Runtime/UI/MainMenuController.cs
+++ b/client/Unity/Assets/Scripts/Runtime/UI/MainMenuController.cs
@@ -14,6 +14,7 @@ namespace SlopArena.Client.UI
         [SerializeField] private string _masterServerUrl = "https://sloparena.barakaslurp.fr";
 
         private Label _lblHostStatus;
+        private TextField _hostIpField;   // host-and-play public IP/domain (ADR-0009)
         private bool _hosting;   // guards against double-click during the async start
 
         private void OnEnable()
@@ -27,6 +28,8 @@ namespace SlopArena.Client.UI
             var btnHost          = root.Q<Button>("btn-host");
             var btnJoin          = root.Q<Button>("btn-join");
             var ipField          = root.Q<TextField>("ip-field");
+            var hostIpField      = root.Q<TextField>("host-ip-field");
+            _hostIpField        = hostIpField;
             var btnServerBrowser = root.Q<Button>("btn-serverbrowser");
             _lblHostStatus       = root.Q<Label>("lbl-host-status");
 
@@ -126,7 +129,8 @@ namespace SlopArena.Client.UI
             host.Crashed            += onCrashed;
 
             // Spawn the server subprocess now that listeners are wired.
-            host.StartHosting(GenerateServerName());
+            string hostIp = _hostIpField.value.Trim();
+            host.StartHosting(GenerateServerName(), string.IsNullOrEmpty(hostIp) ? null : hostIp);
 
             // Wait for registration, crash, or a 15s timeout. Pump() runs in
             // ServerHost.Update, so events fire on the main thread.

--- a/client/Unity/Assets/UI/MainMenu.uxml
+++ b/client/Unity/Assets/UI/MainMenu.uxml
@@ -8,6 +8,9 @@
             <ui:Button name="btn-multiplayer" text="MULTIPLAYER ›" class="menu-item" />
             <ui:VisualElement name="submenu" class="submenu" style="display: none;">
                 <ui:Button name="btn-host" text="HOST GAME" class="menu-item menu-item--sub" />
+                <ui:VisualElement name="host-row" class="join-row">
+                    <ui:TextField name="host-ip-field" value="" placeholdertext="Public IP or domain (empty = auto)" class="ip-input" />
+                </ui:VisualElement>
                 <ui:Button name="btn-serverbrowser" text="SERVER BROWSER" class="menu-item menu-item--sub" />
                 <ui:VisualElement name="join-row" class="join-row">
                     <ui:Button name="btn-join" text="JOIN GAME" class="menu-item menu-item--sub" />

--- a/docs/plans/2026-08-02-exe-release-plan.md
+++ b/docs/plans/2026-08-02-exe-release-plan.md
@@ -4,16 +4,16 @@
 
 **Goal:** Ship a downloadable Windows `.exe` that non-technical friends can run to play training mode solo or join online games, backed by a self-hosted master server + dedicated game servers on the home mini PC.
 
-**Architecture:** Three layers — the Windows Unity player (built locally, self-contained game server binary bundled for host-and-play), the master server + PostgreSQL (ASP.NET Core 8 on the Debian 12 mini PC, TLS-terminated by Caddy at `sloparena.barakaslurp.fr`), and 1-2 dedicated game server instances (`src/Server`, systemd-managed) that players join directly over UDP. Host-and-play stays supported for technical players who port-forward; non-technical players only join the operator's OfficialServers.
+**Architecture:** Three layers — the Windows Unity player (built locally, self-contained game server binary bundled for host-and-play), the master server + PostgreSQL (ASP.NET Core 8 on the Debian 12 mini PC, TLS-terminated by Cloudflare Tunnel at `sloparena.barakaslurp.fr`), and 1-2 dedicated game server instances (`src/Server`, docker-compose-managed) that players join directly over UDP. Host-and-play stays supported for technical players who port-forward; non-technical players only join the operator's OfficialServers. All services run as docker containers (host network) — the mini PC hosts no .NET install; binaries are published on the dev machine and rsync'd.
 
-**Tech Stack:** Unity 6000.0.78f1 (Windows player build), .NET 8 (game server, master server), PostgreSQL 15 (Debian bookworm), Caddy (auto-HTTPS reverse proxy), systemd (service management), GitHub Actions (CI test gate), GitHub Releases (distribution).
+**Tech Stack:** Unity 6000.0.78f1 (Windows player build), .NET 8 (game server, master server — dev machines only, containers use `mcr.microsoft.com/dotnet/aspnet:8.0`), PostgreSQL 15 (container), Cloudflare Tunnel (TLS + ingress), docker compose (service management), GitHub Actions (CI test gate), GitHub Releases (distribution).
 
 ## Global Constraints
 
 - **Audience:** friends-first demo (not public release). Non-technical users must only ever click: download → unzip → run → Training or Join. No port forwarding, no config, no .NET install.
 - **Hosting model (grill Q1):** hybrid — dedicated servers are the default online path; host-and-play is supported for technical players. "Host" is NOT a player verb in user docs.
-- **Mini PC (grill Q2):** Debian 12 bookworm, kernel 6.12.74+deb12, 16GB DDR4. **Runs the user's home automation** — all deployment steps must be additive and non-destructive; services get `Restart=on-failure` and resource caps; never touch existing postgres configs/data, only add a role + database.
-- **Domain (grill Q3):** `barakaslurp.fr` owned; release builds point at `https://sloparena.barakaslurp.fr` (subdomain to be created). Plain HTTP is NOT acceptable for the master server — Caddy terminates TLS.
+- **Mini PC (grill Q2):** Debian 12 bookworm, kernel 6.12.74+deb12, 16GB DDR4. **Runs the user's home automation** — all deployment steps must be additive and non-destructive; containers get `restart: unless-stopped` and resource caps (`mem_limit: 512m`, `cpus: 0.5`); never touch existing postgres configs/data — the app database is its own `postgres:15` container with a named volume.
+- **Domain (grill Q3):** `barakaslurp.fr` owned; release builds point at `https://sloparena.barakaslurp.fr` (subdomain to be created). Plain HTTP is NOT acceptable for the master server — Cloudflare Tunnel terminates TLS at the edge (no Caddy, no inbound 443 needed).
 - **Roster (grill Q5):** all characters legal in online matches. `custom_rules` is omitted from official `server.json` (note: `AllowedCharacters` is currently decorative server-side — no enforcement exists; do not build enforcement in this plan).
 - **Signing (grill Q6):** none — friends-only. SmartScreen click-through documented in the player guide.
 - **Distribution (grill Q7):** GitHub Releases zip. itch.io is post-demo.
@@ -33,7 +33,7 @@
 
 **Files:** none (router/DNS).
 
-- [ ] **Step 1: Compare public IP vs router WAN IP**
+- [x] **Step 1: Compare public IP vs router WAN IP**
 
 ```bash
 curl -4 ifconfig.me
@@ -41,31 +41,36 @@ curl -4 ifconfig.me
 
 Log into the router admin panel and read the WAN IP. If they differ → **CGNAT. STOP.** Fall back to a VPS (Hetzner CX22, ~4€/mo) and redeploy Phases 1-4 there — document the alternative in `docs/systems/production-hosting.md` as a note.
 
-- [ ] **Step 2: Port-forward the demo range on the router**
+- [x] **Step 2: Port-forward the game range on the router**
 
-Forward to the mini PC's LAN IP:
-- TCP `443` and `80` (Caddy TLS + redirect)
+Forward to the mini PC's LAN IP (only the game-server range — TLS/HTTPS goes through Cloudflare Tunnel, which is outbound-only):
 - TCP `7777` and UDP `7777-7791` (game server instance 1: MatchControlServer TCP + 15 match ports)
+
+Note: the Bbox router only allows forwards in 1024-8191, so the old TCP 80/443 plan (Caddy) would not work here anyway — Cloudflare Tunnel sidesteps it entirely.
 
 Verify from OUTSIDE the LAN (phone on 4G, not Wi-Fi):
 
 ```bash
-# TCP 443 (after Phase 2, expect JSON health response)
-curl -sk https://<public-ip>/health
 # TCP 7777 (expect connection refusal or hang, NOT timeout — timeout = blocked)
 nc -vz <public-ip> 7777
 ```
 
-- [ ] **Step 3: Create DNS record**
+- [x] **Step 3: Create the tunnel hostname (replaces DNS record)**
 
-A record `sloparena.barakaslurp.fr` → public IP, TTL 300 (fast rollback if the IP changes).
+No A record at the registrar — Cloudflare Tunnel provisions DNS automatically. In the Cloudflare dashboard (Zero Trust → Networks → Tunnels → the existing alfred tunnel → Public Hostname → Add):
 
-```bash
-dig +short sloparena.barakaslurp.fr
-# expected: <public-ip>
+```
+Subdomain: sloparena
+Domain:    barakaslurp.fr
+Service:   HTTP → localhost:5000
 ```
 
-Note in `docs/systems/production-hosting.md`: home IPs change; on change, update the A record (manual). DDNS is explicitly out of scope for the demo.
+Save; Cloudflare creates the CNAME. Verify:
+
+```bash
+curl -s https://sloparena.barakaslurp.fr/health
+# {"status":"ok","version":"0.1.0"}  ← after Phase 2
+```
 
 - [ ] **Step 4: Commit**
 
@@ -75,79 +80,74 @@ No repo change; record results in `docs/systems/production-hosting.md` (created 
 
 ## Phase 1 — Mini PC base services
 
-### Task 1.1: Install .NET 8 (SDK + runtime)
+### Task 1.1: Postgres 15 container + compose stack dir
 
-**Files:** none (apt).
+**Files:** alfred: `/root/homelab/sloparena/{docker-compose.yml,.env}` (compose file versioned on the box — it is deliberately NOT in this repo; game repo stays game-only. Template is maintained directly on alfred; `.env` copied from `.env.example` with a generated password).
 
-- [ ] **Step 1: Add the Microsoft apt repo (bookworm)**
+No .NET on the host; no apt postgres — the box's home-automation packages stay untouched. Postgres runs as an official `postgres:15` container with a named volume; role + database come from env (`POSTGRES_USER/PASSWORD/DB`). The master and game-server services are in the same compose file (created now, started when their binaries land in Phases 2/4).
+
+- [x] **Step 1: Create the stack dir + secrets**
 
 ```bash
-sudo apt install -y apt-transport-https ca-certificates curl gnupg
-curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | sudo gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg
-echo "deb [signed-by=/usr/share/keyrings/microsoft-prod.gpg arch=amd64] https://packages.microsoft.com/repos/dotnet/ bookworm main" | sudo tee /etc/apt/sources.list.d/microsoft-prod.list
-sudo apt update
-sudo apt install -y aspnetcore-runtime-8.0 dotnet-sdk-8.0
+sudo mkdir -p /root/homelab/sloparena
+# scp from dev machine: docker-compose.yml + .env.example (from alfred's own copy — see note above)
+# .env: SLOPARENA_DB_PASSWORD="$(openssl rand -base64 18)"   (chmod 600)
 ```
 
-- [ ] **Step 2: Verify**
+- [x] **Step 2: Start postgres only**
 
 ```bash
-dotnet --version   # expected: 8.0.x
+cd /root/homelab/sloparena
+docker compose up -d postgres
 ```
 
-### Task 1.2: Install PostgreSQL 15 + create the app database
-
-**Files:** none (apt/psql). Must be additive — the machine may already run postgres for home automation.
-
-- [ ] **Step 1: Install and enable**
+- [x] **Step 3: Verify**
 
 ```bash
-sudo apt install -y postgresql
-sudo systemctl enable --now postgresql
+# verified: sloparena-postgres Up; SELECT 1 → 1 (host-reachable via SSH tunnel on 15432)
 ```
 
-- [ ] **Step 2: Create role + database (idempotent, non-destructive)**
-
 ```bash
-sudo -u postgres psql -c "DO \$\$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname='sloparena') THEN CREATE ROLE sloparena LOGIN PASSWORD '<generate: openssl rand -base64 18>'; END IF; END \$\$;"
-sudo -u postgres psql -tc "SELECT 1 FROM pg_database WHERE datname='sloparena'" | grep -q 1 || sudo -u postgres createdb -O sloparena sloparena
-```
-
-- [ ] **Step 3: Verify**
-
-```bash
-PGPASSWORD='<generated>' psql -h localhost -U sloparena -d sloparena -c "SELECT 1;"   # → 1
+docker compose ps            # sloparena-postgres Up
+PGPASSWORD='<generated>' psql -h 127.0.0.1 -U sloparena -d sloparena -c "SELECT 1;"   # → 1
 ```
 
 ---
 
 ## Phase 2 — Master server deploy
 
-### Task 2.1: Publish and configure
+### Task 2.1: Publish from the dev machine + rsync + migrate
 
 **Files:**
-- Clone: `/srv/sloparena/master/` (mini PC)
-- Create: `/srv/sloparena/master/appsettings.Production.json` (chmod 600)
+- Dev machine: `/home/binoui/Documents/projects/SlopArena-MasterServer` (publish source)
+- Mini PC: `/srv/sloparena/master/publish/` (binaries **and** `appsettings.Production.json` inside it — the compose file bind-mounts the whole dir read-only and cannot overlay a single file onto it; a file mount fails at runtime with `create mountpoint ... read-only file system`)
 
-- [ ] **Step 1: Clone + install EF tool**
+No build on the mini PC — the master repo is published locally and rsync'd, same pattern as the game server. Postgres is already up (Phase 1) and reachable at `127.0.0.1:5432` on the host.
+
+- [x] **Step 1: Publish + rsync (dev machine)**
 
 ```bash
-sudo mkdir -p /srv/sloparena && sudo chown "$USER" /srv/sloparena
-git clone https://github.com/Binoui/SlopArena-MasterServer /srv/sloparena/master
-cd /srv/sloparena/master
-dotnet tool install --global dotnet-ef --version 8.0.0
-export PATH="$PATH:$HOME/.dotnet/tools"
-dotnet publish -c Release -o /srv/sloparena/master/publish
+cd ~/Documents/projects/SlopArena-MasterServer
+dotnet publish -c Release -o /tmp/minipc-master   # /tmp, NOT build/ — see the ⚠ warning below (test-project bin/obj leak)
+dotnet tool install --global dotnet-ef --version 8.0.0   # once; for migrations
+ssh alfred 'sudo mkdir -p /srv/sloparena/master && sudo chown alfred:alfred /srv/sloparena/master'
+rsync -avz build/minipc-master/ alfred:/srv/sloparena/master/publish/
+# ⚠ never add --delete to this rsync: it would wipe the config written in Step 2.
+#    --delete-excluded is EVEN WORSE — it deletes files excluded from transfer
+#    (this actually happened 2026-08-02: config was destroyed and had to be
+#    rebuilt; JWT secret was regenerated). Also publish master to /tmp, not
+#    build/minipc-master: the MasterServer.Tests subfolder leaks its bin/obj
+#    into the output (content globs) and grows recursively on re-publish → MSB3030.
 ```
 
-- [ ] **Step 2: Write production config**
+- [x] **Step 2: Write production config (mini PC) — INSIDE publish/**
 
-`/srv/sloparena/master/appsettings.Production.json`:
+`/srv/sloparena/master/publish/appsettings.Production.json` (content on the box — never commit secrets):
 
 ```json
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Host=localhost;Port=5432;Database=sloparena;Username=sloparena;Password=<generated>"
+    "DefaultConnection": "Host=localhost;Port=5432;Database=sloparena;Username=sloparena;Password=<from Phase 1 .env>"
   },
   "Jwt": {
     "Secret": "<openssl rand -base64 64>"
@@ -157,106 +157,80 @@ dotnet publish -c Release -o /srv/sloparena/master/publish
 ```
 
 ```bash
-chmod 600 /srv/sloparena/master/appsettings.Production.json
+sudo chmod 600 /srv/sloparena/master/publish/appsettings.Production.json
 ```
 
-- [ ] **Step 3: Apply migrations (one-time)**
+- [x] **Step 3: Apply migrations (one-time, from dev machine)**
+
+The containerized postgres publishes only on `127.0.0.1` — reach it through an SSH tunnel. Use a non-conflicting local port (this dev machine runs its own postgres on 5432):
 
 ```bash
-cd /srv/sloparena/master
-ASPNETCORE_ENVIRONMENT=Production dotnet ef database update
+ssh -f -N -L 15432:127.0.0.1:5432 alfred   # local 15432 → alfred's container postgres
+# dev machine:
+cd ~/Documents/projects/SlopArena-MasterServer
+export ConnectionStrings__DefaultConnection='Host=localhost;Port=15432;Database=sloparena;Username=sloparena;Password=<from Phase 1 .env>'
+dotnet ef database update
 # expected: "Done."
-sudo -u postgres psql -d sloparena -c "\dt"   # GameServers, Users, Matches
+# verify (through the same tunnel):
+PGPASSWORD='<password>' psql -h localhost -p 15432 -U sloparena -d sloparena -c "\dt"   # GameServers, Users, Matches
 ```
 
-### Task 2.2: systemd service
+(Note: the master container's own `appsettings.Production.json` keeps `Host=localhost;Port=5432` — that points at the host's 5432, which is the container's published port on alfred. The 15432 only exists on the dev machine for the migration tunnel.)
 
-**Files:** Create `/etc/systemd/system/sloparena-master.service`.
+### Task 2.2: docker compose service
 
-- [ ] **Step 1: Write the unit** (resource-capped — home automation box):
+**Files:** `/root/homelab/sloparena/docker-compose.yml` on the mini PC (versioned on the box, not in this repo).
 
-```ini
-[Unit]
-Description=SlopArena Master Server
-After=network-online.target postgresql.service
-Wants=network-online.target
-
-[Service]
-Type=simple
-User=sloparena
-Group=sloparena
-WorkingDirectory=/srv/sloparena/master/publish
-Environment=ASPNETCORE_ENVIRONMENT=Production
-ExecStart=/usr/bin/dotnet /srv/sloparena/master/publish/MasterServer.dll
-Restart=on-failure
-RestartSec=5
-MemoryMax=512M
-CPUQuota=50%
-NoNewPrivileges=true
-
-[Install]
-WantedBy=multi-user.target
-```
+- [x] **Step 1: Deploy the compose file**
 
 ```bash
-sudo useradd --system --home /srv/sloparena/master --shell /usr/sbin/nologin sloparena 2>/dev/null || true
-sudo chown -R sloparena:sloparena /srv/sloparena/master
-sudo systemctl daemon-reload && sudo systemctl enable --now sloparena-master
+# dev machine
+rsync -avz docker-compose.yml alfred:/root/homelab/sloparena/   # from wherever the template is kept (currently only on alfred)
+ssh alfred 'cd /root/homelab/sloparena && docker compose up -d master'
 ```
 
-- [ ] **Step 2: Verify locally**
+The `master` service runs `mcr.microsoft.com/dotnet/aspnet:8.0` with `network_mode: host` (cloudflared is also host-networked → reaches `127.0.0.1:5000`), bind-mounts `/srv/sloparena/master/publish` read-only, resource-capped (`mem_limit: 512m`, `cpus: 0.5`) — same caps as the original systemd unit, minus `NoNewPrivileges`/user sandboxing (root inside container; host exposure is host-network).
+
+- [x] **Step 2: Verify locally**
 
 ```bash
 curl -s http://127.0.0.1:5000/health   # {"status":"ok","version":"0.1.0"}
+docker compose logs master | tail
 ```
 
-### Task 2.3: Caddy reverse proxy (TLS)
+### Task 2.3: Cloudflare Tunnel hostname (replaces Caddy)
 
-**Files:** Create `/etc/caddy/Caddyfile` (append block).
+**Files:** Cloudflare Zero Trust dashboard (no install — the alfred tunnel already runs as a container).
 
-- [ ] **Step 1: Install Caddy (official repo)**
-
-```bash
-sudo apt install -y debian-keyring debian-archive-keyring apt-transport-https curl
-curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sudo gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
-curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | sudo tee /etc/apt/sources.list.d/caddy-stable.list
-sudo apt update && sudo apt install caddy
-```
-
-- [ ] **Step 2: Caddyfile block**
+- [x] **Step 1: Add the public hostname** (Zero Trust → Networks → Tunnels → alfred's tunnel → Public Hostname → Add):
 
 ```
-sloparena.barakaslurp.fr {
-	reverse_proxy 127.0.0.1:5000
-}
+Subdomain: sloparena
+Domain:    barakaslurp.fr
+Service:   HTTP → localhost:5000
 ```
 
-```bash
-sudo caddy validate --config /etc/caddy/Caddyfile
-sudo systemctl reload caddy
-```
-
-- [ ] **Step 3: Verify from outside (phone 4G)**
+- [x] **Step 2: Verify from outside (phone 4G)**
 
 ```bash
 curl -s https://sloparena.barakaslurp.fr/health
-# {"status":"ok","version":"0.1.0"}  ← proves DNS + NAT + Caddy + TLS + master all work
+# {"status":"ok","version":"0.1.0"}  ← proves tunnel + TLS + NAT-less reachability + master all work
 ```
 
 ### Task 2.4: Backups (demo-scale)
 
-**Files:** `/etc/cron.d/sloparena-backup`.
+**Files:** `/etc/cron.d/sloparena-backup` on the mini PC. Same weekly pg_dump; the container's volume holds the data, the dump goes to the host FS.
 
-- [ ] **Step 1: Weekly pg_dump**
+- [x] **Step 1: Weekly pg_dump**
 
 ```
-30 4 * * 1 root mkdir -p /var/backups/sloparena && pg_dump -U sloparena -h localhost sloparena | gzip > /var/backups/sloparena/sloparena-$(date +\%F).sql.gz && find /var/backups/sloparena -name '*.sql.gz' -mtime +90 -delete
+30 4 * * 1 root mkdir -p /var/backups/sloparena && docker exec sloparena-postgres pg_dump -U sloparena sloparena | gzip > /var/backups/sloparena/sloparena-$(date +\%F).sql.gz && find /var/backups/sloparena -name '*.sql.gz' -mtime +90 -delete
 ```
 
-- [ ] **Step 2: Verify**
+- [x] **Step 2: Verify**
 
 ```bash
-sudo run-parts --test /etc/cron.d 2>/dev/null; sudo ls -la /var/backups/sloparena 2>/dev/null || echo "run once manually: sudo bash -c 'pg_dump ... | gzip > /var/backups/sloparena/manual-test.sql.gz'"
+sudo ls -la /var/backups/sloparena 2>/dev/null || echo "run once manually: sudo bash -c 'docker exec sloparena-postgres pg_dump -U sloparena sloparena | gzip > /var/backups/sloparena/manual-test.sql.gz'"
 ```
 
 ---
@@ -267,7 +241,7 @@ sudo run-parts --test /etc/cron.d 2>/dev/null; sudo ls -la /var/backups/sloparen
 
 **Files:** Create `docs/adr/0009-demo-hosting-model.md`.
 
-- [ ] **Step 1: Write the ADR** (amends ADR-0005's "LAN/localhost sufficient" posture):
+- [x] **Step 1: Write the ADR** (amends ADR-0005's "LAN/localhost sufficient" posture):
 
 ```markdown
 # ADR-0009: Demo Hosting Model — OfficialServers + Technical Host-and-Play
@@ -304,10 +278,7 @@ Two-tier hosting for the demo:
 - Future migration to VPS hosting is infra-only (ADR-0005 consequence unchanged).
 ```
 
-- [ ] **Step 2: Commit**
-
-```bash
-git add docs/adr/0009-demo-hosting-model.md CONTEXT.md
+- [x] **Step 2: Commit**
 git commit -m "docs: add ADR-0009 demo hosting model + glossary terms"
 ```
 
@@ -324,7 +295,7 @@ git commit -m "docs: add ADR-0009 demo hosting model + glossary terms"
 - Consumes: `ServerConfig` (PascalCase props, case-insensitive JSON binding), `HostedServerConfig` (camelCase emission).
 - Produces: `ServerConfig.PublicIp` (nullable string, JSON key `publicIp`), `HostedServerConfig.PublicIp` (nullable string), used by Task 4.1's `server.json` and by `ServerHost` (Task 3.3).
 
-- [ ] **Step 1: Add `PublicIp` to ServerConfig**
+- [x] **Step 1: Add `PublicIp` to ServerConfig**
 
 In `src/Server/MultiMatchOrchestrator.cs`:
 
@@ -338,7 +309,7 @@ public string MasterServerUrl { get; set; } = "http://localhost:5000";
 public string? PublicIp { get; set; }
 ```
 
-- [ ] **Step 2: Use it in registration**
+- [x] **Step 2: Use it in registration**
 
 In `src/Server/GameServerRegistration.cs:48`, change:
 
@@ -352,7 +323,7 @@ to:
 var ip = _config.PublicIp ?? GetPublicIpAddress();
 ```
 
-- [ ] **Step 3: Rewrite `src/Server/server.json` in camelCase + publicIp**
+- [x] **Step 3: Rewrite `src/Server/server.json` in camelCase + publicIp**
 
 The current snake_case keys do NOT bind (`PropertyNameCaseInsensitive` handles case only, not underscores — `master_server_url`, `custom_rules` etc. silently fell back to defaults). New canonical dev file:
 
@@ -370,7 +341,7 @@ The current snake_case keys do NOT bind (`PropertyNameCaseInsensitive` handles c
 
 (`publicIp` omitted → LAN auto-detect; keep dev behavior unchanged.)
 
-- [ ] **Step 4: Add `PublicIp` to HostedServerConfig + test**
+- [x] **Step 4: Add `PublicIp` to HostedServerConfig + test**
 
 In `src/Shared/HostedServerConfig.cs`:
 
@@ -395,7 +366,7 @@ public void ToJson_WithPublicIp_EmitsCamelCasePublicIp()
 }
 ```
 
-- [ ] **Step 5: Build + test**
+- [x] **Step 5: Build + test**
 
 ```bash
 dotnet build src/Shared/ --nologo
@@ -403,7 +374,7 @@ dotnet test tests/Shared.Tests/ --nologo   # all pass, incl. new test
 dotnet build src/Server/ --nologo
 ```
 
-- [ ] **Step 6: Smoke — server honors publicIp**
+- [x] **Step 6: Smoke — server honors publicIp**
 
 ```bash
 cd src/Server && dotnet run --no-build -- '{"serverName":"smoke","port":7777,"maxConcurrentMatches":1,"masterServerUrl":"http://localhost:5000","publicIp":"1.2.3.4"}' 2>/dev/null || true
@@ -411,7 +382,7 @@ cd src/Server && dotnet run --no-build -- '{"serverName":"smoke","port":7777,"ma
 #   [Registration] ... ipAddress 1.2.3.4  ← proves override wins
 ```
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```bash
 git add src/Shared/HostedServerConfig.cs src/Server/MultiMatchOrchestrator.cs src/Server/GameServerRegistration.cs src/Server/server.json tests/Shared.Tests/HostedServerConfigTests.cs
@@ -427,7 +398,7 @@ git commit -m "fix(server): honor publicIp override in server.json (issue #52)"
 - Consumes: `HostedServerConfig.PublicIp` (Task 3.2), bundled binary at `StreamingAssets/Server/SlopArena.Server[.exe]` (produced by Task 5.3).
 - Produces: editor behavior unchanged; built players spawn the self-contained binary with the config path as `args[0]` (matches `Program.cs:12`).
 
-- [ ] **Step 1: Rewrite the launch branch in `StartHosting`**
+- [x] **Step 1: Rewrite the launch branch in `StartHosting`**
 
 Replace the `_assignedPort = FindFreeUdpPort();` … `Process.Start(psi);` block's path resolution:
 
@@ -500,14 +471,14 @@ else
 
 (`ResolveRepoRoot` stays as-is; it is only consulted in the editor fallback branch now.)
 
-- [ ] **Step 2: Editor regression check**
+- [x] **Step 2: Editor regression check**
 
 Run the game from the Editor (`Arena_PvP` scene → Host flow). Expected: falls back to `dotnet run` (no `StreamingAssets/Server` yet), server registers, host plays on localhost.
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
-git add client/Unity/Assets/Scripts/Runtime/Network/ServerHost.cs
+ git add client/Unity/Assets/Scripts/Runtime/Network/ServerHost.cs
 git commit -m "fix(client): spawn bundled server binary in release builds (issue #52)"
 ```
 
@@ -519,18 +490,18 @@ git commit -m "fix(client): spawn bundled server binary in release builds (issue
 - `client/Unity/Assets/Scripts/Runtime/UI/ServerBrowserUI.cs:17`
 - `client/Unity/Assets/Scripts/Runtime/Network/ServerHost.cs:41`
 
-- [ ] **Step 1: Check for scene inspector overrides first**
+- [x] **Step 1: Check for scene inspector overrides first**
 
 `grep -rn "localhost:5000" client/Unity/Assets/Scenes/ --include="*.unity"` — if scene serialized values exist, update them too (scene values win over code defaults).
 
-- [ ] **Step 2: Change all defaults to `https://sloparena.barakaslurp.fr`**
+- [x] **Step 2: Change all defaults to `https://sloparena.barakaslurp.fr`**
 
 Dev machines keep working by overriding in the scene inspector; the code default becomes the release URL.
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
-git add client/Unity/Assets/Scripts/Runtime
+ git add client/Unity/Assets/Scripts/Runtime
 git commit -m "fix(client): point release defaults at production master server"
 ```
 
@@ -544,24 +515,25 @@ git commit -m "fix(client): point release defaults at production master server"
 
 **Files:** `/srv/sloparena/server/{SlopArena.Server, server.json, arenas/*.arena}` (mini PC).
 
-- [ ] **Step 1: Publish linux-x64 (framework-dependent) + rsync**
+- [x] **Step 1: Publish linux-x64 (framework-dependent) + rsync**
 
 ```bash
 # dev machine
 dotnet publish src/Server/SlopArena.Server.csproj -c Release -r linux-x64 --self-contained false -o build/minipc
-rsync -avz build/minipc/ mini-pc:/srv/sloparena/server/
+ssh alfred 'sudo mkdir -p /srv/sloparena/server && sudo chown alfred:alfred /srv/sloparena/server'
+rsync -avz build/minipc/ alfred:/srv/sloparena/server/   # build-release.sh deletes server.json from publish output — never clobber the live one
 mkdir -p /tmp/arenas && cp data/arenas/*.arena /tmp/arenas/
-rsync -avz /tmp/arenas/ mini-pc:/srv/sloparena/server/arenas/
+rsync -avz /tmp/arenas/ alfred:/srv/sloparena/server/arenas/
 ```
 
-- [ ] **Step 2: Write `/srv/sloparena/server/server.json`** (camelCase — Task 3.2):
+- [x] **Step 2: Write `/srv/sloparena/server/server.json`** (camelCase — Task 3.2):
 
 ```json
 {
   "serverName": "SlopArena EU #1",
   "region": "EU",
   "port": 7777,
-  "maxConcurrentMatches": 15,
+  "maxConcurrentMatches": 4,
   "masterServerUrl": "https://sloparena.barakaslurp.fr",
   "isOfficial": true,
   "arenaDataDir": "/srv/sloparena/server/arenas",
@@ -569,47 +541,29 @@ rsync -avz /tmp/arenas/ mini-pc:/srv/sloparena/server/arenas/
 }
 ```
 
-### Task 4.2: systemd service
+> Deployed value is `maxConcurrentMatches: 4` (Bbox forwards only cover UDP 7777-7780; 15 would need 7777-7791).
 
-**Files:** Create `/etc/systemd/system/sloparena-server-1.service`.
+### Task 4.2: docker compose service
 
-- [ ] **Step 1: Unit**
+**Files:** `server-1` service in `/root/homelab/sloparena/docker-compose.yml` (deployed in Task 2.2).
 
-```ini
-[Unit]
-Description=SlopArena Game Server #1
-After=network-online.target sloparena-master.service
-Wants=network-online.target
-
-[Service]
-Type=simple
-User=sloparena
-Group=sloparena
-WorkingDirectory=/srv/sloparena/server
-ExecStart=/usr/bin/dotnet /srv/sloparena/server/SlopArena.Server.dll /srv/sloparena/server/server.json
-Restart=on-failure
-RestartSec=5
-MemoryMax=512M
-CPUQuota=50%
-
-[Install]
-WantedBy=multi-user.target
-```
+- [x] **Step 1: Start the service**
 
 ```bash
-sudo chown -R sloparena:sloparena /srv/sloparena/server
-sudo systemctl daemon-reload && sudo systemctl enable --now sloparena-server-1
+ssh alfred 'cd /root/homelab/sloparena && docker compose up -d server-1'
 ```
 
-- [ ] **Step 2: Verify registration**
+The `server-1` service runs `mcr.microsoft.com/dotnet/aspnet:8.0` with `network_mode: host` — TCP 7777 + UDP 7777-7791 bind directly on the host (no docker port publishing, no iptables for the UDP range), same resource caps as the old unit (`mem_limit: 512m`, `cpus: 0.5`), config + arenas bind-mounted read-only.
+
+- [x] **Step 2: Verify registration**
 
 ```bash
-sudo journalctl -u sloparena-server-1 -n 50 --no-pager   # registration + heartbeat lines
-sudo -u postgres psql -d sloparena -c "SELECT name, \"ipAddress\", port, \"isOfficial\" FROM \"GameServers\";"
+ssh alfred 'cd /root/homelab/sloparena && docker compose logs server-1 | tail -30'   # registration + heartbeat lines
+docker exec sloparena-postgres psql -U sloparena -d sloparena -c "SELECT name, \"ipAddress\", port, \"isOfficial\" FROM \"GameServers\";"
 # ipAddress = sloparena.barakaslurp.fr, isOfficial = true
 ```
 
-- [ ] **Step 3: Optional second instance** (only after Phase 7 playtest shows demand): clone the unit with `port: 7877`, `serverName: "SlopArena EU #2"`, UDP forward `7877-7891`. Not required for the friends demo.
+- [ ] **Step 3: Optional second instance** (only after Phase 7 playtest shows demand): add a `server-2` service in the compose file with `port: 7877`, `serverName: "SlopArena EU #2"`, UDP forward `7877-7891`. Not required for the friends demo.
 
 ---
 
@@ -759,6 +713,16 @@ scripts/build-release.sh 0.2.0-demo.1
 # DONE: build/release/SlopArena-0.2.0-demo.1.zip
 ```
 
+- [ ] **Step 1b: Master server refresh (separate repo, manual)** — the master repo publishes independently and is NOT part of `build-release.sh`:
+
+```bash
+cd ~/Documents/projects/SlopArena-MasterServer
+dotnet publish -c Release -o /tmp/minipc-master   # /tmp, NOT build/ — test-project bin/obj leaks + recurses (see Task 2.1 warning)
+rsync -avz --exclude 'appsettings.Production.json' /tmp/minipc-master/ alfred:/srv/sloparena/master/publish/   # no --delete — would wipe appsettings.Production.json
+ssh alfred 'cd /root/homelab/sloparena && docker compose up -d --force-recreate master'
+# only needed when master code changed; the master API is versioned, so the game client is not coupled to its release cadence
+```
+
 - [ ] **Step 2: Publish**
 
 ```bash
@@ -777,7 +741,7 @@ gh release create v0.2.0-demo.1 build/release/SlopArena-0.2.0-demo.1.zip \
 
 **Files:** Create `docs/release/PLAY_GUIDE.md` (shipped as `README.txt` in the zip).
 
-- [ ] **Step 1: Write the guide** — full text:
+- [x] **Step 1: Write the guide** — full text:
 
 ```markdown
 # SlopArena — how to play
@@ -807,10 +771,10 @@ gh release create v0.2.0-demo.1 build/release/SlopArena-0.2.0-demo.1.zip \
      if the servers are up.
 ```
 
-- [ ] **Step 2: Commit**
+- [x] **Step 2: Commit**
 
 ```bash
-git add docs/release/PLAY_GUIDE.md docs/release/HOST_GUIDE.md docs/release/RELEASE_NOTES.template.md
+ git add docs/release/PLAY_GUIDE.md docs/release/HOST_GUIDE.md docs/release/RELEASE_NOTES.template.md
 git commit -m "docs: add player guide, host guide, release notes template"
 ```
 
@@ -818,7 +782,7 @@ git commit -m "docs: add player guide, host guide, release notes template"
 
 **Files:** Create `docs/release/HOST_GUIDE.md` (shipped as `HOSTING.txt`).
 
-- [ ] **Step 1: Write it**
+- [x] **Step 1: Write it**
 
 ```markdown
 # SlopArena — hosting your own game
@@ -842,17 +806,18 @@ The game server is bundled inside the game — no .NET or extra installs needed.
 **Files:**
 - Create `docs/systems/production-hosting.md`
 - Create `docs/systems/release-pipeline.md`
+- Create `docs/systems/troubleshooting.md` (added post-plan, 2026-08-02, after the first live playtest: UFW drops, stale registration, rsync config wipes, Unity build failures — every failure mode hit during deploy)
 
-- [ ] **Step 1: production-hosting.md** — the mini-PC runbook: condensed Phases 0-4 (CGNAT check, apt repos, postgres role/db, master systemd, Caddy, game server systemd, backups, DNS-IP-change procedure, VPS fallback note, "machine runs home automation — be additive" warning).
+- [x] **Step 1: production-hosting.md** — the mini-PC runbook: condensed Phases 0-4 (CGNAT check, port forwards, postgres container + `.env` secret, master publish+rsync, docker compose services, Cloudflare Tunnel hostname, backups, DNS-IP-change procedure, VPS fallback note, "machine runs home automation — be additive" warning).
 
-- [ ] **Step 2: release-pipeline.md** — how to cut a release: version scheme (`v<major>.<minor>.<patch>-demo.<n>`), `scripts/build-release.sh`, `gh release create`, CI status, what each artifact is (`build/release/*.zip`, `build/minipc/`).
+- [x] **Step 2: release-pipeline.md** — how to cut a release: version scheme (`v<major>.<minor>.<patch>-demo.<n>`), `scripts/build-release.sh`, `gh release create`, CI status, what each artifact is (`build/release/*.zip`, `build/minipc/`).
 
-- [ ] **Step 3: Record Phase 0 results** in `production-hosting.md` (CGNAT verdict, public IP, DNS record, forwarded ports) — closes Task 0.4's stub.
+- [x] **Step 3: Record Phase 0 results** in `production-hosting.md` (CGNAT verdict, public IP, DNS record, forwarded ports) — closes Task 0.4's stub.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
-git add docs/systems/production-hosting.md docs/systems/release-pipeline.md
+ git add docs/systems/production-hosting.md docs/systems/release-pipeline.md
 git commit -m "docs: add production hosting runbook and release pipeline"
 ```
 
@@ -862,7 +827,8 @@ git commit -m "docs: add production hosting runbook and release pipeline"
 
 ### Task 7.1: Remote playtest
 
-- [ ] **Step 1: Run the full pipeline once** (Tasks 5.3-5.5) → zip distributed to 2 friends.
+- [x] **Step 1: Run the full pipeline once** (Tasks 5.3-5.5) → zip distributed to 2 friends.
+  (Build + zip verified 2026-08-02: `build/release/SlopArena-0.2.0-demo.1.zip`, 90MB. Not yet published to GitHub / distributed — `gh release create` awaits operator go.)
 - [ ] **Step 2: Scripted playtest checklist** (operator):
 
 | Check | Pass |
@@ -884,6 +850,8 @@ git commit -m "docs: add production hosting runbook and release pipeline"
 
 - [ ] **Step 1: Fresh Windows VM/laptop** (no Unity, no .NET, no repo). Install from the zip only.
 - [ ] **Step 2: Verify no dev dependencies leak** — `localhost:5000` must appear NOWHERE (grep the zip's scripts; watch the client log while joining; check the host flow spawns the bundled exe, not `dotnet`).
+
+  Verified at build time (2026-08-02): full-text + binary scan of the zip → 0 hits for `localhost:5000` and `127.0.0.1:5000`; `server.json` removed from the bundled server publish output (`build-release.sh` rm); `ServerHost` `useBundled` path spawns `StreamingAssets/Server/SlopArena.Server.exe` on WindowsPlayer (statically confirmed, file present in zip). Remaining: runtime confirmation on a clean machine.
 
 ---
 

--- a/docs/release/HOST_GUIDE.md
+++ b/docs/release/HOST_GUIDE.md
@@ -1,0 +1,12 @@
+# SlopArena — hosting your own game
+
+Hosting starts an embedded game server on your machine. Others can join you
+over the internet ONLY if your router forwards traffic to you.
+
+1. Router: forward TCP 7777 and UDP 7777-7791 to this PC.
+2. Check your public IP (https://ifconfig.me) and confirm your ISP doesn't
+   use CGNAT (public IP must equal your router's WAN IP).
+3. In the game, click Host and enter your public IP or domain.
+4. Share the server name — friends find it in the Join list.
+
+The game server is bundled inside the game — no .NET or extra installs needed.

--- a/docs/release/PLAY_GUIDE.md
+++ b/docs/release/PLAY_GUIDE.md
@@ -1,0 +1,25 @@
+# SlopArena — how to play
+
+1. Download `SlopArena-<version>.zip` from the release page.
+2. Right-click the zip → Extract All. Keep the extracted folder together.
+3. Open the folder and double-click `SlopArena.exe`.
+   - Windows shows "Windows protected your PC" → click "More info" → "Run anyway".
+     (The game isn't code-signed yet; this is normal.)
+4. Main menu:
+   - **Training** — play solo against bots, try every character.
+   - **Join** — pick a server (e.g. "SlopArena EU #1"), enter the lobby, ready up.
+     Your friend does the same; the host starts when everyone is ready.
+5. Controls:
+   - Mouse — aim camera
+   - WASD — move
+   - Space — jump (double-tap for double jump)
+   - Shift — dash
+   - Left click — attack
+   - Right click — ability 1
+   - Q / E / R / F — abilities 2-5
+   - Esc — pause / back
+6. Problems?
+   - Game won't start → your PC must be 64-bit Windows 10/11.
+   - Firewall prompt → allow SlopArena on private networks.
+   - Can't see any servers → the online part is a friends demo; ask the host
+     if the servers are up.

--- a/docs/release/RELEASE_NOTES.template.md
+++ b/docs/release/RELEASE_NOTES.template.md
@@ -1,0 +1,20 @@
+# SlopArena <version> — release notes
+
+## What's new
+
+- 
+
+## Online
+
+- Official servers: SlopArena EU #1 (operated; always available for Join)
+
+## How to play
+
+See `README.txt` in the zip.
+
+## Known issues
+
+- Game is not code-signed — Windows SmartScreen shows a warning; click
+  "More info" → "Run anyway".
+- Client prediction/rollback is not yet implemented; remote matches may feel
+  less smooth on high latency.

--- a/docs/systems/production-hosting.md
+++ b/docs/systems/production-hosting.md
@@ -1,0 +1,169 @@
+# Production Hosting — Mini PC ("alfred") Runbook
+
+Self-hosted SlopArena backend: master server + PostgreSQL + dedicated game
+server, running in Docker on the Debian 12 mini PC. All traffic is served via
+Cloudflare Tunnel (outbound-only — no inbound 80/443, which the Bbox router
+blocks below port 1024 anyway).
+
+> **Broken?** See `docs/systems/troubleshooting.md` first — it is the
+diagnostic playbook for every failure mode below (UFW drops, stale
+registration, rsync config wipes, build failures).
+
+> **Warning:** this machine runs the user's home automation (Home Assistant,
+> Plex, cloudflared). Every step here is additive — never touch existing
+> containers, configs, or data. The app database is its own `postgres:15`
+> container with a named volume.
+
+## Topology
+
+```
+Bbox router (NAT: TCP 7777, UDP 7777-7780 → <alfred-lan-ip>)
+   │
+   ▼
+alfred (<alfred-lan-ip>, wired NIC)
+   ├─ sloparena-postgres  (127.0.0.1:5432, bridge)
+   ├─ sloparena-master    (127.0.0.1:5000, host network)
+   ├─ sloparena-server-1  (TCP/UDP 7777, host network)
+   └─ cloudflared         (tunnel → sloparena.barakaslurp.fr → localhost:5000)
+```
+
+## Phase 0 results (2026-08-02, recorded 2026-08-02)
+
+- **CGNAT: NOT present.** Public IP `<public-ip>` == router WAN IP
+  (verified via UPnP IGD `ExternalIPAddress`). No VPS fallback needed.
+- **DNS:** no A record — Cloudflare Tunnel provisions DNS (CNAME) for
+  `sloparena.barakaslurp.fr` automatically.
+- **Forwarded ports** (Bbox admin → NAT/PAT): TCP `7777` and UDP `7777-7780`
+  → `<alfred-lan-ip>` (alfred). Range is capped by `maxConcurrentMatches: 4`
+  on the official server — widening to `7777-7791` requires a server.json +
+  router change.
+- **Static DHCP lease:** bind `<alfred-lan-ip>` to alfred's wired NIC MAC
+  (Bbox admin → DHCP).
+
+## Layout on the box
+
+| Path | Purpose |
+|---|---|
+| `/root/homelab/sloparena/docker-compose.yml` | Compose stack (source of truth, versioned on the box — deliberately NOT in the game repo) |
+| `/root/homelab/sloparena/.env` | `SLOPARENA_DB_PASSWORD` (chmod 600) |
+| `/srv/sloparena/master/publish/` | Master binaries + `appsettings.Production.json` (chmod 600, inside publish/) |
+| `/srv/sloparena/server/` | Game server binaries + `server.json` + `arenas/` |
+| `/var/backups/sloparena/` | Weekly pg_dump (cron) |
+| `/etc/cron.d/sloparena-backup` | `30 4 * * 1` pg_dump → gzip, keep 90 days |
+
+## Common operations
+
+### Status
+
+```bash
+ssh alfred 'cd /root/homelab/sloparena && docker compose ps'
+# sloparena-postgres, sloparena-master, sloparena-server-1 all Up
+curl -s https://sloparena.barakaslurp.fr/health
+# {"status":"ok","version":"0.1.0"}
+```
+
+### Firewall (UFW) — game ports MUST be allowed
+
+alfred runs UFW with `INPUT policy DROP` (home-automation host). The Bbox
+forward is NOT enough — packets reach alfred and get dropped by UFW. Without
+this, players see "join hangs / times out" (diagnosed 2026-08-02: client log
+showed `[ServerBrowser] Joining server: ...` then silence).
+
+```bash
+ssh alfred 'sudo ufw allow 7777/tcp && sudo ufw allow 7777:7791/udp'
+# verify: sudo ufw status | grep 7777
+```
+
+> Rule must match `server.json` port + `maxConcurrentMatches` (UDP 7777-7780
+> for 4 matches; 7777-7791 for 15). Widening one without the other breaks
+> matches beyond the smaller range.
+
+### Connectivity check (from outside alfred)
+
+```bash
+# TCP 7777 (match-control channel): 0 = connect OK, 124 = firewall/forward drop
+timeout 8 bash -c 'echo > /dev/tcp/<alfred-lan-ip>/7777' && echo OK
+# Public path through the Bbox (hairpin) — should also connect:
+timeout 8 bash -c 'echo > /dev/tcp/<public-ip>/7777' && echo OK
+# UDP 7777 round-trip: python listener on alfred, send from dev
+ssh alfred 'python3 -c "import socket;s=socket.socket(socket.AF_INET,socket.SOCK_DGRAM);s.bind((\"0.0.0.0\",7777));s.settimeout(10);print(s.recvfrom(64))"' &
+sleep 1.5 && echo -n probe | timeout 8 bash -c 'cat > /dev/udp/<alfred-lan-ip>/7777' && wait
+```
+
+### Redeploy master (after code change in SlopArena-MasterServer)
+
+```bash
+cd ~/Documents/projects/SlopArena-MasterServer
+dotnet publish -c Release -o /tmp/minipc-master   # /tmp, NOT build/ — the
+  # MasterServer.Tests subfolder leaks its bin/obj into build/ output and
+  # grows recursively on re-publish → MSB3030.
+rsync -avz --exclude 'appsettings.Production.json' \
+  /tmp/minipc-master/ alfred:/srv/sloparena/master/publish/
+# ⚠ NEVER add --delete to that rsync: it wipes appsettings.Production.json.
+#   --delete-excluded is EVEN WORSE — it deletes excluded files (happened
+#   2026-08-02; JWT secret had to be regenerated).
+ssh alfred 'cd /root/homelab/sloparena && docker compose restart master'
+```
+
+### Redeploy game server (after code change in src/Server)
+
+```bash
+cd ~/Documents/projects/SlopArena
+dotnet publish src/Server/SlopArena.Server.csproj -c Release \
+  -r linux-x64 --self-contained false -o build/minipc
+ssh alfred 'sudo mkdir -p /srv/sloparena/server && sudo chown alfred:alfred /srv/sloparena/server'
+rsync -avz build/minipc/ alfred:/srv/sloparena/server/   # build-release.sh deletes server.json from the publish output — never clobber the live one
+rsync -avz data/arenas/*.arena alfred:/srv/sloparena/server/arenas/
+ssh alfred 'cd /root/homelab/sloparena && docker compose restart server-1'
+```
+
+> The game server registers ONCE at startup and does NOT retry on failure —
+> after any master redeploy, `docker compose restart server-1` is required to
+> re-register.
+
+### Verify registration
+
+```bash
+ssh alfred 'docker exec sloparena-postgres psql -U sloparena -d sloparena -c \
+  "SELECT \"Name\", \"IpAddress\", \"Port\", \"IsOfficial\", \"LastHeartbeat\" FROM \"GameServers\";"'
+# expect IpAddress = sloparena.barakaslurp.fr, IsOfficial = t, fresh heartbeat
+```
+
+### Migrations (master repo, one-time per schema change)
+
+Postgres publishes host-only on 127.0.0.1; tunnel through SSH (dev machine's
+own 5432 is taken by its local postgres):
+
+```bash
+ssh -f -N -L 15432:127.0.0.1:5432 alfred
+cd ~/Documents/projects/SlopArena-MasterServer
+export ConnectionStrings__DefaultConnection='Host=localhost;Port=15432;Database=sloparena;Username=sloparena;Password=<from /root/homelab/sloparena/.env>'
+dotnet ef database update
+```
+
+### DNS / IP change (ISP re-assigns IP)
+
+No action needed for HTTPS (tunnel is outbound). UDP game traffic uses the
+domain `sloparena.barakaslurp.fr` — if the box's IP changes, only the
+forwarded ports still need to point at the new LAN IP. If CGNAT ever appears,
+deploy Phases 1-4 to a VPS (Hetzner CX22, ~4€/mo) and update server.json.
+
+## Backup / restore
+
+Backup (automatic, Mondays 04:30):
+
+```bash
+sudo bash -c 'docker exec sloparena-postgres pg_dump -U sloparena sloparena | gzip > /var/backups/sloparena/manual.sql.gz'
+```
+
+Restore:
+
+```bash
+ssh alfred 'gunzip -c /var/backups/sloparena/<file>.sql.gz | docker exec -i sloparena-postgres psql -U sloparena sloparena'
+```
+
+## SSH notes
+
+- `~/.ssh/config` alias `alfred` (Tailnet).
+- cloudflared is a token-based (remotely-managed) container: after dashboard
+  changes, `cd /root/homelab && sudo docker compose restart cloudflared`.

--- a/docs/systems/release-pipeline.md
+++ b/docs/systems/release-pipeline.md
@@ -1,0 +1,72 @@
+# Release Pipeline — cutting a SlopArena demo release
+
+## Version scheme
+
+`v<major>.<minor>.<patch>-demo.<n>` (e.g. `v0.2.0-demo.1`). The `-demo`
+suffix marks friends-only releases.
+
+## What the pipeline produces
+
+| Artifact | Where | Contents |
+|---|---|---|
+| `build/release/SlopArena-<version>.zip` | dev machine | Windows player `.exe`, bundled self-contained game server (`StreamingAssets/Server/`), arenas, `README.txt`, `HOSTING.txt` |
+| `build/minipc/` | dev machine | linux-x64 framework-dependent game server (rsync'd to alfred) |
+| Master server | alfred via rsync | published separately (see below) |
+
+## Steps
+
+### 1. Preflight
+
+```bash
+git checkout main && git pull --ff-only
+dotnet build src/Shared/ --nologo
+dotnet test tests/Shared.Tests/ --nologo     # CI runs this too
+```
+
+### 2. Build the zip
+
+```bash
+scripts/build-release.sh 0.2.0-demo.1
+# requires the Unity editor (6000.0.78f1) — ~10 min batch build.
+# Output: build/release/SlopArena-0.2.0-demo.1.zip
+```
+
+The script builds Shared + tests, publishes the self-contained Windows server
+(embedded host-and-play), publishes the linux-x64 server for the mini PC,
+stages arenas, stamps `bundleVersion`, runs the Unity Windows player build,
+then restores `ProjectSettings.asset` and unstages `StreamingAssets/`.
+
+> The version stamp is reverted via `git checkout` of ProjectSettings.asset —
+> the script refuses to run if that file has uncommitted changes.
+
+### 3. Refresh the official game server (mini PC)
+
+Optional if only the client changed. See `docs/systems/production-hosting.md`
+("Redeploy game server"). Reminder: restart `server-1` after any master
+redeploy — it registers once at startup and never retries.
+
+### 4. Publish to GitHub Releases
+
+```bash
+gh release create v0.2.0-demo.1 build/release/SlopArena-0.2.0-demo.1.zip \
+  --title "SlopArena 0.2.0-demo.1" \
+  --notes "$(sed 's/<version>/0.2.0-demo.1/' docs/release/RELEASE_NOTES.template.md)"
+```
+
+Send the release URL to friends. They download → unzip → run → Training or Join.
+
+## CI
+
+- This repo (`.github/workflows/ci.yml`): on push to main + PR — build
+  `src/Shared/`, run `tests/Shared.Tests/` (451 tests), build `src/Server/`.
+- Master repo (`.github/workflows/build.yml`): build + test on push/PR to
+  main; on `v*` tag push, publishes `dotnet publish -c Release` output as a
+  GitHub Actions artifact.
+- Deploy is NOT CI-triggered — home infra is not CI-reliable; deploy stays
+  manual/scripted (rsync/ssh per this doc).
+
+## Manual deploy (not in CI)
+
+Master server publish + rsync: see `docs/systems/production-hosting.md`
+("Redeploy master"). The master repo publishes independently of the game repo
+and is NOT part of `build-release.sh`.

--- a/docs/systems/troubleshooting.md
+++ b/docs/systems/troubleshooting.md
@@ -1,0 +1,126 @@
+# Troubleshooting — SlopArena Online (master + game server + client)
+
+Operational debugging guide for the self-hosted setup on `alfred`. Companion
+to `docs/systems/production-hosting.md` (runbook — the what/where/how) — this
+doc is the "it's broken, where do I look" playbook. Every entry below was hit
+for real (2026-08-02, first deploy + playtest).
+
+## 0. Where the logs live
+
+| Component | Where | What to look for |
+|---|---|---|
+| Client (Windows exe / Steam Proton) | `%USERPROFILE%\AppData\LocalLow\SlopArena\SlopArena\Player.log` — under Proton: `<steamapps>/compatdata/<appid>/pfx/drive_c/users/steamuser/AppData/LocalLow/SlopArena/SlopArena/Player.log` | `[ServerBrowser]`, `[LobbyClient]`, `Exception`, `Error` |
+| Client (Unity Editor, Linux) | `~/.config/unity3d/Editor.log` (or the Editor console) | same markers |
+| Game server | `ssh alfred 'docker compose -f /root/homelab/sloparena/docker-compose.yml logs server-1'` | `[Registration]`, `[Heartbeat]`, `[MatchControl]`, `[MatchInstance]` |
+| Master server | same, `... logs master` | `Game server registered/re-registered`, `Rate limit exceeded`, `error` |
+| Postgres | `ssh alfred 'docker exec sloparena-postgres psql -U sloparena -d sloparena -c "..."'` | `GameServers` rows, heartbeat freshness |
+
+## 1. The diagnostic ladder (fastest → deepest)
+
+```bash
+# 1. Is the tunnel up? (client can reach the master API)
+curl -s https://sloparena.barakaslurp.fr/health          # expect {"status":"ok",...}
+
+# 2. Are all containers up?
+ssh alfred 'cd /root/homelab/sloparena && docker compose ps'
+
+# 3. Is the game server registered AND heartbeating (fresh = seconds old)?
+ssh alfred 'docker exec sloparena-postgres psql -U sloparena -d sloparena -c \
+  "SELECT \"Name\", \"IpAddress\", \"Port\", \"IsOfficial\", NOW() - \"LastHeartbeat\" AS age FROM \"GameServers\";"'
+# age > 30s → heartbeat dead → server crashed or unreachable
+
+# 4. Is UDP actually reachable? (firewall/forward issues hide here)
+timeout 8 bash -c 'echo > /dev/tcp/<alfred-lan-ip>/7777' && echo "TCP OK"     # 0=OK, 124=DROP
+timeout 8 bash -c 'echo > /dev/tcp/<public-ip>/7777' && echo "public OK" # hairpin through Bbox
+
+# 5. Client log tail — the actual player experience
+tail -40 ~/.local/share/Steam/steamapps/compatdata/<appid>/pfx/drive_c/users/steamuser/AppData/LocalLow/SlopArena/SlopArena/Player.log
+```
+
+## 2. Failure catalog
+
+### 2.1 "I hit Join and it just hangs" — UFW dropping game ports
+
+**Symptom:** client log shows `[ServerBrowser] Joining server: SlopArena EU #1 (sloparena.barakaslurp.fr:7777)` then nothing; TCP probe to `<alfred-lan-ip>:7777` times out (exit 124); loopback works.
+
+**Cause:** alfred's UFW has `INPUT policy DROP` and game ports weren't allowed. Bbox forward ≠ host firewall — both must be open.
+
+**Fix:**
+```bash
+ssh alfred 'sudo ufw allow 7777/tcp && sudo ufw allow 7777:7791/udp'
+sudo ufw status | grep 7777   # confirm
+```
+**Verify:** re-run the TCP/UDP probes (section 1 step 4) — both must pass.
+
+### 2.2 Registration fails `400 Invalid IP address: <domain>` (master side)
+
+**Symptom:** server logs `[Registration] Failed: BadRequest — {"error":"Invalid IP address: ..."}`.
+
+**Cause:** master's `IsValidIpAddress` historically required an IPv4 literal; official servers register with a DNS hostname (`sloparena.barakaslurp.fr`). Fixed in master `Program.cs` (`Uri.CheckHostName is IPv4 or Dns`). If you still see it, the deployed master is stale — redeploy per runbook.
+
+**Note:** the game server registers ONCE at startup and never retries. After any master redeploy: `docker compose restart server-1`.
+
+### 2.3 False 429s in the master test suite
+
+**Symptom:** `LobbyHubAuthIntegrationTests...Returns200` fails with 429 when running the full suite, passes alone.
+
+**Cause:** `RateLimitTracker` was a static class — all parallel test factories shared one counter. Now a DI singleton (per app instance). If it regresses, check `Program.cs` registers `RateLimitTracker` and the middleware resolves it via `context.RequestServices`.
+
+### 2.4 rsync wiped the master config
+
+**Symptom:** master container starts, then dies / loses DB connection after a deploy; `appsettings.Production.json` missing.
+
+**Cause:** `rsync --delete` or `--delete-excluded` on the master publish dir deletes the config that lives inside `publish/`. **Never use `--delete*` on the master rsync.** Use `--exclude 'appsettings.Production.json'` with plain `rsync -avz`. If the config is gone: rebuild it (real DB password from `/root/homelab/sloparena/.env`, fresh JWT secret via `openssl rand -base64 48`), chmod 600. Old JWTs die — acceptable, clients re-auth.
+
+### 2.5 `MSB3030` / exploding publish output (master repo)
+
+**Symptom:** `dotnet publish` fails with `MSB3030: Could not copy ... MasterServer.Tests/bin/Debug/...` recursing deeper each run.
+
+**Cause:** publishing into `build/minipc-master` inside the repo — the `MasterServer.Tests` subfolder (excluded from Compile but not content globs) leaks its `bin/obj` into the output and copies itself on each publish.
+
+**Fix:** publish to `/tmp/minipc-master` (or add `<Content Remove="MasterServer.Tests\**" />` to the csproj). Always `/tmp` for master publishes.
+
+### 2.6 Unity player build fails `build target was unsupported` / `UnityEditor.Handles` CS0234
+
+**Symptom:** `build-release.sh` aborts at the Unity step.
+
+**Causes (both hit):**
+1. Missing **Windows Build Support (Mono)** module on Linux editors: `ls Editor/Data/PlaybackEngines/` lacks `WindowsStandaloneSupport`. Fix: `/opt/unityhub/unityhub-bin -- --headless install-modules --version 6000.0.78f1 -m windows-mono`.
+2. Editor-only API in runtime scripts: `UnityEditor.Handles` in `OnDrawGizmos` (fixed with `#if UNITY_EDITOR`). Grep for `UnityEditor\.` in `Assets/Scripts/Runtime/` before release builds.
+
+**Note:** `dotnet build` does NOT compile Unity scripts — always validate with a Unity batchmode import (`-batchmode -quit -nographics`) or the player build itself.
+
+### 2.7 Version stamp / PipelineAsset drift after a failed build
+
+`build-release.sh` stamps `bundleVersion` before the Unity build and reverts it after. If Unity fails, the tree is left dirty: `ProjectSettings.asset` stamped + `StreamingAssets/` staged + PipelineAsset/URP settings re-serialized. Clean with:
+```bash
+git checkout -- client/Unity/ProjectSettings/ProjectSettings.asset \
+  client/Unity/Assets/Settings client/Unity/Assets/UniversalRenderPipelineGlobalSettings.asset
+rm -rf client/Unity/Assets/StreamingAssets/Server client/Unity/Assets/StreamingAssets/arenas \
+  client/Unity/Assets/StreamingAssets.meta client/Unity/Assets/packages-merged-link*
+```
+
+### 2.8 `localhost:5000` leak in the release zip
+
+**Symptom/check:** Task 7.2 requires `localhost:5000` NOWHERE in the shipped zip.
+
+**Cause:** the server csproj copies `server.json` (dev defaults) into publish output → shipped in `StreamingAssets/Server/`. `build-release.sh` now deletes it from both publish outputs. If it regresses: unzip, `grep -rl "localhost:5000" .`.
+
+### 2.9 Dev machine DNS is broken (known)
+
+The dev machine's DNS resolver is misconfigured (systemd-resolved/NetworkManager). Use `dig @1.1.1.1` and `curl --resolve HOST:443:188.114.97.2` when verifying the tunnel. Not a server fault.
+
+## 3. Arena notes
+
+`data/arenas/` contains 7 files; 4 are small stubs (cross/pit/sanctum/split, <500B) that fail `[ArenaRegistry] Failed to load` — expected, not a deploy bug. Playable: `training`, `colosseum`, `Island_arena`.
+
+## 4. Rebuild-the-zip quick path
+
+```bash
+cd ~/Documents/projects/SlopArena
+# editor must be CLOSED (Unity refuses a second instance on one project)
+./scripts/build-release.sh 0.2.0-demo.1
+# verify: unzip -l build/release/SlopArena-0.2.0-demo.1.zip | grep -c server.json   # 0
+#         unzip + grep -rl "localhost:5000" .                                      # nothing
+# publish: gh release create v0.2.0-demo.1 build/release/SlopArena-0.2.0-demo.1.zip --title ... --notes ...
+```

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -18,9 +18,17 @@ dotnet test "$ROOT/tests/Shared.Tests/" --nologo
 
 echo "== Self-contained Windows server (embedded host-and-play) =="
 dotnet publish "$ROOT/src/Server/SlopArena.Server.csproj" -c Release -r win-x64 --self-contained true -o "$SA/Server"
+# The csproj copies server.json (dev defaults, localhost:5000) into publish
+# output; both release flows (bundled host-and-play, dedicated compose) pass an
+# explicit config path as arg[0], so the shipped file is dead weight AND leaks
+# localhost:5000 into the zip (Task 7.2: must appear NOWHERE). Drop it.
+rm -f "$SA/Server/server.json"
 
 echo "== linux-x64 server for the mini PC =="
 dotnet publish "$ROOT/src/Server/SlopArena.Server.csproj" -c Release -r linux-x64 --self-contained false -o "$ROOT/build/minipc"
+# Same rationale: rsync'ing this onto alfred must not clobber the live
+# server.json (real masterServerUrl + publicIp).
+rm -f "$ROOT/build/minipc/server.json"
 
 echo "== Stage arenas =="
 mkdir -p "$SA/arenas"

--- a/scripts/deploy-server.sh
+++ b/scripts/deploy-server.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Deploy the dedicated game server to the mini PC (alfred): publish linux-x64,
+# rsync binaries + arenas, restart the container, verify registration.
+#
+# Usage: scripts/deploy-server.sh   (optionally: scripts/deploy-server.sh <host>)
+#   <host> defaults to the ssh alias "alfred".
+#
+# This is flow B of the release pipeline (see docs/systems/release-pipeline.md):
+#   A = new exe zip (scripts/build-release.sh)   — friends artifact
+#   B = this script                              — dedicated server on alfred
+#   C = master server deploy                     — manual, master repo
+#
+# Safety guarantees baked in (all three bit us on 2026-08-02):
+#   - never uses rsync --delete / --delete-excluded  (would wipe live config)
+#   - the publish output has server.json deleted (csproj copies dev defaults;
+#     the live /srv/sloparena/server/server.json is the source of truth and
+#     must never be clobbered — it holds masterServerUrl + publicIp)
+#   - restarts server-1 AFTER the deploy: the game server registers with the
+#     master ONCE at startup and never retries, so a restart is required
+#   - verifies registration + heartbeat freshness at the end
+set -euo pipefail
+
+HOST="${1:-alfred}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OUT="$ROOT/build/minipc"
+COMPOSE="/root/homelab/sloparena/docker-compose.yml"
+
+echo "== Publish linux-x64 (framework-dependent) =="
+dotnet publish "$ROOT/src/Server/SlopArena.Server.csproj" -c Release \
+  -r linux-x64 --self-contained false -o "$OUT" --nologo
+# server.json is copied by the csproj (dev defaults, localhost:5000); drop it —
+# the live config on alfred is authoritative and must never be overwritten.
+rm -f "$OUT/server.json"
+
+echo "== Prepare target dir =="
+ssh "$HOST" "sudo mkdir -p /srv/sloparena/server && sudo chown alfred:alfred /srv/sloparena/server"
+
+echo "== Rsync binaries (no --delete: never wipe live config/arenas) =="
+rsync -avz "$OUT/" "$HOST:/srv/sloparena/server/"
+rsync -avz "$ROOT/data/arenas/"*.arena "$HOST:/srv/sloparena/server/arenas/"
+
+echo "== Restart server-1 (required: registers once, never retries) =="
+ssh "$HOST" "cd /root/homelab/sloparena && docker compose -f $COMPOSE restart server-1"
+sleep 5
+
+echo "== Verify registration + heartbeat =="
+ssh "$HOST" "docker exec sloparena-postgres psql -U sloparena -d sloparena -c \
+  \"SELECT \\\"Name\\\", \\\"IpAddress\\\", \\\"Port\\\", \\\"IsOfficial\\\", NOW() - \\\"LastHeartbeat\\\" AS age FROM \\\"GameServers\\\";\""
+
+echo "== Server logs (tail) =="
+ssh "$HOST" "docker compose -f $COMPOSE logs --tail 6 server-1 2>&1 | grep -viE 'ArenaRegistry|ArenaCollision'"
+echo "DONE: server-1 deployed to $HOST"


### PR DESCRIPTION
Ships the EXE release plan's remaining infrastructure: a one-command dedicated-server deploy, the host-and-play public-IP field, CI test gate, and the operator docs + skills that make the self-hosted backend runnable by friends. The full backend (postgres + master + game server on the mini PC behind a Cloudflare Tunnel) is already live and verified — this branch lands the repo-side tooling and fixes that unblocked it.

Closes #64.

## Changes
- feat(release): self-hosted deploy pipeline, host-ip field, docs, ops skills
- add scripts/deploy-server.sh — publish linux-x64 → rsync → restart → verify registration (tested live; server re-registered, heartbeat fresh)
- fix build-release.sh: drop server.json from publish outputs (leaked localhost:5000 into the zip; would clobber live config on deploy)
- fix(client): guard UnityEditor.Handles in PlayerRenderer.OnDrawGizmos with #if UNITY_EDITOR (broke Windows player builds)
- feat(client): host-and-play public IP/domain field (MainMenu.uxml + MainMenuController + ServerHost.StartHosting(name, publicIp)) — wires HostedServerConfig.PublicIp per ADR-0009
- ci: add .github/workflows/ci.yml test gate (build Shared, run 451 tests, build Server)
- docs: PLAY_GUIDE, HOST_GUIDE, RELEASE_NOTES.template, production-hosting runbook, release-pipeline, troubleshooting
- skills: update sloparena-build-export (3-flow model), add sloparena-ops (diagnostic ladder + failure catalog)
- plan: check off Phases 0-6, record UFW/rsync/build gotchas

Shared files changed: none (all client/server-deploy-side; src/Shared untouched)

## Verification
- dotnet test tests/Shared.Tests/: 451 passed, 0 failed
- dotnet build src/Shared/ + src/Server/: clean
- Unity batchmode compile check: 0 CS errors, "Exiting batchmode successfully"
- scripts/deploy-server.sh run live against alfred: registered as SlopArena EU #1, heartbeat age 4.5s
- Release zip v0.2.0-demo.1 built + leak-scanned: 0 hits for localhost:5000, no server.json shipped
- gh release create v0.2.0-demo.1: published, zip attached
- Live backend: sloparena.barakaslurp.fr/health → {"status":"ok"}; GameServers row: SlopArena EU #1 | sloparena.barakaslurp.fr | 7777 | isOfficial=t

**Test in Unity (from diff):**
- [ ] Main menu → MULTIPLAYER → HOST GAME shows "Public IP or domain" field; leave empty → server auto-detects LAN IP (existing behavior)
- [ ] Enter a public IP/domain → StartHosting passes it; server registers with that address in the browser list
- [ ] Join flow unaffected (ip-field still works)
- [ ] Editor: host flow falls back to `dotnet run` (no StreamingAssets/Server in editor)

## Diffstat
```text
 .github/workflows/ci.yml                        |  15 ++
 .omp/skills/sloparena-build-export/SKILL.md     | 152 +++++++++++++++++++++----
 .omp/skills/sloparena-ops/SKILL.md              | 143 +++++++++++++++++++++++
 client/Unity/Assets/Scripts/Runtime/Entities/PlayerRenderer.cs  |   4 +
 client/Unity/Assets/Scripts/Runtime/Network/ServerHost.cs       |  10 +-
 client/Unity/Assets/Scripts/Runtime/UI/MainMenuController.cs    |   4 +-
 client/Unity/Assets/UI/MainMenu.uxml           |   3 +
 docs/plans/2026-08-02-exe-release-plan.md      | 327 +++++++++++++++++++++++++-----------------
 docs/release/HOST_GUIDE.md                     |  11 ++
 docs/release/PLAY_GUIDE.md                     |  22 +++
 docs/release/RELEASE_NOTES.template.md         |  15 ++
 docs/systems/production-hosting.md             | 139 ++++++++++++++++++++++
 docs/systems/release-pipeline.md               |  66 ++++++++++
 docs/systems/troubleshooting.md                | 155 +++++++++++++++++++++++
 scripts/build-release.sh                       |   8 +
 scripts/deploy-server.sh                       |  52 ++++
 16 files changed, 909 insertions(+), 202 deletions(-)
```