### PR TITLE
feat(netcode): relay consumed inputs on server state broadcast (issue #80)

### DIFF
--- a/.omp/AGENTS.md
+++ b/.omp/AGENTS.md
@@ -40,7 +40,7 @@ Master Server (SignalR/REST)          Game Server (src/Server, .NET console)
 - All tick durations use `ushort` (max 65535 ticks = ~18 minutes).
 - Packet serialization uses `System.Buffers.Binary.BinaryPrimitives` (little-endian).
 - Client → Server: `entityId(8) + tick(4) + InputState(19)` = 31 bytes, 60Hz.
-- Server → Client: `entityId(8) + tick(4) + CharacterStatePacket(63)` = 75 bytes per entity.
+- Server → Client: `entityId(8) + tick(4) + CharacterStatePacket(63) + hasInput(1) + InputState(19)` = up to 95 bytes per entity (input relay, issue #80).
 - Match flow: Server Browser → Lobby Room → Character Select → Countdown → Fight → Results → Lobby Room (ADR-0008). Master server (SignalR) manages lobby/char-select/results; game server (UDP) manages countdown/fight only.
 
 ## Key Conventions
@@ -97,7 +97,7 @@ Master Server (SignalR/REST)          Game Server (src/Server, .NET console)
   - `dotnet build src/Shared/ --nologo` after any Shared change (auto-copies the DLL to Unity Plugins).
   - `dotnet test tests/Shared.Tests/` — filtered during development, full suite at the end.
   - `dotnet build src/Server/` when server code changed.
-- Optional stronger gate: `"$UNITY_EDITOR" -batchmode -quit -projectPath <worktree>/client/Unity` once per worktree — catches Unity-script compile errors. First run builds a fresh `Library/` (slow, multi-GB); afterwards fast. `$UNITY_EDITOR` = Unity 6000.0.78f1 install path.
+- Optional stronger gate: `"$UNITY_EDITOR" -batchmode -quit -projectPath <worktree>/client/Unity` once per worktree — catches Unity-script compile errors. First run builds a fresh `Library/` (slow, multi-GB); afterwards fast. `$UNITY_EDITOR` = Unity 6000.0.78f1 install path. **Gitignored local packages don't travel to worktrees** (`Packages/com.kybernetik.animancer` is paid and never committed): run `scripts/setup-worktree-unity-packages.sh` first or the gate fails on Animancer type errors.
 - **Handoff:** if the slice touches Unity-facing code (`client/Unity/Assets/Scripts/`, prefabs, animation, input), write a short "Test in Unity" checklist (what to playtest, what to look for) to `TESTING-UNITY.md` at the repo root (gitignored — never committed). `sloparena-finish-branch` picks it up into the PR body.
 
 ### Debugging Protocol

--- a/.omp/skills/sloparena-netcode/SKILL.md
+++ b/.omp/skills/sloparena-netcode/SKILL.md
@@ -26,7 +26,9 @@ Verified against `src/Shared/` and `src/Server/MatchInstance.cs`:
 - `InputState.Size = 19` (`src/Shared/InputState.cs`)
 - **Client → server: `entityId(8) + tick(4) + InputState(19)` = 31 bytes** (`MatchInstance.ReceiveInputs` comment)
 - `CharacterStatePacket.Size = 63` (`src/Shared/CharacterStatePacket.cs`)
-- **Server → client, per entity: `entityId(8) + tick(4) + CharacterStatePacket(63)` = 75 bytes** (`MatchInstance.SendState` comment)
+- **Server → client, per entity: `entityId(8) + tick(4) + CharacterStatePacket(63) + hasInput(1) + InputState(19)` = up to 95 bytes** — 76B no-input marker / 95B with relayed input (`ServerEntityPacket`, issue #80)
+
+Input relay (issue #80): the server appends the exact `InputState` it consumed for that entity that tick, or the explicit no-input marker when its queue was empty / the entity is eliminated or disconnected. `hasInput = 0` → client omits the entity from re-sim inputs (server's `default(InputState)` path). Clients decode via `ServerEntityPacket.Deserialize` (`NetworkClient.ReceiveLoop`); the relayed inputs are consumed by the rollback bridge.
 
 InputState layout (19 bytes): MoveX(4) + MoveY(4) + flags(1) + ActiveSlot(1) + FacingYaw(2) + AimYaw(2) + AimPitch(2) + AimDistance(2) + TargetEntityId(1).
 

--- a/client/Unity/Assets/Scripts/Runtime/Network/NetworkClient.cs
+++ b/client/Unity/Assets/Scripts/Runtime/Network/NetworkClient.cs
@@ -22,7 +22,7 @@ namespace SlopArena.Client.Network
         private bool _connected;
         private Thread? _receiveThread;
         private volatile bool _running;
-        private readonly ConcurrentQueue<(ulong entityId, uint tick, CharacterState state)> _receivedQueue = new();
+        private readonly ConcurrentQueue<ServerEntityPacket> _receivedQueue = new();
 
         public ulong EntityId { get => _entityId; set => _entityId = value; }
         public bool IsServerConnected => _connected;
@@ -116,13 +116,18 @@ namespace SlopArena.Client.Network
             }
         }
 
+        /// <summary>
+        /// Drain the receive queue into the latest server-authoritative states.
+        /// The input-relay section (issue #80) is deliberately dropped here —
+        /// the rollback bridge drains it via its own accessor when re-sim lands.
+        /// </summary>
         public Dictionary<ulong, CharacterState> ReceiveStates()
         {
             var result = new Dictionary<ulong, CharacterState>();
             while (_receivedQueue.TryDequeue(out var entry))
             {
-                result[entry.entityId] = entry.state;
-                LastServerTick = entry.tick;
+                result[entry.EntityId] = entry.State.ToState();
+                LastServerTick = entry.Tick;
             }
             return result;
         }
@@ -140,13 +145,9 @@ namespace SlopArena.Client.Network
 
                     var ep = new IPEndPoint(IPAddress.Any, 0);
                     byte[] buf = _udp.Receive(ref ep);
-                    int minSize = 8 + 4 + CharacterStatePacket.Size;
-                    if (buf.Length < minSize) continue;
+                    if (buf.Length < ServerEntityPacket.BaseSize) continue;
 
-                    ulong eid = ReadUInt64LE(buf, 0);
-                    uint tick = ReadUInt32LE(buf, 8);
-                    var packet = CharacterStatePacket.Deserialize(buf.AsSpan(12));
-                    _receivedQueue.Enqueue((eid, tick, packet.ToState()));
+                    _receivedQueue.Enqueue(ServerEntityPacket.Deserialize(buf));
                 }
                 catch
                 {
@@ -182,12 +183,5 @@ namespace SlopArena.Client.Network
             buf[off] = (byte)val; buf[off+1] = (byte)(val>>8);
             buf[off+2] = (byte)(val>>16); buf[off+3] = (byte)(val>>24);
         }
-
-        private static ulong ReadUInt64LE(byte[] buf, int off) =>
-            buf[off] | (ulong)buf[off+1]<<8 | (ulong)buf[off+2]<<16 | (ulong)buf[off+3]<<24
-            | (ulong)buf[off+4]<<32 | (ulong)buf[off+5]<<40 | (ulong)buf[off+6]<<48 | (ulong)buf[off+7]<<56;
-
-        private static uint ReadUInt32LE(byte[] buf, int off) =>
-            (uint)(buf[off] | buf[off+1]<<8 | buf[off+2]<<16 | buf[off+3]<<24);
     }
 }

--- a/docs/systems/netcode-architecture.md
+++ b/docs/systems/netcode-architecture.md
@@ -134,8 +134,10 @@ Tick():
   6. SendState() — broadcast to all connected clients
      → For each client:
        → For each entity (all rostered players):
-       → Packet: entityId(8) + tick(4) + CharacterStatePacket(63) = 75B
+       → Packet: entityId(8) + tick(4) + CharacterStatePacket(63) + hasInput(1) + InputState(19) = up to 95B
          → tick = _serverTick (echoed back)
+         → hasInput/InputState = the input the server consumed for that entity
+           that tick, or the no-input marker (issue #80 — input relay)
        → Client filters by entityId
 ```
 
@@ -171,12 +173,16 @@ Total: 31 bytes (8 + 4 + 19)
 ### 4b. Server → Client (per entity)
 
 ```
-Receive packet per entity: entityId(8) + tick(4) + CharacterStatePacket(63) = 75 bytes
+Receive packet per entity: entityId(8) + tick(4) + CharacterStatePacket(63) + hasInput(1) + InputState(19) = up to 95 bytes
 
 [0..7]   entityId          (ulong)
 [8..11]  tick              (uint)       ← echoes client's tick number
 [12..74] CharacterStatePacket (63 bytes)
+[75]     hasInput          (byte)       ← 1 = relayed InputState follows; 0 = no input consumed this tick
+[76..94] InputState        (19 bytes)   ← present iff hasInput == 1 (issue #80 — input relay)
 ```
+
+**The relay section** (issue #80, ADR-0010): the server appends the exact `InputState` it consumed for that entity that tick, so clients can replay opponents' inputs — and exact omissions — during rollback re-simulation. `hasInput = 0` means the server's queue for that entity was empty that tick (or the entity is eliminated/disconnected): clients must *omit* the entity from their re-sim inputs, reproducing the server's `default(InputState)` path exactly. The flag is always present: a no-input packet is 76 bytes, a relayed packet 95 bytes. Encoded by `ServerEntityPacket` (`src/Shared/ServerEntityPacket.cs`).
 
 **CharacterStatePacket layout (63 bytes):**
 | Offset | Type    | Field               | Notes                              |
@@ -204,7 +210,7 @@ Receive packet per entity: entityId(8) + tick(4) + CharacterStatePacket(63) = 75
 | 49-50  | ushort  | DamagePercent       | Smash-style damage %, HUD display (issue #38) |
 | 51-62  | ushort×6| Cooldown0..5        | Per-slot cooldown ticks, local HUD fills (issue #38) |
 
-Total: 75 bytes per entity (8 + 4 + 63)
+Total: 75 bytes base (8 + 4 + 63), up to 95 with the relay section (76 no-input marker / 95 relayed — issue #80)
 
 **The server sends ALL states to every client.** Clients ignore the ones that don't concern them. No routing overhead.
 

--- a/scripts/setup-worktree-unity-packages.sh
+++ b/scripts/setup-worktree-unity-packages.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Link gitignored local Unity packages (e.g. Packages/com.kybernetik.animancer —
+# paid, never committed) from the main checkout into this worktree.
+#
+# Worktrees share the git index but NOT gitignored files, so a fresh worktree's
+# client/Unity/Packages/ lacks Animancer and the Unity compile gate fails with
+# "The type or namespace name 'Animancer' could not be found". Run this once per
+# worktree before `$UNITY_EDITOR -batchmode -quit -projectPath <worktree>/client/Unity`.
+#
+# Symlinks (not copies) so package updates in the main checkout propagate and no
+# disk is duplicated. Only links packages git ignores — tracked packages already
+# exist in the worktree.
+#
+# Usage: scripts/setup-worktree-unity-packages.sh [MAIN_CHECKOUT]
+#   MAIN_CHECKOUT defaults to ~/Documents/projects/SlopArena (the main repo).
+set -euo pipefail
+
+MAIN="${1:-$HOME/Documents/projects/SlopArena}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [ ! -d "$MAIN/client/Unity/Packages" ]; then
+  echo "error: main checkout not found at '$MAIN' (pass it as \$1)" >&2
+  exit 1
+fi
+
+linked=0
+for pkg in "$MAIN"/client/Unity/Packages/*/; do
+  [ -d "$pkg" ] || continue
+  [ -f "$pkg/package.json" ] || continue
+
+  name="$(basename "$pkg")"
+  dest="$HERE/client/Unity/Packages/$name"
+  [ -e "$dest" ] && continue # already present (copied or linked)
+
+  if git -C "$HERE" check-ignore -q "client/Unity/Packages/$name"; then
+    ln -s "$pkg" "$dest"
+    echo "linked $name -> $pkg"
+    linked=$((linked + 1))
+  fi
+done
+
+if [ "$linked" -eq 0 ]; then
+  echo "no missing gitignored packages — worktree ready for the Unity gate."
+fi

--- a/src/Server/MatchInstance.cs
+++ b/src/Server/MatchInstance.cs
@@ -30,6 +30,16 @@ namespace SlopArena.Server
 		private ServerSimulation _sim = null!;
 		private uint _serverTick;
 
+		/// <summary>
+		/// The inputs the server actually consumed for the last sim tick, keyed by
+		/// entity. Sent back to clients as the input-relay section of each state
+		/// broadcast (issue #80, ADR-0010): membership in this dict is the relay
+		/// signal, so empty queues, eliminated entities, and disconnected players
+		/// all broadcast the explicit no-input marker. Null until the first
+		/// playing tick (countdown broadcasts relay nothing).
+		/// </summary>
+		private Dictionary<ulong, InputState>? _lastTickInputs;
+
 		private const double TimeoutSeconds = 5.0;
 
 		// Match lifecycle
@@ -347,6 +357,7 @@ namespace SlopArena.Server
 			}
 
 			// Run authoritative simulation (movement + hit detection + hurtboxes + void death)
+			_lastTickInputs = inputs;
 			if (inputs.Count > 0)
 			{
 				_sim.Tick(inputs);
@@ -386,20 +397,35 @@ namespace SlopArena.Server
 
 			// Packet format (matching NetworkClient expectations):
 			//   entityId(8) + tick(4) + CharacterStatePacket(63)
-			const int envelopeSize = 8 + 4 + CharacterStatePacket.Size;
+			//   + hasInput(1) + InputState(19) when this entity's input was consumed
+			//   this tick — the input relay for client rollback prediction (issue #80).
+			// Max 95 bytes per entity; the flag is always present (76B no-input marker).
 
 			// Build a packet per entity once, then send each to every connected client.
-			var packets = new List<(ulong entityId, byte[] buffer)>(_slots.Count);
+			var packets = new List<(byte[] buffer, int length)>(_slots.Count);
 			foreach (var slot in _slots)
 			{
 				var statePacket = CharacterStatePacket.FromState(_sim.GetState(slot.EntityId), _serverTick);
 				statePacket.MatchState = _matchState;
 
-				var buf = new byte[envelopeSize];
-				BitConverter.TryWriteBytes(buf.AsSpan(0, 8), slot.EntityId);
-				BitConverter.TryWriteBytes(buf.AsSpan(8, 4), _serverTick);
-				statePacket.Serialize(buf.AsSpan(12));
-				packets.Add((slot.EntityId, buf));
+				// Relay the exact input the sim consumed this tick — membership in the
+				// consumed dict — or the explicit no-input marker. Entities excluded
+				// from the sim inputs (empty queue, eliminated, disconnected) must relay
+				// nothing so clients reproduce the server's default(InputState) path.
+				InputState consumed = default;
+				bool hasInput = _lastTickInputs != null && _lastTickInputs.TryGetValue(slot.EntityId, out consumed);
+				var packet = new ServerEntityPacket
+				{
+					EntityId = slot.EntityId,
+					Tick = _serverTick,
+					State = statePacket,
+					HasInput = hasInput,
+					Input = consumed,
+				};
+
+				var buf = new byte[ServerEntityPacket.MaxSize];
+				packet.Serialize(buf);
+				packets.Add((buf, packet.WireSize));
 			}
 
 			try
@@ -408,7 +434,7 @@ namespace SlopArena.Server
 				{
 					if (slot.EndPoint == null || slot.Disconnected) continue;
 					foreach (var pkt in packets)
-						_udpServer.Send(pkt.buffer, envelopeSize, slot.EndPoint);
+						_udpServer.Send(pkt.buffer, pkt.length, slot.EndPoint);
 				}
 			}
 			catch (Exception ex)

--- a/src/Shared/ServerEntityPacket.cs
+++ b/src/Shared/ServerEntityPacket.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Buffers.Binary;
+
+namespace SlopArena.Shared
+{
+    /// <summary>
+    /// Downlink per-entity state envelope: the existing broadcast
+    /// (entityId + tick + CharacterStatePacket) plus the input-relay section
+    /// (issue #80, ADR-0010): a 1-byte hasInput flag followed by the 19-byte
+    /// InputState the server actually consumed for that entity that tick.
+    ///
+    /// Layout:
+    ///   [0..7]   entityId          (8)
+    ///   [8..11]  tick              (4)   — _serverTick echo, unchanged reconciliation anchor
+    ///   [12..74] CharacterStatePacket (63)
+    ///   [75]     hasInput          (1)   — 0x01 = relayed InputState follows; 0x00 = no input this tick
+    ///   [76..94] InputState        (19)  — present iff hasInput == 1
+    ///
+    /// hasInput = 0 reproduces the server's empty-queue path exactly
+    /// (Simulation falls back to default(InputState)): the client must omit the
+    /// entity from its re-sim inputs dict. The flag is always present, so a
+    /// no-input packet is 76 bytes and a relayed-input packet is 95 bytes.
+    /// </summary>
+    public struct ServerEntityPacket
+    {
+        public ulong EntityId;
+        public uint Tick;
+        public CharacterStatePacket State;
+        /// <summary>True when the server consumed an InputState for this entity this tick.</summary>
+        public bool HasInput;
+        /// <summary>The relayed input (meaningful iff <see cref="HasInput"/>).</summary>
+        public InputState Input;
+
+        /// <summary>75 bytes — envelope without the relay section.</summary>
+        public const int BaseSize = 8 + 4 + CharacterStatePacket.Size;
+        /// <summary>20 bytes — hasInput flag + InputState.</summary>
+        public const int RelaySize = 1 + InputState.Size;
+        /// <summary>95 bytes — full envelope with relayed input.</summary>
+        public const int MaxSize = BaseSize + RelaySize;
+        /// <summary>76 bytes — envelope with the no-input marker.</summary>
+        public const int NoInputSize = BaseSize + 1;
+
+        /// <summary>Encoded length of this packet (76 or 95 bytes).</summary>
+        public int WireSize => HasInput ? MaxSize : NoInputSize;
+
+        public void Serialize(Span<byte> buffer)
+        {
+            if (buffer.Length < WireSize)
+                throw new ArgumentException("Buffer too small");
+
+            BinaryPrimitives.WriteUInt64LittleEndian(buffer.Slice(0, 8), EntityId);
+            BinaryPrimitives.WriteUInt32LittleEndian(buffer.Slice(8, 4), Tick);
+            State.Serialize(buffer.Slice(12));
+            buffer[BaseSize] = HasInput ? (byte)1 : (byte)0;
+            if (HasInput)
+                Input.Write(buffer.Slice(BaseSize + 1));
+        }
+
+        public static ServerEntityPacket Deserialize(ReadOnlySpan<byte> buffer)
+        {
+            if (buffer.Length < BaseSize)
+                throw new ArgumentException("Buffer too small");
+
+            var packet = new ServerEntityPacket
+            {
+                EntityId = BinaryPrimitives.ReadUInt64LittleEndian(buffer.Slice(0, 8)),
+                Tick = BinaryPrimitives.ReadUInt32LittleEndian(buffer.Slice(8, 4)),
+                State = CharacterStatePacket.Deserialize(buffer.Slice(12)),
+            };
+
+            if (buffer.Length >= MaxSize && buffer[BaseSize] == 1)
+            {
+                packet.HasInput = true;
+                // The MaxSize gate IS the truncation handling: a packet short of
+                // 95 bytes with the flag set reads as the no-input marker, keeping
+                // the invariant that HasInput implies a full, exact relayed input.
+                // (Truncated packets are never emitted by the server.)
+                packet.Input = InputState.Deserialize(buffer.Slice(BaseSize + 1));
+            }
+            return packet;
+        }
+    }
+}

--- a/tests/Shared.Tests/ServerEntityPacketTests.cs
+++ b/tests/Shared.Tests/ServerEntityPacketTests.cs
@@ -1,0 +1,188 @@
+using Xunit;
+
+namespace SlopArena.Shared.Tests;
+
+/// <summary>
+/// Downlink per-entity envelope: entityId(8) + tick(4) + CharacterStatePacket(63)
+/// + hasInput(1) + InputState(19) when the server consumed input that tick.
+/// Input relay for client rollback prediction (issue #80, ADR-0010).
+/// </summary>
+public class ServerEntityPacketTests
+{
+    private static CharacterStatePacket SampleState()
+    {
+        var state = new CharacterState
+        {
+            PX = 12.5f,
+            PY = 3.25f,
+            PZ = -7.1f,
+            VX = 1.5f,
+            VY = -2.5f,
+            VZ = 0.75f,
+            State = ActionState.Attacking,
+            StateTicks = 42,
+            IsGrounded = true,
+            AttackSlot = 3,
+            ComboStage = 2,
+            AnimIndex = 5,
+            FacingYaw = 1.234f,
+            MatchState = MatchState.Playing,
+            BuffRemainingTicks = 60,
+            BuffActiveFlags = 0b_0011,
+            HitstunLevel = 2,
+            AimPitch = -0.5f,
+            Deaths = 2,
+            DamagePercent = 87,
+            Cooldown0 = 1,
+            Cooldown1 = 12,
+            Cooldown2 = 33,
+            Cooldown3 = 44,
+            Cooldown4 = 55,
+            Cooldown5 = 66,
+        };
+        return CharacterStatePacket.FromState(state, tick: 999);
+    }
+
+    private static InputState SampleInput() => new InputState
+    {
+        MoveX = 0.75f,
+        MoveY = -0.25f,
+        Up = true,
+        Down = true,
+        Left = true,
+        Right = true,
+        Jump = true,
+        Dash = true,
+        Crouch = true,
+        IsAiming = true,
+        ActiveSlot = 3,
+        FacingYaw = 420,
+        AimYaw = -18000,
+        AimPitch = 9000,
+        AimDistance = 6500,
+        TargetEntityId = 7,
+    };
+
+    [Fact]
+    public void RoundTrip_WithRelay_PreservesAllFields()
+    {
+        // Arrange
+        var statePacket = SampleState();
+        var input = SampleInput();
+        var packet = new ServerEntityPacket
+        {
+            EntityId = 2,
+            Tick = 999,
+            State = statePacket,
+            HasInput = true,
+            Input = input,
+        };
+
+        // Act: Serialize → Deserialize
+        var buffer = new byte[ServerEntityPacket.MaxSize];
+        packet.Serialize(buffer);
+        var restored = ServerEntityPacket.Deserialize(buffer);
+
+        // Assert: envelope + tick echo + state + relayed input all survive
+        Assert.Equal(2UL, restored.EntityId);
+        Assert.Equal(999u, restored.Tick);
+        Assert.Equal(999u, restored.State.TickNumber); // tick echo unchanged — reconciliation anchor
+        Assert.True(restored.HasInput);
+
+        Assert.Equal(statePacket.PositionX, restored.State.PositionX);
+        Assert.Equal(statePacket.PositionY, restored.State.PositionY);
+        Assert.Equal(statePacket.PositionZ, restored.State.PositionZ);
+        Assert.Equal(statePacket.VelocityX, restored.State.VelocityX);
+        Assert.Equal(statePacket.CurrentActionState, restored.State.CurrentActionState);
+        Assert.Equal(statePacket.IsGrounded, restored.State.IsGrounded);
+        Assert.Equal(statePacket.StateDurationFrames, restored.State.StateDurationFrames);
+        Assert.Equal(statePacket.AttackSlot, restored.State.AttackSlot);
+        Assert.Equal(statePacket.ComboStage, restored.State.ComboStage);
+        Assert.Equal(statePacket.AnimIndex, restored.State.AnimIndex);
+        Assert.Equal(statePacket.FacingYaw, restored.State.FacingYaw);
+        Assert.Equal(statePacket.MatchState, restored.State.MatchState);
+        Assert.Equal(statePacket.DamagePercent, restored.State.DamagePercent);
+
+        Assert.Equal(input.MoveX, restored.Input.MoveX);
+        Assert.Equal(input.MoveY, restored.Input.MoveY);
+        Assert.Equal(input.Up, restored.Input.Up);
+        Assert.Equal(input.Down, restored.Input.Down);
+        Assert.Equal(input.Left, restored.Input.Left);
+        Assert.Equal(input.Right, restored.Input.Right);
+        Assert.Equal(input.Jump, restored.Input.Jump);
+        Assert.Equal(input.Dash, restored.Input.Dash);
+        Assert.Equal(input.Crouch, restored.Input.Crouch);
+        Assert.Equal(input.IsAiming, restored.Input.IsAiming);
+        Assert.Equal(input.ActiveSlot, restored.Input.ActiveSlot);
+        Assert.Equal(input.FacingYaw, restored.Input.FacingYaw);
+        Assert.Equal(input.AimYaw, restored.Input.AimYaw);
+        Assert.Equal(input.AimPitch, restored.Input.AimPitch);
+        Assert.Equal(input.AimDistance, restored.Input.AimDistance);
+        Assert.Equal(input.TargetEntityId, restored.Input.TargetEntityId);
+    }
+
+    [Fact]
+    public void RoundTrip_NoInputMarker_EncodesFlagWithoutRelay()
+    {
+        // Arrange: empty queue / eliminated entity path — explicit no-input marker
+        var packet = new ServerEntityPacket
+        {
+            EntityId = 1,
+            Tick = 99,
+            State = SampleState(),
+            HasInput = false,
+        };
+
+        // Act
+        var buffer = new byte[ServerEntityPacket.MaxSize];
+        packet.Serialize(buffer);
+        Assert.Equal(ServerEntityPacket.NoInputSize, packet.WireSize);
+        var restored = ServerEntityPacket.Deserialize(buffer);
+
+        // Assert: flag reads 0, no stale input is ever carried
+        Assert.Equal(1UL, restored.EntityId);
+        Assert.Equal(99u, restored.Tick);
+        Assert.False(restored.HasInput);
+        Assert.Equal(0, restored.Input.ActiveSlot);
+        Assert.False(restored.Input.Up);
+        Assert.False(restored.Input.Jump);
+    }
+
+    [Fact]
+    public void TruncatedRelay_DecodesAsNoInputMarker()
+    {
+        // A relay flag=1 whose 19 input bytes never arrived is a protocol violation;
+        // decode leniently to the no-input marker (mirrors InputState.Deserialize guards).
+        var packet = new ServerEntityPacket
+        {
+            EntityId = 1,
+            Tick = 5,
+            State = SampleState(),
+            HasInput = true,
+            Input = SampleInput(),
+        };
+        var buffer = new byte[ServerEntityPacket.MaxSize];
+        packet.Serialize(buffer);
+        var truncated = buffer.AsSpan(0, ServerEntityPacket.NoInputSize).ToArray();
+
+        var restored = ServerEntityPacket.Deserialize(truncated);
+
+        Assert.Equal(1UL, restored.EntityId);
+        Assert.Equal(5u, restored.Tick);
+        Assert.False(restored.HasInput);
+    }
+
+    [Fact]
+    public void SizeConstants_AssertWireLayout()
+    {
+        // Downlink max packet size is a wire contract (issue #80): 75B base + 1B flag + 19B input
+        Assert.Equal(8 + 4 + CharacterStatePacket.Size, ServerEntityPacket.BaseSize);
+        Assert.Equal(75, ServerEntityPacket.BaseSize);
+        Assert.Equal(1 + InputState.Size, ServerEntityPacket.RelaySize);
+        Assert.Equal(20, ServerEntityPacket.RelaySize);
+        Assert.Equal(95, ServerEntityPacket.MaxSize);
+        Assert.Equal(76, ServerEntityPacket.NoInputSize);
+        // Uplink format untouched: 31B (entityId + tick + InputState)
+        Assert.Equal(19, InputState.Size);
+    }
+}


### PR DESCRIPTION
The server now appends, per entity, the exact `InputState` it consumed that tick — or an explicit no-input marker — to the state broadcast. Clients can replay opponents' exact inputs (and omissions) during rollback re-simulation; this is the wire half of ADR-0010 (the client-side `RollbackSimulator`/bridge land in later issues).

Closes #80.

## Changes
- **Shared codec:** new `ServerEntityPacket` (`src/Shared/ServerEntityPacket.cs`) — the whole per-entity downlink envelope: `entityId(8) + tick(4) + CharacterStatePacket(63) + hasInput(1) + InputState(19)` = max 95B. Always-present flag: 76B no-input marker / 95B relayed. Truncated relay decodes as the no-input marker. Only Shared file changed; all other Shared files untouched.
- **Server:** `MatchInstance` records the consumed-inputs dict per tick and relays it in `SendState()`; membership in that dict is the relay signal, so empty queue / eliminated / disconnected entities always emit the marker (never a stale input). Countdown broadcasts carry markers only. Tick echo unchanged — still the reconciliation anchor.
- **Client:** `NetworkClient` decodes through the shared codec (queue holds `ServerEntityPacket`); `ReceiveStates()` behavior unchanged. The relayed inputs ride the queue for the future rollback bridge.
- **Tests:** new `ServerEntityPacketTests` — round-trip with/without relay, wire-layout constants asserted (95 max / 76 no-input / uplink 31B untouched), truncated-relay leniency, tick echo preserved. TDD (red → green).
- **Docs:** `docs/systems/netcode-architecture.md` §3c/§4b, `.omp/AGENTS.md`, netcode skill updated to the new wire format.
- **Worktree ops:** `scripts/setup-worktree-unity-packages.sh` links gitignored paid packages (Animancer) from the main checkout into worktrees so the Unity compile gate works on fresh worktrees.

## Verification
- `dotnet test tests/Shared.Tests/` — **459/459 pass** (incl. 4 new `ServerEntityPacketTests`)
- `dotnet build src/Shared/` and `src/Server/` — 0 errors
- Unity batchmode compile gate (worktree, Animancer linked): **exit 0, 0 errors**
- Two-axis code review (Standards + Spec): all 5 acceptance criteria met, no hard violations; review nits addressed (removed dead `ReceiveStateBatches` API, corrected docs/comment)

**Test in Unity:** server state broadcast now carries, per entity, the `InputState` the server consumed that tick (or an explicit no-input marker) — the input-relay section (`ServerEntityPacket`, issue #80). This is a **wire-format change**: server and client must ship together (they do — one repo). The client decodes the relay via `ServerEntityPacket` in `NetworkClient.ReceiveLoop()`; `ReceiveStates()` behavior is unchanged (it drops the relay for now — the rollback bridge consumes it later).

### Prerequisites
- Build Shared once so the DLL in `Assets/Plugins/SlopArena.Shared` is current: `dotnet build src/Shared/ --nologo` (already done on this branch — DLL copies automatically to `client/Unity/Assets/Plugins/SlopArena.Shared/`).
- Start the game server (`src/Server`) and connect two clients through the normal host-and-play / dedicated flow.

### Playtest checklist
1. **Host-and-play (localhost, 0 RTT) behaves as before.** Movement, jumping, attacking, hit reactions, KO/respawn, match end — nothing regressed. The relay is transparent to gameplay today (client still renders raw server state).
2. **Opponent movement smooth & identical to pre-change.** Two clients in a match; both see each other move continuously. The state path is byte-identical to the old 75B layout — only 1-20 trailing bytes were appended per entity.
3. **Countdown phase works.** During countdown the server broadcasts no-input markers (76B packets) — verify the match still counts down and starts normally.
4. **Eliminated / disconnected players don't break the broadcast.** KO someone (their entity broadcasts no-input markers from then on); quit one client mid match — the remaining client keeps rendering the idle entity.
5. **No console errors.** Watch the Unity Console: no `Buffer too small` exceptions from `ServerEntityPacket.Deserialize`, no socket errors. (The old `NetworkClient` helpers `ReadUInt64LE`/`ReadUInt32LE` were removed — nothing references them.)

### What to look at if something looks off
- `ServerEntityPacket` (`src/Shared/ServerEntityPacket.cs`) — offsets: eid(8) + tick(4) + state(63) + flag(1) + input(19) = 95B max.
- `MatchInstance.SendState()` — relay = membership in the consumed-inputs dict.
- `NetworkClient.ReceiveLoop()` — decode through `ServerEntityPacket.Deserialize`.

## Diffstat
```text
.omp/AGENTS.md                                     |   4 +-
.omp/skills/sloparena-netcode/SKILL.md             |   4 +-
.../Scripts/Runtime/Network/NetworkClient.cs       |  26 ++-
docs/systems/netcode-architecture.md               |  12 +-
scripts/setup-worktree-unity-packages.sh           |  44 +++++
src/Server/MatchInstance.cs                        |  42 ++++-
src/Shared/ServerEntityPacket.cs                   |  83 +++++++++
tests/Shared.Tests/ServerEntityPacketTests.cs      | 188 +++++++++++++++++++++
8 files changed, 373 insertions(+), 30 deletions(-)
```