### PR TITLE
feat(ui): rebuild combat HUD with tracked overhead panels + cooldown action bar

### DIFF
--- a/client/Unity/Assets/Scripts/Runtime/UI/HUDManager.cs
+++ b/client/Unity/Assets/Scripts/Runtime/UI/HUDManager.cs
@@ -1,17 +1,30 @@
 using System;
 using System.Collections.Generic;
 using SlopArena.Shared;
+using SlopArena.Client.Input;
 using UnityEngine;
+using UnityEngine.InputSystem;
 using UnityEngine.UIElements;
 
 namespace SlopArena.Client.UI
 {
     /// <summary>
-    /// HUD for stock matches (ADR-0007, issue #38): one panel per player showing
-    /// name, damage % and stock count, with the local player highlighted. The
-    /// local player's ability cooldown slots stay visible below the panels.
-    /// Panels are built at runtime from the roster so the layout adapts to
-    /// 2, 3 or 4 players with no per-count UXML variants.
+    /// Combat HUD (spec §1-§3), rebuilt on UI Toolkit.
+    ///
+    /// Two layers:
+    ///  • Overhead — one screen-space-tracked panel per player (badge, damage %,
+    ///    stocks), clamped to each player's simulation position via
+    ///    Camera.WorldToScreenPoint → RuntimePanelUtils.ScreenToPanel. Panels are
+    ///    built at runtime from the roster, so 1v1, 2/3/4-player PvP all adapt
+    ///    with no per-count UXML variants.
+    ///  • Action bar — the local player's cooldowns: Dash + abilities 1-4 + A/E/R/F
+    ///    + Burst (doc §2). Key labels are read live from InputBindings; slot and
+    ///    cooldown data come from the client-side simulation state (read-only —
+    ///    the UI never drives gameplay).
+    ///
+    /// Juice (spec §3.2): cooldown-ready pulse (1.15x / 0.15s) + white flash,
+    /// persistent burst glow while available, and a damage-taken hit-flash on the
+    /// overhead percent.
     /// </summary>
     public class HUDManager : MonoBehaviour
     {
@@ -32,27 +45,114 @@ namespace SlopArena.Client.UI
             }
         }
 
-        private sealed class Panel
+        private sealed class OverheadPanel
         {
             public VisualElement Root = null!;
-            public Label DamageLabel = null!;
+            public Label Badge = null!;
+            public Label Damage = null!;
             public VisualElement[] StockIcons = Array.Empty<VisualElement>();
             public Label StockCountLabel = null!;
+            public Color TierColor = Color.white;
+            public Vector2 SmoothPos;
+            public ushort PrevDamage;
+            public float HitFlashTimer;
         }
+
+        private sealed class ActionSlot
+        {
+            public readonly VisualElement Root;
+            public readonly VisualElement Cooldown;
+            public readonly Label Timer;
+            public readonly Label Key;
+            public readonly VisualElement Flash;
+            public ushort MaxCooldown;
+            public ushort PrevCooldown;
+            public float PulseTimer;
+            public float FlashTimer;
+            public bool Locked;
+
+            public ActionSlot(VisualElement root, string cooldownName, string timerName, string keyName, string flashName)
+            {
+                Root = root;
+                Cooldown = root.Q<VisualElement>(cooldownName);
+                Timer = root.Q<Label>(timerName);
+                Key = root.Q<Label>(keyName);
+                Flash = root.Q<VisualElement>(flashName);
+            }
+        }
+
+        private readonly struct AbilitySlotDef
+        {
+            public readonly string Name;
+            public readonly int SlotIndex; // GetSlotAbility index == cooldown index (0-10)
+            public readonly BindableAction Action;
+
+            public AbilitySlotDef(string name, int slotIndex, BindableAction action)
+            {
+                Name = name;
+                SlotIndex = slotIndex;
+                Action = action;
+            }
+        }
+
+        /// <summary>
+        /// The action bar's ability slots, in doc §2 order: abilities 1-4 then A/E/R/F.
+        /// SlotIndex is the AbilitySlots/cooldown index (key "1" = 2 … key "A" = 10).
+        /// LMB/RMB and the dead Slot5 are intentionally excluded (they are not
+        /// ability slots in the current re-tier; key "5" has no kit data).
+        /// </summary>
+        private static readonly AbilitySlotDef[] AbilitySlotDefs =
+        {
+            new("ab-1", 2, BindableAction.Slot1),
+            new("ab-2", 6, BindableAction.Slot2),
+            new("ab-3", 7, BindableAction.Slot3),
+            new("ab-4", 8, BindableAction.Slot4),
+            new("ab-a", 10, BindableAction.SlotA),
+            new("ab-e", 3, BindableAction.SlotE),
+            new("ab-r", 4, BindableAction.SlotR),
+            new("ab-f", 5, BindableAction.SlotF),
+        };
 
         // Stock icons beyond this many become a "×N" count label instead (MaxStocks ≤ 99).
         private const int MaxStockIcons = 8;
 
+        /// <summary>Height above the character's feet the overhead panel hovers at (spec §3.1).</summary>
+        private const float OverheadHeightOffset = 2.2f;
+        private const float TrackLerpSpeed = 25f;
+        private const float JuiceDuration = 0.15f;
+
+        private static readonly Color[] BadgeColors;
+        private static readonly Color OrangeDamage;
+        private static readonly Color CrimsonDamage;
+
+        static HUDManager()
+        {
+            BadgeColors = new Color[4];
+            TryHex("#FBBF24", out BadgeColors[0]); // P1 gold
+            TryHex("#EA580C", out BadgeColors[1]); // P2 orange-red
+            TryHex("#3B82F6", out BadgeColors[2]); // P3 blue
+            TryHex("#22C55E", out BadgeColors[3]); // P4 green
+            TryHex("#F97316", out OrangeDamage);   // damage 40-89
+            TryHex("#EF4444", out CrimsonDamage);  // damage 90+
+        }
+
+        private static bool TryHex(string hex, out Color color)
+            => ColorUtility.TryParseHtmlString(hex, out color);
+
         private Func<ulong, CharacterState> _getState;
         private ulong _localEntityId;
         private int _maxStocks;
-        private readonly Dictionary<ulong, Panel> _panels = new();
+        private CharacterDefinition _charDef;
+        private InputBindings _bindings;
+        private Camera _camera;
 
-        // Local player's cooldown slots (unchanged from the single-player HUD)
-        private VisualElement[] _slotIcons = new VisualElement[6];
-        private VisualElement[] _slotCooldownFills = new VisualElement[6];
-        private ushort[] _slotMaxCooldowns = new ushort[6];
-        private CharacterDefinition? _charDef;
+        private VisualElement _overheadLayer;
+        private VisualElement _actionBar;
+        private readonly Dictionary<ulong, OverheadPanel> _panels = new();
+
+        private ActionSlot _dashSlot;
+        private ActionSlot _burstSlot;
+        private ActionSlot[] _abilitySlots = Array.Empty<ActionSlot>();
 
         /// <summary>
         /// Initialize the HUD.
@@ -67,6 +167,7 @@ namespace SlopArena.Client.UI
             _getState = getState;
             _maxStocks = Mathf.Max(0, maxStocks);
             _localEntityId = 0;
+            _bindings = Resources.Load<InputBindings>("InputBindings");
 
             if (_uiDocument == null)
             {
@@ -75,42 +176,67 @@ namespace SlopArena.Client.UI
             }
 
             var root = _uiDocument.rootVisualElement;
+            _overheadLayer = root.Q<VisualElement>("overhead-layer");
+            _actionBar = root.Q<VisualElement>("action-bar");
 
-            // Rebuild player panels from the roster.
-            var panelsContainer = root.Q<VisualElement>("player-panels");
-            panelsContainer.Clear();
+            // Rebuild player panels from the roster (badge color by roster position).
+            _overheadLayer?.Clear();
             _panels.Clear();
-            foreach (var p in players)
+            for (int i = 0; i < players.Count; i++)
             {
-                var panel = BuildPanel(p);
+                var p = players[i];
+                var panel = BuildOverheadPanel(p, i);
                 _panels[p.EntityId] = panel;
-                panelsContainer.Add(panel.Root);
+                _overheadLayer?.Add(panel.Root);
                 if (p.IsLocal) _localEntityId = p.EntityId;
             }
 
-            for (int i = 0; i < 6; i++)
-            {
-                _slotIcons[i] = root.Q<VisualElement>($"slot-{i}");
-                _slotCooldownFills[i] = root.Q<VisualElement>($"slot-{i}-cooldown");
-            }
+            SetupActionBar();
+
+            if (_actionBar != null)
+                _actionBar.style.display = _localEntityId != 0 ? DisplayStyle.Flex : DisplayStyle.None;
         }
 
-        private Panel BuildPanel(HudPlayer p)
+        private void SetupActionBar()
+        {
+            if (_uiDocument == null) return;
+            var root = _uiDocument.rootVisualElement;
+
+            _dashSlot = new ActionSlot(root.Q<VisualElement>("dash-slot"), "dash-cooldown", "dash-timer", "dash-key", "dash-flash");
+            _burstSlot = new ActionSlot(root.Q<VisualElement>("burst-slot"), "burst-cooldown", "burst-timer", "burst-key", "burst-flash");
+
+            _abilitySlots = new ActionSlot[AbilitySlotDefs.Length];
+            for (int i = 0; i < AbilitySlotDefs.Length; i++)
+            {
+                var d = AbilitySlotDefs[i];
+                _abilitySlots[i] = new ActionSlot(
+                    root.Q<VisualElement>(d.Name),
+                    $"{d.Name}-cooldown", $"{d.Name}-timer", $"{d.Name}-key", $"{d.Name}-flash");
+            }
+
+            // Live key labels from the remappable bindings.
+            _dashSlot.Key.text = KeyLabel(GetBoundKey(BindableAction.Dash));
+            _burstSlot.Key.text = KeyLabel(GetBoundKey(BindableAction.Burst));
+            for (int i = 0; i < AbilitySlotDefs.Length; i++)
+                _abilitySlots[i].Key.text = KeyLabel(GetBoundKey(AbilitySlotDefs[i].Action));
+        }
+
+        private OverheadPanel BuildOverheadPanel(HudPlayer p, int colorIndex)
         {
             var root = new VisualElement();
-            root.name = $"player-panel-{p.EntityId}";
-            root.AddToClassList("player-panel");
-            if (p.IsLocal) root.AddToClassList("local");
+            root.name = $"overhead-{p.EntityId}";
+            root.AddToClassList("overhead-panel");
 
-            var nameLabel = new Label(p.Label);
-            nameLabel.AddToClassList("player-name");
-            root.Add(nameLabel);
+            var badge = new Label(p.Label);
+            badge.AddToClassList("badge");
+            badge.style.backgroundColor = BadgeColors[colorIndex % BadgeColors.Length];
+            root.Add(badge);
 
-            var damageLabel = new Label("0%");
-            damageLabel.AddToClassList("player-damage");
-            root.Add(damageLabel);
+            var damage = new Label("0%");
+            damage.AddToClassList("overhead-damage");
+            root.Add(damage);
 
-            var panel = new Panel { Root = root, DamageLabel = damageLabel };
+            var panel = new OverheadPanel { Root = root, Badge = badge, Damage = damage };
 
             if (_maxStocks > 0)
             {
@@ -141,35 +267,52 @@ namespace SlopArena.Client.UI
             return panel;
         }
 
-        public void SetSlotMaxCooldown(int slot, ushort ticks)
-        {
-            if (slot >= 0 && slot < 6)
-                _slotMaxCooldowns[slot] = ticks;
-        }
-
+        /// <summary>
+        /// Provide the character definition: resolves ability icons, per-slot max
+        /// cooldowns (max of grounded/airborne), and the locked (no-data) state.
+        /// </summary>
         public void SetCharacterDefinition(CharacterDefinition def)
         {
             _charDef = def;
-            LoadIcons();
-        }
 
-        private void LoadIcons()
-        {
-            if (_charDef == null || _slotIcons == null) return;
-            for (int i = 0; i < 6; i++)
+            if (_abilitySlots == null || _abilitySlots.Length == 0) return;
+            for (int i = 0; i < _abilitySlots.Length; i++)
             {
-                var spec = _charDef.GetSlotAbility(i, airborne: false);
-                if (spec == null || string.IsNullOrEmpty(spec.IconName)) continue;
+                var slot = _abilitySlots[i];
+                var d = AbilitySlotDefs[i];
+                var grounded = def.GetSlotAbility(d.SlotIndex, airborne: false);
+                var airborne = def.GetSlotAbility(d.SlotIndex, airborne: true);
 
-                string path = $"Icons/{_charDef.Class}/{spec.IconName}";
-                var tex = Resources.Load<Texture2D>(path);
-                if (tex != null)
-                    _slotIcons[i].style.backgroundImage = new StyleBackground(tex);
-                else
-                    Debug.LogWarning($"[HUD] Icon not found: {path}");
+                ushort max = 0;
+                if (grounded != null) max = grounded.CooldownTicks;
+                if (airborne != null && airborne.CooldownTicks > max) max = airborne.CooldownTicks;
+                slot.MaxCooldown = max;
+                slot.Locked = grounded == null && airborne == null;
+                slot.Root.EnableInClassList("locked", slot.Locked);
+
+                LoadSlotIcon(slot.Root.Q<VisualElement>($"{d.Name}-icon"), grounded ?? airborne);
             }
+
+            _dashSlot.MaxCooldown = def.Movement.DashCooldownTicks;
+            _burstSlot.MaxCooldown = BurstConfig.CooldownTicks;
         }
 
+        private void LoadSlotIcon(VisualElement icon, AbilitySpec spec)
+        {
+            if (icon == null || _charDef == null) return;
+            if (spec == null || string.IsNullOrEmpty(spec.IconName)) return;
+
+            string path = $"Icons/{_charDef.Class}/{spec.IconName}";
+            var tex = Resources.Load<Texture2D>(path);
+            if (tex != null)
+                icon.style.backgroundImage = new StyleBackground(tex);
+            // No icon art yet — the USS .slot-icon-inner placeholder remains. Silent on purpose.
+        }
+
+        /// <summary>
+        /// Refresh all HUD data from the simulation. Called by the owning MatchBase
+        /// each fixed tick. Overhead panel screen positions are smoothed in LateUpdate.
+        /// </summary>
         public void Refresh()
         {
             if (_getState == null || _uiDocument == null) return;
@@ -180,59 +323,164 @@ namespace SlopArena.Client.UI
                 var state = _getState(kv.Key);
                 var panel = kv.Value;
 
-                panel.DamageLabel.text = $"{(int)state.DamagePercent}%";
+                int dmg = (int)state.DamagePercent;
+                panel.TierColor = DamageColor(dmg);
+                panel.Damage.text = $"{dmg}%";
+                if (dmg > panel.PrevDamage) panel.HitFlashTimer = JuiceDuration;
+                panel.PrevDamage = (ushort)dmg;
 
                 if (_maxStocks > 0)
                 {
-                    int stocksLeft = _maxStocks - state.Deaths;
-                    if (stocksLeft < 0) stocksLeft = 0;
-
+                    int left = Mathf.Max(0, _maxStocks - state.Deaths);
                     if (panel.StockIcons.Length > 0)
                     {
                         for (int i = 0; i < panel.StockIcons.Length; i++)
-                            panel.StockIcons[i].EnableInClassList("lost", i >= stocksLeft);
+                            panel.StockIcons[i].EnableInClassList("lost", i >= left);
                     }
                     else if (panel.StockCountLabel != null)
                     {
-                        panel.StockCountLabel.text = $"×{stocksLeft}";
+                        panel.StockCountLabel.text = $"×{left}";
                     }
-
-                    // Eliminated (0 stocks) → dim the panel (spectator).
-                    panel.Root.EnableInClassList("eliminated", stocksLeft <= 0);
+                    panel.Root.EnableInClassList("eliminated", left <= 0);
                 }
             }
 
-            // Cooldown slots — local player only.
+            // Action bar — local player only.
             if (_localEntityId != 0)
             {
                 var state = _getState(_localEntityId);
-                ushort[] cooldowns = {
-                    state.Cooldown0, state.Cooldown1, state.Cooldown2,
-                    state.Cooldown3, state.Cooldown4, state.Cooldown5
-                };
 
-                for (int i = 0; i < 6; i++)
+                UpdateCooldownSlot(_dashSlot, state.DashCooldownTicks);
+
+                ushort burstCd = state.BurstCooldownTicks;
+                UpdateCooldownSlot(_burstSlot, burstCd);
+                _burstSlot.Root.EnableInClassList("ready-glow", burstCd == 0);
+
+                for (int i = 0; i < _abilitySlots.Length; i++)
                 {
-                    ushort cd = cooldowns[i];
-                    bool onCooldown = cd > 0;
-
-                    if (_slotCooldownFills[i] != null)
-                    {
-                        _slotCooldownFills[i].style.display = onCooldown
-                            ? DisplayStyle.Flex
-                            : DisplayStyle.None;
-
-                        if (onCooldown)
-                        {
-                            float fraction = _slotMaxCooldowns[i] > 0
-                                ? Mathf.Clamp01(cd / (float)_slotMaxCooldowns[i])
-                                : 1f;
-                            // Scale Y from bottom (1 = full height = just started)
-                            _slotCooldownFills[i].style.scale = new Scale(new Vector2(1f, fraction));
-                        }
-                    }
+                    var slot = _abilitySlots[i];
+                    if (slot.Locked) continue;
+                    UpdateCooldownSlot(slot, state.GetCooldown((byte)(AbilitySlotDefs[i].SlotIndex + 1)));
                 }
             }
         }
+
+        private void UpdateCooldownSlot(ActionSlot s, ushort cooldown)
+        {
+            bool onCooldown = cooldown > 0;
+
+            s.Cooldown.style.display = onCooldown ? DisplayStyle.Flex : DisplayStyle.None;
+            if (onCooldown)
+            {
+                float frac = s.MaxCooldown > 0 ? Mathf.Clamp01(cooldown / (float)s.MaxCooldown) : 1f;
+                s.Cooldown.style.scale = new Scale(new Vector2(1f, frac));
+                s.Timer.text = $"{(cooldown / 60f):0.0}s";
+            }
+            else
+            {
+                s.Timer.text = "";
+            }
+
+            // Cooldown ready (was on cooldown, now 0) → pulse + flash (spec §3.2).
+            if (s.PrevCooldown > 0 && cooldown == 0)
+            {
+                s.PulseTimer = JuiceDuration;
+                s.FlashTimer = JuiceDuration;
+                s.Root.EnableInClassList("ready-pulse", true);
+                s.Flash.EnableInClassList("active", true);
+            }
+            s.PrevCooldown = cooldown;
+        }
+
+        /// <summary>Drive transient juice timers and overhead hit-flashes at render rate.</summary>
+        private void Update()
+        {
+            float dt = Time.deltaTime;
+
+            if (_dashSlot != null) TickSlotJuice(_dashSlot, dt);
+            if (_burstSlot != null) TickSlotJuice(_burstSlot, dt);
+            for (int i = 0; i < _abilitySlots.Length; i++) TickSlotJuice(_abilitySlots[i], dt);
+
+            foreach (var panel in _panels.Values)
+            {
+                bool flashing = panel.HitFlashTimer > 0f;
+                if (flashing) panel.HitFlashTimer -= dt;
+                panel.Damage.style.color = flashing ? Color.white : panel.TierColor;
+            }
+        }
+
+        private static void TickSlotJuice(ActionSlot s, float dt)
+        {
+            if (s.PulseTimer > 0f)
+            {
+                s.PulseTimer -= dt;
+                s.Root.EnableInClassList("ready-pulse", s.PulseTimer > 0f);
+            }
+            if (s.FlashTimer > 0f)
+            {
+                s.FlashTimer -= dt;
+                s.Flash.EnableInClassList("active", s.FlashTimer > 0f);
+            }
+        }
+
+        /// <summary>Track overhead panels to player sim positions (after the camera moves).</summary>
+        private void LateUpdate()
+        {
+            if (_panels.Count == 0 || _uiDocument == null) return;
+            _camera ??= Camera.main;
+            if (_camera == null) return;
+
+            if (_uiDocument.rootVisualElement.panel is not RuntimePanel runtimePanel) return;
+
+            float dt = Time.deltaTime;
+            foreach (var kv in _panels)
+            {
+                var state = _getState(kv.Key);
+                var panel = kv.Value;
+
+                Vector3 world = new(state.PX, state.PY, state.PZ) + Vector3.up * OverheadHeightOffset;
+                Vector3 screenPoint = _camera.WorldToScreenPoint(world);
+                bool visible = screenPoint.z > 0;
+
+                if (visible)
+                {
+                    Vector2 target = RuntimePanelUtils.ScreenToPanel(runtimePanel, new Vector2(screenPoint.x, screenPoint.y));
+                    panel.SmoothPos = Vector2.Lerp(panel.SmoothPos, target, dt * TrackLerpSpeed);
+                    panel.Root.style.left = panel.SmoothPos.x;
+                    panel.Root.style.top = panel.SmoothPos.y;
+                    // Center the panel horizontally, its bottom edge at the tracked point.
+                    panel.Root.style.translate = new Translate(
+                        new Length(-50, LengthUnit.Percent),
+                        new Length(-100, LengthUnit.Percent));
+                }
+
+                panel.Root.style.display = visible ? DisplayStyle.Flex : DisplayStyle.None;
+            }
+        }
+
+        // ── Small helpers ───────────────────────────────────────────────────
+
+        private Key GetBoundKey(BindableAction action)
+            => _bindings != null ? _bindings.GetKey(action) : InputBindings.DefaultKey(action);
+
+        private static string KeyLabel(Key key)
+        {
+            if (key >= Key.A && key <= Key.Z)
+                return ((char)((int)key - (int)Key.A + 'A')).ToString();
+            if (key >= Key.Digit0 && key <= Key.Digit9)
+                return ((char)((int)key - (int)Key.Digit0 + '0')).ToString();
+            return key switch
+            {
+                Key.LeftShift => "Shift",
+                Key.RightShift => "R-Shift",
+                Key.Space => "Space",
+                Key.None => "?",
+                _ => key.ToString(),
+            };
+        }
+
+        /// <summary>Damage-percent tier colors (spec §3.1): white &lt;40, orange 40-89, crimson 90+.</summary>
+        private static Color DamageColor(int percent)
+            => percent < 40 ? Color.white : percent < 90 ? OrangeDamage : CrimsonDamage;
     }
 }

--- a/client/Unity/Assets/Scripts/Runtime/World/MatchBase.cs
+++ b/client/Unity/Assets/Scripts/Runtime/World/MatchBase.cs
@@ -144,14 +144,6 @@ namespace SlopArena.Client.World
             int maxStocks = MatchConfig.Mode == GameMode.PvP ? MatchConfig.MaxStocks : 0;
             _hudManager?.Initialize(Bridge.GetState, players, maxStocks);
             _hudManager?.SetCharacterDefinition(def);
-            for (int slot = 0; slot < 6; slot++)
-            {
-                var spec = def.GetSlotAbility(slot, airborne: false);
-                if (spec != null) _hudManager?.SetSlotMaxCooldown(slot, spec.CooldownTicks);
-                var specAir = def.GetSlotAbility(slot, airborne: true);
-                if (specAir != null && specAir.CooldownTicks > spec?.CooldownTicks)
-                    _hudManager?.SetSlotMaxCooldown(slot, specAir.CooldownTicks);
-            }
         }
 
         protected void SetupAimHandler(CharacterDefinition def)

--- a/client/Unity/Assets/UI/HUD.uss
+++ b/client/Unity/Assets/UI/HUD.uss
@@ -1,64 +1,64 @@
+/* ────────────────────────────────────────────────────────────────────────────
+   SlopArena combat HUD — UI Toolkit (spec §5).
+   Two layers: a full-screen overhead layer for screen-space-tracked per-player
+   panels, and a bottom-center action bar for the local player's cooldowns.
+   ──────────────────────────────────────────────────────────────────────────── */
+
 .hud-root {
     flex-grow: 1;
-    justify-content: flex-end;
+    /* The HUD never intercepts clicks/input. */
+    pointer-events: none;
+}
+
+/* ── Overhead layer: full-screen, top-left origin. Panels positioned in code. */
+.overhead-layer {
+    position: absolute;
+    left: 0;
+    top: 0;
+    right: 0;
+    bottom: 0;
+}
+
+.overhead-panel {
+    position: absolute;
     align-items: center;
-    padding-bottom: 40px;
-}
-
-.player-panels {
-    flex-direction: row;
-    justify-content: center;
-    margin-bottom: 12px;
-}
-
-.player-panel {
-    min-width: 140px;
-    margin: 4px;
-    padding: 8px 12px;
+    padding: 4px 10px;
     border-radius: 8px;
-    border-width: 2px;
-    border-color: rgba(255, 255, 255, 0.35);
     background-color: rgba(0, 0, 0, 0.5);
-    align-items: center;
+    border-width: 2px;
+    border-color: rgba(255, 255, 255, 0.25);
 }
 
-/* Local player's panel is highlighted (issue #38) */
-.player-panel.local {
-    border-color: #ffd700;
-    background-color: rgba(40, 35, 0, 0.55);
-}
-
-/* Eliminated (0 stocks) — dimmed spectator */
-.player-panel.eliminated {
+.overhead-panel.eliminated {
     opacity: 0.45;
 }
 
-.player-name {
-    font-size: 16px;
-    color: rgba(255, 255, 255, 0.85);
+.badge {
+    font-size: 14px;
     -unity-font-style: bold;
+    color: #000000;
+    padding: 2px 8px;
+    border-radius: 4px;
 }
 
-.player-panel.local .player-name {
-    color: #ffd700;
-}
-
-.player-damage {
-    font-size: 40px;
+.overhead-damage {
+    font-size: 34px;
+    -unity-font-style: bold;
     color: white;
-    -unity-font-style: bold;
+    transition-property: color;
+    transition-duration: 0.15s;
 }
 
 .stock-row {
     flex-direction: row;
-    margin-top: 6px;
+    margin-top: 4px;
 }
 
 .stock-icon {
-    width: 14px;
-    height: 14px;
+    width: 12px;
+    height: 12px;
     margin: 2px;
-    border-radius: 7px;
+    border-radius: 6px;
     background-color: white;
 }
 
@@ -67,47 +67,133 @@
 }
 
 .stock-count {
-    font-size: 18px;
+    font-size: 14px;
     color: white;
     -unity-font-style: bold;
 }
 
-.slot-row {
+/* ── Bottom action bar ─────────────────────────────────────────────────────── */
+.action-bar {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 20px;
     flex-direction: row;
     justify-content: center;
-    height: 80px;
+    align-items: flex-end;
 }
 
-.slot-icon {
-    width: 64px;
-    height: 64px;
-    margin: 4px;
-    border-radius: 8px;
-    border-width: 2px;
-    border-color: white;
-    background-color: rgba(0, 0, 0, 0.5);
+.slot-group {
+    flex-direction: row;
+    margin: 0 6px;
+}
+
+.slot {
+    width: 48px;
+    height: 48px;
+    margin: 0 4px;
+    border-radius: 6px;
+    border-width: 1px;
+    border-color: #475569;
+    background-color: #1e293b;
     align-items: center;
     justify-content: center;
     overflow: hidden;
     position: relative;
+    /* Cooldown-ready pulse (1.15x over 0.15s, spec §3.2). */
+    transition-property: scale;
+    transition-duration: 0.15s;
 }
 
+.slot.ready-pulse {
+    scale: 1.15;
+}
+
+/* Non-FightGuy kits leave some of the 8 slots empty — dim + desaturate. */
+.slot.locked {
+    opacity: 0.4;
+}
+
+/* Placeholder icon tile; real icons drop in via code (Resources/Icons). */
+.slot-icon-inner {
+    position: absolute;
+    left: 0;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(255, 255, 255, 0.06);
+}
+
+/* Ability-ready flash overlay (bright white, fades fast). */
+.slot-flash {
+    position: absolute;
+    left: 0;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    background-color: white;
+    opacity: 0;
+    transition-property: opacity;
+    transition-duration: 0.15s;
+}
+
+.slot-flash.active {
+    opacity: 0.85;
+}
+
+/* Cooldown mask — fills from the bottom, shrinking as the cooldown expires. */
 .slot-cooldown {
     position: absolute;
+    left: 0;
+    top: 0;
+    right: 0;
     bottom: 0;
-    width: 100%;
-    height: 100%;
-    background-color: rgba(255, 0, 0, 0.4);
+    background-color: rgba(0, 0, 0, 0.55);
     display: none;
-    scale: 1 1;
-    translate: 0 0;
     transform-origin: bottom center;
+    scale: 1 1;
+}
+
+.slot-timer {
+    font-size: 16px;
+    color: white;
+    -unity-font-style: bold;
+    -unity-text-align: middle-center;
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 30%;
 }
 
 .slot-key-label {
-    font-size: 14px;
+    font-size: 12px;
     color: white;
     -unity-font-style: bold;
     position: absolute;
     bottom: 2px;
+    left: 0;
+    right: 0;
+    -unity-text-align: middle-center;
+}
+
+/* Dash — circular slot (spec §3.2: Dash is a circle/radial). */
+.dash-slot {
+    width: 56px;
+    height: 56px;
+    border-radius: 28px;
+    border-color: #64748b;
+}
+
+/* Burst — prominent wide slot. */
+.burst-slot {
+    width: 72px;
+    height: 56px;
+    border-width: 2px;
+    border-color: #f59e0b;
+}
+
+/* Burst available (cooldown 0) — persistent gold glow (spec §3.2). */
+.burst-slot.ready-glow {
+    border-color: #fbbf24;
+    background-color: rgba(251, 191, 36, 0.15);
 }

--- a/client/Unity/Assets/UI/HUD.uxml
+++ b/client/Unity/Assets/UI/HUD.uxml
@@ -1,34 +1,94 @@
 <ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements">
     <ui:Style src="HUD.uss" />
     <ui:VisualElement name="hud-root" class="hud-root">
-        <!-- Player panels — one per player, built at runtime by HUDManager (issue #38) -->
-        <ui:VisualElement name="player-panels" class="player-panels" />
+        <!-- Overhead layer: full-screen, top-left origin. Per-player panels are
+             created and positioned here by HUDManager, screen-space tracked to each
+             player's simulation position (spec §3.1). -->
+        <ui:VisualElement name="overhead-layer" class="overhead-layer" />
 
-        <!-- Slot row (local player only) -->
-        <ui:VisualElement name="slot-row" class="slot-row">
-            <ui:VisualElement name="slot-0" class="slot-icon">
-                <ui:VisualElement name="slot-0-cooldown" class="slot-cooldown" />
-                <ui:Label text="LMB" class="slot-key-label" />
+        <!-- Bottom action bar (local player only) -->
+        <ui:VisualElement name="action-bar" class="action-bar">
+
+            <!-- Dash (key: Shift) -->
+            <ui:VisualElement name="dash-slot" class="slot dash-slot">
+                <ui:VisualElement name="dash-icon" class="slot-icon-inner" />
+                <ui:VisualElement name="dash-flash" class="slot-flash" />
+                <ui:VisualElement name="dash-cooldown" class="slot-cooldown" />
+                <ui:Label name="dash-timer" class="slot-timer" />
+                <ui:Label name="dash-key" class="slot-key-label" />
             </ui:VisualElement>
-            <ui:VisualElement name="slot-1" class="slot-icon">
-                <ui:VisualElement name="slot-1-cooldown" class="slot-cooldown" />
-                <ui:Label text="RMB" class="slot-key-label" />
+
+            <!-- Abilities 1-4 (spec §2 AbilityGroup_1_4) -->
+            <ui:VisualElement name="ability-group-1-4" class="slot-group">
+                <ui:VisualElement name="ab-1" class="slot ability-slot">
+                    <ui:VisualElement name="ab-1-icon" class="slot-icon-inner" />
+                    <ui:VisualElement name="ab-1-flash" class="slot-flash" />
+                    <ui:VisualElement name="ab-1-cooldown" class="slot-cooldown" />
+                    <ui:Label name="ab-1-timer" class="slot-timer" />
+                    <ui:Label name="ab-1-key" class="slot-key-label" />
+                </ui:VisualElement>
+                <ui:VisualElement name="ab-2" class="slot ability-slot">
+                    <ui:VisualElement name="ab-2-icon" class="slot-icon-inner" />
+                    <ui:VisualElement name="ab-2-flash" class="slot-flash" />
+                    <ui:VisualElement name="ab-2-cooldown" class="slot-cooldown" />
+                    <ui:Label name="ab-2-timer" class="slot-timer" />
+                    <ui:Label name="ab-2-key" class="slot-key-label" />
+                </ui:VisualElement>
+                <ui:VisualElement name="ab-3" class="slot ability-slot">
+                    <ui:VisualElement name="ab-3-icon" class="slot-icon-inner" />
+                    <ui:VisualElement name="ab-3-flash" class="slot-flash" />
+                    <ui:VisualElement name="ab-3-cooldown" class="slot-cooldown" />
+                    <ui:Label name="ab-3-timer" class="slot-timer" />
+                    <ui:Label name="ab-3-key" class="slot-key-label" />
+                </ui:VisualElement>
+                <ui:VisualElement name="ab-4" class="slot ability-slot">
+                    <ui:VisualElement name="ab-4-icon" class="slot-icon-inner" />
+                    <ui:VisualElement name="ab-4-flash" class="slot-flash" />
+                    <ui:VisualElement name="ab-4-cooldown" class="slot-cooldown" />
+                    <ui:Label name="ab-4-timer" class="slot-timer" />
+                    <ui:Label name="ab-4-key" class="slot-key-label" />
+                </ui:VisualElement>
             </ui:VisualElement>
-            <ui:VisualElement name="slot-2" class="slot-icon">
-                <ui:VisualElement name="slot-2-cooldown" class="slot-cooldown" />
-                <ui:Label text="Q" class="slot-key-label" />
+
+            <!-- Abilities A E R F (spec §2 AbilityGroup_A_F) -->
+            <ui:VisualElement name="ability-group-a-f" class="slot-group">
+                <ui:VisualElement name="ab-a" class="slot ability-slot">
+                    <ui:VisualElement name="ab-a-icon" class="slot-icon-inner" />
+                    <ui:VisualElement name="ab-a-flash" class="slot-flash" />
+                    <ui:VisualElement name="ab-a-cooldown" class="slot-cooldown" />
+                    <ui:Label name="ab-a-timer" class="slot-timer" />
+                    <ui:Label name="ab-a-key" class="slot-key-label" />
+                </ui:VisualElement>
+                <ui:VisualElement name="ab-e" class="slot ability-slot">
+                    <ui:VisualElement name="ab-e-icon" class="slot-icon-inner" />
+                    <ui:VisualElement name="ab-e-flash" class="slot-flash" />
+                    <ui:VisualElement name="ab-e-cooldown" class="slot-cooldown" />
+                    <ui:Label name="ab-e-timer" class="slot-timer" />
+                    <ui:Label name="ab-e-key" class="slot-key-label" />
+                </ui:VisualElement>
+                <ui:VisualElement name="ab-r" class="slot ability-slot">
+                    <ui:VisualElement name="ab-r-icon" class="slot-icon-inner" />
+                    <ui:VisualElement name="ab-r-flash" class="slot-flash" />
+                    <ui:VisualElement name="ab-r-cooldown" class="slot-cooldown" />
+                    <ui:Label name="ab-r-timer" class="slot-timer" />
+                    <ui:Label name="ab-r-key" class="slot-key-label" />
+                </ui:VisualElement>
+                <ui:VisualElement name="ab-f" class="slot ability-slot">
+                    <ui:VisualElement name="ab-f-icon" class="slot-icon-inner" />
+                    <ui:VisualElement name="ab-f-flash" class="slot-flash" />
+                    <ui:VisualElement name="ab-f-cooldown" class="slot-cooldown" />
+                    <ui:Label name="ab-f-timer" class="slot-timer" />
+                    <ui:Label name="ab-f-key" class="slot-key-label" />
+                </ui:VisualElement>
             </ui:VisualElement>
-            <ui:VisualElement name="slot-3" class="slot-icon">
-                <ui:VisualElement name="slot-3-cooldown" class="slot-cooldown" />
-                <ui:Label text="E" class="slot-key-label" />
-            </ui:VisualElement>
-            <ui:VisualElement name="slot-4" class="slot-icon">
-                <ui:VisualElement name="slot-4-cooldown" class="slot-cooldown" />
-                <ui:Label text="R" class="slot-key-label" />
-            </ui:VisualElement>
-            <ui:VisualElement name="slot-5" class="slot-icon">
-                <ui:VisualElement name="slot-5-cooldown" class="slot-cooldown" />
-                <ui:Label text="F" class="slot-key-label" />
+
+            <!-- Burst (key: C) — prominent slot -->
+            <ui:VisualElement name="burst-slot" class="slot burst-slot">
+                <ui:VisualElement name="burst-icon" class="slot-icon-inner" />
+                <ui:VisualElement name="burst-flash" class="slot-flash" />
+                <ui:VisualElement name="burst-cooldown" class="slot-cooldown" />
+                <ui:Label name="burst-timer" class="slot-timer" />
+                <ui:Label name="burst-key" class="slot-key-label" />
             </ui:VisualElement>
         </ui:VisualElement>
     </ui:VisualElement>


### PR DESCRIPTION
Rebuilds the combat HUD on Unity UI Toolkit per the generated UI spec (§1-§3): screen-space-tracked overhead panels per player (badge, damage %, stocks) plus a bottom action bar for the local player's Dash / 1-4 / A-E-R-F / Burst cooldowns. Replaces the old vibecoded `HUDManager`/`HUD.uxml`/`HUD.uss`. This is the HUD slice of the UI rework epic — char select / lobby / results remain separate work.

Refs #92.

## Changes
- **HUDManager** (full rewrite): runtime-built per-player overhead panels (2-4 players), tracked from `CharacterState` position via `WorldToScreenPoint` → `RuntimePanelUtils.ScreenToPanel`; local action bar (Dash + 8 ability slots + Burst) reading cooldowns from the client sim; live key labels from `InputBindings`; juice (cooldown-ready pulse/flash, persistent burst glow, damage-taken hit-flash).
- **HUD.uxml / HUD.uss**: new overhead layer + action-bar structure, color palette (P1-P4 badges, damage tiers), cooldown fill, transitions.
- **MatchBase**: dropped the obsolete `SetSlotMaxCooldown` loop — HUDManager now derives slot cooldown maxes (max of grounded/airborne) from the character definition internally.

No `src/Shared` / server changes.

## Verification
- `dotnet test tests/Shared.Tests`: **675 passed, 0 failed**.
- `dotnet build src/Shared`: **0 errors** (9 pre-existing nullable warnings; no Shared edits in this branch).
- Unity compile not run from this worktree (no Animancer package / `Library/` / `$UNITY_EDITOR`); requires main-repo playtest — see checklist below.

**Test in Unity:**
The HUD was rebuilt on UI Toolkit (worktree branch `Binoui/GUI`). The old vibecoded `HUDManager`/`HUD.uxml`/`HUD.uss` are gone. Open this in the main repo (which has the Animancer package + `Library/`), playtest, and report back.

Files changed: `HUDManager.cs` (rewrite), `HUD.uxml`/`HUD.uss` (rewrite), `MatchBase.cs` (removed obsolete loop). No Shared/server changes.

What to playtest:
1. **Enter training.** Bottom action bar renders: **Dash (Shift) | 1 2 3 4 | A E R F | Burst (C)**. Non-FightGuy kits (Manki/Kistu/Nilus) dim/lock slots 2/3/4/A; FightGuy shows all 8 live. Key labels reflect actual bound keys.
2. **Dash cooldown.** Fill shrinks + countdown text, clears on expiry, then scale-pulse + white-flash (0.15s).
3. **Ability cooldowns.** Slot fill + timer per ability; pulse + flash on expiry. Grounded AND airborne cooldowns both register (max used as denominator).
4. **Burst.** Press **C** → 60s countdown. While ready (cooldown 0), persistent gold glow; pulses/flashes on the ready transition.
5. **Overhead HUD.** Each player tracked above head: badge (P1 gold, P2 orange-red), damage % (white <40 / orange 40-89 / crimson 90+), stock pips in PvP. Smooth follow, hides behind camera. Hit a player → percent flashes white.
6. **Stocks (PvP).** Render per ADR-0007; eliminated player's panel dims.
7. **2/3/4 players.** Panels for all opponents, badge colors cycling gold/orange-red/blue/green by roster position.

Known deviations from the spec (intentional):
- Burst = cooldown countdown, not the doc's damage-fill meter (matches ADR-0014: key C, 60s, persists through KO).
- Burst shown only in the local action bar — overrides ADR-0014's "both players" (user decision).
- Dash cooldown uses vertical fill, not radial 360 (UI Toolkit has no radial fill mask); matches the pre-existing HUD style.
- Key labels live from `InputBindings` (rebindable), not hardcoded.

Gotchas while playing: overhead panel follows without jitter; damage hit-flash doesn't leave the percent stuck white; action bar correct for the local player and not overlapping at 4 players; no missing-UXML warnings.

## Diffstat
```text
 .../Unity/Assets/Scripts/Runtime/UI/HUDManager.cs  | 420 ++++++++++++++++-----
 .../Assets/Scripts/Runtime/World/MatchBase.cs      |   8 -
 client/Unity/Assets/UI/HUD.uss                     | 192 +++++++---
 client/Unity/Assets/UI/HUD.uxml                    | 108 ++++--
 4 files changed, 557 insertions(+), 171 deletions(-)
```
